### PR TITLE
Add waiters to aws-setup script

### DIFF
--- a/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
+++ b/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
@@ -106,8 +106,9 @@ On this machine, run the following:
 
 See
 https://docs.aws.amazon.com/cli/latest/userguide/tutorial-ec2-ubuntu.html#configure-cli-launch-ec2
-for more about aws configure. You should specify the same region that
-you chose above and set the default output format to ``json``.
+for more about aws configure. You should specify the same region that you chose
+above (one of ``us-east-1``, ``us-west-2``, ``eu-west-1``) and set the default
+output format to ``json``.
 
 Again on the ``t2.nano`` instance, do the following:
 

--- a/scripts/aws-setup.py
+++ b/scripts/aws-setup.py
@@ -14,6 +14,10 @@ av_zones_with_3octet = zip(range(len(avail_zones)), avail_zones)
 
 print("Creating VPC for FireSim...")
 vpc = ec2.create_vpc(CidrBlock='192.168.0.0/16')
+vpc_id = vpc.id
+# confirm that vpc is actually available before running commands
+client.get_waiter('vpc_available').wait(VpcIds=[vpc_id])
+
 vpc.create_tags(Tags=[{"Key": "Name", "Value": vpcname}])
 vpc.wait_until_available()
 

--- a/scripts/aws-setup.py
+++ b/scripts/aws-setup.py
@@ -16,6 +16,7 @@ print("Creating VPC for FireSim...")
 vpc = ec2.create_vpc(CidrBlock='192.168.0.0/16')
 vpc_id = vpc.id
 # confirm that vpc is actually available before running commands
+client.get_waiter('vpc_exists').wait(VpcIds=[vpc_id])
 client.get_waiter('vpc_available').wait(VpcIds=[vpc_id])
 
 vpc.create_tags(Tags=[{"Key": "Name", "Value": vpcname}])
@@ -36,6 +37,7 @@ subnets = []
 # create a subnet in each availability zone for this vpc
 for ip, zone in av_zones_with_3octet:
     subnets.append(ec2.create_subnet(CidrBlock='192.168.' + str(ip) + '.0/24', VpcId=vpc.id, AvailabilityZone=zone))
+    client.get_waiter('subnet_available').wait(SubnetIds=[subnets[-1].id])
     client.modify_subnet_attribute(MapPublicIpOnLaunch={'Value': True}, SubnetId=subnets[-1].id)
     route_table.associate_with_subnet(SubnetId=subnets[-1].id)
 print("Success!")


### PR DESCRIPTION
This adds waiters to some of the calls in aws-setup to prevent timeout errors. Has been tested by a user. Resolves #42 