### PR TITLE
Bump upstream aws-fpga 1.4.0

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -13,7 +13,7 @@ rootLogger = logging.getLogger()
 keyname = 'firesim'
 
 # this needs to be updated whenever the FPGA Dev AMI changes
-f1_ami_name = "FPGA Developer AMI - 1.3.5-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-0067013ed95d27159.4"
+f1_ami_name = "FPGA Developer AMI - 1.4.0 - pre8-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-0335b86e84e820e8d.4"
 
 # users are instructed to create these in the setup instructions
 securitygroupname = 'firesim'

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -297,7 +297,7 @@ class InstanceDeployManager:
         # TODO: we checkout a specific version of aws-fpga here, in case upstream
         # master is bumped. But now we have to remember to change AWS_FPGA_FIRESIM_UPSTREAM_VERSION
         # when we bump our stuff. Need a better way to do this.
-        AWS_FPGA_FIRESIM_UPSTREAM_VERSION = "b1ed5e951de3442ffb1fc8c7097e7064489e83f1"
+        AWS_FPGA_FIRESIM_UPSTREAM_VERSION = "7f1e76765766f579d3a767bedf669019d50342f3"
         self.instance_logger("""Installing AWS FPGA SDK on remote nodes.""")
         with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
             run('git clone https://github.com/aws/aws-fpga')

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -297,8 +297,8 @@ class InstanceDeployManager:
         # TODO: we checkout a specific version of aws-fpga here, in case upstream
         # master is bumped. But now we have to remember to change AWS_FPGA_FIRESIM_UPSTREAM_VERSION
         # when we bump our stuff. Need a better way to do this.
-        AWS_FPGA_FIRESIM_UPSTREAM_VERSION = "7f1e76765766f579d3a767bedf669019d50342f3"
-        self.instance_logger("""Installing AWS FPGA SDK on remote nodes.""")
+        AWS_FPGA_FIRESIM_UPSTREAM_VERSION = "2fdf23ffad944cb94f98d09eed0f34c220c522fe"
+        self.instance_logger("""Installing AWS FPGA SDK on remote nodes. Upstream hash: {}""".format(AWS_FPGA_FIRESIM_UPSTREAM_VERSION))
         with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
             run('git clone https://github.com/aws/aws-fpga')
             run('cd aws-fpga && git checkout ' + AWS_FPGA_FIRESIM_UPSTREAM_VERSION)

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -7,43 +7,42 @@
 # The AGFIs provided below are public and available to all users.
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-070ca8088af693c4b
+agfi=agfi-00faf6d30b215e4f3
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-singlecore-nic-lbp]
-agfi=agfi-0a9e9d3a09aba8eea
+agfi=agfi-0880e7413eca11ef4
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-lbp]
-agfi=agfi-05a70e068a558bda6
+agfi=agfi-0e51e38abfe819411
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-lbp]
-agfi=agfi-0878d0de2643ea8da
+agfi=agfi-06d58e09efc0fe7e0
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-00f8511c144ca7774
+agfi=agfi-003c9da9a72b2d740
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-004095a8c996d801d
+agfi=agfi-0aab2fda162483ffb
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-lbp]
-agfi=agfi-04d6eb94c8a9123b4
+agfi=agfi-031dddf10b6b6aa20
 deploytripletoverride=None
 customruntimeconfig=None
 
-
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-0e088a42443e5638e
+agfi=agfi-00a7f66e3fdbc7249
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -22,7 +22,7 @@ To launch a manager instance, follow these steps:
    data is preserved when you stop/start the instance, and your data is
    not lost when pricing spikes on the spot market.
 2. When prompted to select an AMI, search in the ``Community AMIs`` tab for
-   "FPGA" and select the option that starts with ``FPGA Developer AMI - 1.3.5``.
+   "FPGA" and select the option that starts with ``FPGA Developer AMI - 1.4.0``.
    **DO NOT USE ANY OTHER VERSION.**
 3. When prompted to choose an instance type, select the instance type of
    your choosing. A good choice is a ``c4.4xlarge``.


### PR DESCRIPTION
This is mostly done and works on the FPGA for the simple designs I've tested (rocket chip, singlecore, nic + no nic). This should be merged to master in the beginning of August, since Amazon is **removing** support of the current shell on September 1st.

XDMA conversion is not included here, since it needs to be tested more extensively, but lives on a separate branch. EDMA is still the default and works fine.

This should probably trigger a major version release (FireSim 1.3.0).

TODOs for merge to dev:

- [x] Regenerate all images (in progress)
- [ ] Notify dev branch users of requirement to upgrade AMI
- [x] Do we want a dev branch of aws-fpga also?

TODOs for merge to master (copy this into the WIP dev -> master PR once that is created):
- [ ] We should notify users by email in advance about the fact that they will need to upgrade any existing instances to the new 1.4.0 AMI.
- [ ] Need to test XSim, VCS
- [ ] Mark which issues it resolves
- [ ] Merge branch (dev or other) to master of aws-fpga-firesim