### PR TITLE
LoadMem improvements and DRAM initialization

### DIFF
--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -86,7 +86,7 @@ class RuntimeHWConfig:
         # the sed is in there to get rid of newlines in runtime confs
         driver = self.get_local_driver_binaryname()
         runtimeconf = self.get_local_runtimeconf_binaryname()
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr={macaddr} +blkdev={blkdev} +slotid={slotid} +niclog=niclog +linklatency={linklatency} +netbw={netbw} +profile-interval=-1 +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(slotid=slotid, driver=driver, runtimeconf=runtimeconf, macaddr=macaddr, blkdev=blkdev, linklatency=linklatency, netbw=netbw, bootbin=bootbin)
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr={macaddr} +blkdev={blkdev} +slotid={slotid} +niclog=niclog +linklatency={linklatency} +netbw={netbw} +profile-interval=-1 +zero-out-dram +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(slotid=slotid, driver=driver, runtimeconf=runtimeconf, macaddr=macaddr, blkdev=blkdev, linklatency=linklatency, netbw=netbw, bootbin=bootbin)
 
         return basecommand
 

--- a/sim/src/main/cc/fesvr/fesvr_proxy.h
+++ b/sim/src/main/cc/fesvr/fesvr_proxy.h
@@ -11,9 +11,11 @@ struct fesvr_loadmem_t {
 class fesvr_proxy_t
 {
     public:
-        virtual bool recv_loadmem_req(fesvr_loadmem_t& req) = 0;
+        virtual bool recv_loadmem_write_req(fesvr_loadmem_t& req) = 0;
+        virtual bool recv_loadmem_read_req(fesvr_loadmem_t& req) = 0;
         virtual void recv_loadmem_data(void* buf, size_t len) = 0;
 
+        virtual bool has_loadmem_reqs() = 0;
         virtual bool data_available() = 0;
         virtual uint32_t recv_word() = 0;
         virtual void send_word(uint32_t word) = 0;

--- a/sim/src/main/cc/fesvr/firesim_fesvr.h
+++ b/sim/src/main/cc/fesvr/firesim_fesvr.h
@@ -41,11 +41,14 @@ class firesim_fesvr_t : public htif_t
 
         std::deque<uint32_t> in_data;
         std::deque<uint32_t> out_data;
-        std::deque<fesvr_loadmem_t> loadmem_reqs;
-        std::deque<char> loadmem_data;
+        std::deque<fesvr_loadmem_t> loadmem_write_reqs;
+        std::deque<fesvr_loadmem_t> loadmem_read_reqs;
+        std::deque<char> loadmem_write_data;
 
     private:
         bool is_busy;
+        // A flag set only during program load to forward fesvr
+        // read/write_chunks to the loadmem unit instead of going over tsi
         bool is_loadmem;
         size_t idle_counts;
 
@@ -54,7 +57,9 @@ class firesim_fesvr_t : public htif_t
 
         virtual void read(uint32_t* data, size_t len);
         virtual void write(const uint32_t* data, size_t len);
-        virtual void load_mem(addr_t addr, size_t nbytes, const void* src);
+        virtual void load_mem_write(addr_t addr, size_t nbytes, const void* src);
+        virtual void load_mem_read(addr_t addr, size_t nbytes);
+
 };
 
 #endif // __FIRESIM_FESVR_H

--- a/sim/src/main/cc/fesvr/firesim_tsi.cc
+++ b/sim/src/main/cc/fesvr/firesim_tsi.cc
@@ -48,16 +48,29 @@ bool firesim_tsi_t::data_available()
     return !in_data.empty();
 }
 
-bool firesim_tsi_t::recv_loadmem_req(fesvr_loadmem_t& loadmem) {
-    if (loadmem_reqs.empty()) return false;
-    auto r = loadmem_reqs.front();
+bool firesim_tsi_t::has_loadmem_reqs() {
+    return(!loadmem_write_reqs.empty() || !loadmem_read_reqs.empty());
+}
+
+bool firesim_tsi_t::recv_loadmem_write_req(fesvr_loadmem_t& loadmem) {
+    if (loadmem_write_reqs.empty()) return false;
+    auto r = loadmem_write_reqs.front();
     loadmem.addr = r.addr;
     loadmem.size = r.size;
-    loadmem_reqs.pop_front();
+    loadmem_write_reqs.pop_front();
+    return true;
+}
+
+bool firesim_tsi_t::recv_loadmem_read_req(fesvr_loadmem_t& loadmem) {
+    if (loadmem_read_reqs.empty()) return false;
+    auto r = loadmem_read_reqs.front();
+    loadmem.addr = r.addr;
+    loadmem.size = r.size;
+    loadmem_read_reqs.pop_front();
     return true;
 }
 
 void firesim_tsi_t::recv_loadmem_data(void* buf, size_t len) {
-    std::copy(loadmem_data.begin(), loadmem_data.begin() + len, (char*)buf);
-    loadmem_data.erase(loadmem_data.begin(), loadmem_data.begin() + len);
+    std::copy(loadmem_write_data.begin(), loadmem_write_data.begin() + len, (char*)buf);
+    loadmem_write_data.erase(loadmem_write_data.begin(), loadmem_write_data.begin() + len);
 }

--- a/sim/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/src/main/cc/fesvr/firesim_tsi.h
@@ -9,31 +9,28 @@ class firesim_tsi_t : public fesvr_proxy_t, public firesim_fesvr_t
 {
     public:
         firesim_tsi_t(const std::vector<std::string>& args);
-        virtual ~firesim_tsi_t();
-        virtual void tick();
+        ~firesim_tsi_t();
+        void tick();
 
-        virtual bool data_available();
-        virtual void send_word(uint32_t word);
-        virtual uint32_t recv_word();
+        bool data_available();
+        void send_word(uint32_t word);
+        uint32_t recv_word();
 
-        virtual bool recv_loadmem_req(fesvr_loadmem_t& loadmem);
-        virtual void recv_loadmem_data(void* buf, size_t len);
+        bool recv_loadmem_write_req(fesvr_loadmem_t& loadmem);
+        bool recv_loadmem_read_req(fesvr_loadmem_t& loadmem);
+        void recv_loadmem_data(void* buf, size_t len);
 
-        virtual bool busy() {
-            return firesim_fesvr_t::busy();
-        }
-        virtual bool done() {
-            return firesim_fesvr_t::done();
-        }
-        virtual int exit_code() {
-            return firesim_fesvr_t::exit_code();
-        }
+        bool has_loadmem_reqs();
+
+        bool busy() { return firesim_fesvr_t::busy(); }
+        bool done() { return firesim_fesvr_t::done(); }
+        int exit_code() { return firesim_fesvr_t::exit_code(); }
 
     private:
         midas_context_t host;
         midas_context_t* target;
 
-        virtual void wait();
+        void wait();
         static int host_thread(void *tsi);
 };
 

--- a/sim/src/main/cc/firesim_top.cc
+++ b/sim/src/main/cc/firesim_top.cc
@@ -102,16 +102,52 @@ firesim_top_t::firesim_top_t(int argc, char** argv, fesvr_proxy_t* fesvr): fesvr
 
 }
 
-void firesim_top_t::loadmem() {
+void firesim_top_t::handle_loadmem_read(fesvr_loadmem_t loadmem) {
+    assert(loadmem.size % sizeof(uint32_t) == 0);
+    // Loadmem reads are in granularities of the width of the FPGA-DRAM bus
+    mpz_t buf;
+    mpz_init(buf);
+    while (loadmem.size > 0) {
+        read_mem(loadmem.addr, buf);
+
+        // If the read word is 0; mpz_export seems to return an array with length 0
+        size_t beats_requested = (loadmem.size/sizeof(uint32_t) > MEM_DATA_CHUNK) ?
+                                 MEM_DATA_CHUNK :
+                                 loadmem.size/sizeof(uint32_t);
+        // The number of beats exported from buf; may be less than beats requested.
+        size_t non_zero_beats;
+        uint32_t* data = (uint32_t*)mpz_export(NULL, &non_zero_beats, -1, sizeof(uint32_t), 0, 0, buf);
+        for (size_t j = 0; j < beats_requested; j++) {
+            if (j < non_zero_beats) {
+                fesvr->send_word(data[j]);
+            } else {
+                fesvr->send_word(0);
+            }
+        }
+        loadmem.size -= beats_requested * sizeof(uint32_t);
+    }
+    mpz_clear(buf);
+    // Switch back to fesvr for it to process read data
+    fesvr->tick();
+}
+
+void firesim_top_t::handle_loadmem_write(fesvr_loadmem_t loadmem) {
+    assert(loadmem.size <= 1024);
+    static char buf[1024];
+    fesvr->recv_loadmem_data(buf, loadmem.size);
+    mpz_t data;
+    mpz_init(data);
+    mpz_import(data, (loadmem.size + sizeof(uint32_t) - 1)/sizeof(uint32_t), -1, sizeof(uint32_t), 0, 0, buf); \
+    write_mem_chunk(loadmem.addr, data, loadmem.size);
+    mpz_clear(data);
+}
+
+void firesim_top_t::tether_bypass_loadmem() {
     fesvr_loadmem_t loadmem;
-    while (fesvr->recv_loadmem_req(loadmem)) {
-        assert(loadmem.size <= 1024);
-        static char buf[1024]; // This should be enough...
-        fesvr->recv_loadmem_data(buf, loadmem.size);
-        mpz_t data;
-        mpz_init(data);
-        mpz_import(data, (loadmem.size + sizeof(uint32_t) - 1)/sizeof(uint32_t), -1, sizeof(uint32_t), 0, 0, buf); \
-        write_mem_chunk(loadmem.addr, data, loadmem.size);
+    while (fesvr->has_loadmem_reqs()) {
+        // Check for reads first as they preceed a narrow write;
+        if (fesvr->recv_loadmem_read_req(loadmem)) handle_loadmem_read(loadmem);
+        if (fesvr->recv_loadmem_write_req(loadmem)) handle_loadmem_write(loadmem);
     }
 }
 
@@ -153,7 +189,8 @@ void firesim_top_t::loop(size_t step_size, uint64_t coarse_step_size) {
                     s->work();
                 }
             }
-            loadmem();
+            // Generally this will do nothing except during program_load;
+            tether_bypass_loadmem();
 
             if (delta_sum == step_size) delta_sum = 0;
         }

--- a/sim/src/main/cc/firesim_top.cc
+++ b/sim/src/main/cc/firesim_top.cc
@@ -169,7 +169,11 @@ void firesim_top_t::run(size_t step_size) {
         e->init();
     }
 
-    if (do_zero_out_dram) zero_out_dram(); 
+    if (do_zero_out_dram) {
+        fprintf(stderr, "Zeroing out FPGA DRAM...\n");
+        zero_out_dram();
+    }
+    fprintf(stderr, "Commencing simulation.\n");
 
     // Assert reset T=0 -> 50
     target_reset(0, 50);

--- a/sim/src/main/cc/firesim_top.cc
+++ b/sim/src/main/cc/firesim_top.cc
@@ -207,7 +207,7 @@ void firesim_top_t::run(size_t step_size) {
     }
 
     if (do_zero_out_dram) {
-        fprintf(stderr, "Zeroing out FPGA DRAM...\n");
+        fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few seconds...\n");
         zero_out_dram();
     }
     fprintf(stderr, "Commencing simulation.\n");

--- a/sim/src/main/cc/firesim_top.cc
+++ b/sim/src/main/cc/firesim_top.cc
@@ -142,7 +142,7 @@ void firesim_top_t::handle_loadmem_write(fesvr_loadmem_t loadmem) {
     mpz_clear(data);
 }
 
-void firesim_top_t::tether_bypass_loadmem() {
+void firesim_top_t::tether_bypass_via_loadmem() {
     fesvr_loadmem_t loadmem;
     while (fesvr->has_loadmem_reqs()) {
         // Check for reads first as they preceed a narrow write;
@@ -190,7 +190,7 @@ void firesim_top_t::loop(size_t step_size, uint64_t coarse_step_size) {
                 }
             }
             // Generally this will do nothing except during program_load;
-            tether_bypass_loadmem();
+            tether_bypass_via_loadmem();
 
             if (delta_sum == step_size) delta_sum = 0;
         }

--- a/sim/src/main/cc/firesim_top.h
+++ b/sim/src/main/cc/firesim_top.h
@@ -32,6 +32,8 @@ class firesim_top_t: virtual simif_t
         // This sets the coarse_step_size in loop
         uint64_t profile_interval;
 
+        // If set, will write all zeros to fpga dram before commencing simulation
+        bool do_zero_out_dram = false;
         // Main simulation loop
         // stepsize = number of target cycles between FESVR interactions
         // coarse_step_size = maximum number of target cycles loop may advance the simulator

--- a/sim/src/main/cc/firesim_top.h
+++ b/sim/src/main/cc/firesim_top.h
@@ -13,7 +13,7 @@ class firesim_top_t: virtual simif_t
         ~firesim_top_t() { }
 
         void run(size_t step_size);
-        void tether_bypass_loadmem();
+        void tether_bypass_via_loadmem();
 
     protected:
         void add_endpoint(endpoint_t* endpoint) {

--- a/sim/src/main/cc/firesim_top.h
+++ b/sim/src/main/cc/firesim_top.h
@@ -13,7 +13,7 @@ class firesim_top_t: virtual simif_t
         ~firesim_top_t() { }
 
         void run(size_t step_size);
-        void loadmem();
+        void tether_bypass_loadmem();
 
     protected:
         void add_endpoint(endpoint_t* endpoint) {
@@ -38,6 +38,10 @@ class firesim_top_t: virtual simif_t
         // stepsize = number of target cycles between FESVR interactions
         // coarse_step_size = maximum number of target cycles loop may advance the simulator
         void loop(size_t step_size, uint64_t coarse_step_size);
+
+        // Helper functions to handoff fesvr requests to the loadmem unit
+        void handle_loadmem_read(fesvr_loadmem_t loadmem);
+        void handle_loadmem_write(fesvr_loadmem_t loadmem);
 };
 
 #endif // __FIRESIM_TOP_H


### PR DESCRIPTION
This PR improves loadmem performance by reducing the number of driver-writes per host-beat, from 4 to ~2 which should help with Shell-level RTL simulation speed. 

It also adds a feature to zero-out FPGA DRAM completely, which can be invoked by passing "+zero-out-dram" to the driver. When set, this enables a mode in the loadmem unit that requires no further writes from the driver. Instead, it issues multi-beat writes to the host-memory system as rapidly as it will accept them across the available address space. This takes about ~10 seconds to zero out a 16 GiB channel. 

This changes the simulation memory map, so this driver change may not be compatible with existing AGFIs. How should we proceed? 