### PR TITLE
Re-work main loop, encapsulate FESVR entirely in the Serial endpoint

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -9,28 +9,27 @@
 # If you are using an older version of FireSim, you will need to generate your
 # own images.
 
-[firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-0363594a482851ec5
-deploytripletoverride=None
-customruntimeconfig=None
-
-[firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-04c48101af4a6e84a
-deploytripletoverride=None
-customruntimeconfig=None
-
-[firesim-singlecore-no-nic-lbp]
-agfi=agfi-08e0a4ad02494f1ac
-deploytripletoverride=None
-customruntimeconfig=None
-
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-0158db44fcbe84c1c
+agfi=agfi-071f4dea2a3f1c1f8
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-039147ddc85487581
+agfi=agfi-0ad5196a19ce1914e
 deploytripletoverride=None
 customruntimeconfig=None
 
+[firesim-quadcore-nic-ddr3-llc4mb]
+agfi=agfi-04f9e6df60e1fccde
+deploytripletoverride=None
+customruntimeconfig=None
+
+[firesim-quadcore-no-nic-ddr3-llc4mb]
+agfi=agfi-0b526fc79d612f70a
+deploytripletoverride=None
+customruntimeconfig=None
+
+[firesim-singlecore-no-nic-lbp]
+agfi=agfi-08101276564cd94f9
+deploytripletoverride=None
+customruntimeconfig=None

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -334,12 +334,3 @@ void blockdev_t::tick() {
         /* While: if we did any work during this iteration, do another iter */
     } while((a_req_valid && a_req_ready) || (a_data_valid && a_data_ready) || (a_resp_valid && a_resp_ready));
 }
-
-/* Check if blockdev widget has any work left */
-bool blockdev_t::done() {
-#ifdef BLOCKDEVWIDGET_0
-    return read(BLOCKDEVWIDGET_0(done));
-#else
-    return true;
-#endif
-}

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -45,6 +45,7 @@ class blockdev_t: public endpoint_t
         virtual void init();
         virtual void tick();
         virtual bool terminate() { return false; }
+        virtual int exit_code() { return 0; }
 
     private:
         bool a_req_valid;

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -44,8 +44,7 @@ class blockdev_t: public endpoint_t
         void recv();
         virtual void init();
         virtual void tick();
-        virtual bool done();
-        virtual bool stall() { return false; }
+        virtual bool terminate() { return false; }
 
     private:
         bool a_req_valid;

--- a/sim/src/main/cc/endpoints/serial.cc
+++ b/sim/src/main/cc/endpoints/serial.cc
@@ -2,7 +2,7 @@
 #include "serial.h"
 
 serial_t::serial_t(simif_t* sim, firesim_fesvr_t* fesvr, uint32_t step_size):
-    endpoint_t(sim), fesvr(fesvr), step_size(step_size) { }
+    endpoint_t(sim), sim(sim), fesvr(fesvr), step_size(step_size) { }
 
 void serial_t::init() {
     write(SERIALWIDGET_0(step_size), step_size);
@@ -27,15 +27,68 @@ void serial_t::recv() {
     }
 }
 
+void serial_t::handle_loadmem_read(fesvr_loadmem_t loadmem) {
+    assert(loadmem.size % sizeof(uint32_t) == 0);
+    // Loadmem reads are in granularities of the width of the FPGA-DRAM bus
+    mpz_t buf;
+    mpz_init(buf);
+    while (loadmem.size > 0) {
+        sim->read_mem(loadmem.addr, buf);
+
+        // If the read word is 0; mpz_export seems to return an array with length 0
+        size_t beats_requested = (loadmem.size/sizeof(uint32_t) > MEM_DATA_CHUNK) ?
+                                 MEM_DATA_CHUNK :
+                                 loadmem.size/sizeof(uint32_t);
+        // The number of beats exported from buf; may be less than beats requested.
+        size_t non_zero_beats;
+        uint32_t* data = (uint32_t*)mpz_export(NULL, &non_zero_beats, -1, sizeof(uint32_t), 0, 0, buf);
+        for (size_t j = 0; j < beats_requested; j++) {
+            if (j < non_zero_beats) {
+                fesvr->send_word(data[j]);
+            } else {
+                fesvr->send_word(0);
+            }
+        }
+        loadmem.size -= beats_requested * sizeof(uint32_t);
+    }
+    mpz_clear(buf);
+    // Switch back to fesvr for it to process read data
+    fesvr->tick();
+}
+
+void serial_t::handle_loadmem_write(fesvr_loadmem_t loadmem) {
+    assert(loadmem.size <= 1024);
+    static char buf[1024];
+    fesvr->recv_loadmem_data(buf, loadmem.size);
+    mpz_t data;
+    mpz_init(data);
+    mpz_import(data, (loadmem.size + sizeof(uint32_t) - 1)/sizeof(uint32_t), -1, sizeof(uint32_t), 0, 0, buf); \
+    sim->write_mem_chunk(loadmem.addr, data, loadmem.size);
+    mpz_clear(data);
+}
+
+void serial_t::serial_bypass_via_loadmem() {
+    fesvr_loadmem_t loadmem;
+    while (fesvr->has_loadmem_reqs()) {
+        // Check for reads first as they preceed a narrow write;
+        if (fesvr->recv_loadmem_read_req(loadmem)) handle_loadmem_read(loadmem);
+        if (fesvr->recv_loadmem_write_req(loadmem)) handle_loadmem_write(loadmem);
+    }
+}
+
 void serial_t::tick() {
-    // Collect all the responses from the target
-    this->recv();
     // First, check to see step_size tokens have been enqueued
     if (!read(SERIALWIDGET_0(done))) return;
+    // Collect all the responses from the target
+    this->recv();
     // Punt to FESVR
-    if (!fesvr->data_available()) fesvr->tick();
+    if (!fesvr->data_available()) {
+        fesvr->tick();
+    }
+    if (fesvr->has_loadmem_reqs()) {
+        serial_bypass_via_loadmem();
+    }
     // Write all the requests to the target
     this->send();
-    // Tell the widget license to start generating tokens
     go();
 }

--- a/sim/src/main/cc/endpoints/serial.cc
+++ b/sim/src/main/cc/endpoints/serial.cc
@@ -88,7 +88,9 @@ void serial_t::tick() {
     if (fesvr->has_loadmem_reqs()) {
         serial_bypass_via_loadmem();
     }
-    // Write all the requests to the target
-    this->send();
-    go();
+    if (!terminate()) {
+        // Write all the requests to the target
+        this->send();
+        go();
+    }
 }

--- a/sim/src/main/cc/endpoints/serial.cc
+++ b/sim/src/main/cc/endpoints/serial.cc
@@ -1,8 +1,22 @@
 #include <assert.h>
 #include "serial.h"
 
-serial_t::serial_t(simif_t* sim, firesim_fesvr_t* fesvr, uint32_t step_size):
-    endpoint_t(sim), sim(sim), fesvr(fesvr), step_size(step_size) { }
+#if defined(SIMULATION_XSIM) || defined(RTLSIM)
+#define DEFAULT_STEPSIZE (128)
+#else
+#define DEFAULT_STEPSIZE (2004765L)
+#endif
+
+serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args):
+        endpoint_t(sim), sim(sim), fesvr(args) {
+
+    step_size = DEFAULT_STEPSIZE;
+    for (auto &arg: args) {
+        if (arg.find("+fesvr-step-size=") == 0) {
+            step_size = atoi(arg.c_str()+17);
+        }
+    }
+}
 
 void serial_t::init() {
     write(SERIALWIDGET_0(step_size), step_size);
@@ -14,15 +28,15 @@ void serial_t::go() {
 }
 
 void serial_t::send() {
-    while(fesvr->data_available() && read(SERIALWIDGET_0(in_ready))) {
-        write(SERIALWIDGET_0(in_bits), fesvr->recv_word());
+    while(fesvr.data_available() && read(SERIALWIDGET_0(in_ready))) {
+        write(SERIALWIDGET_0(in_bits), fesvr.recv_word());
         write(SERIALWIDGET_0(in_valid), 1);
     }
 }
 
 void serial_t::recv() {
     while(read(SERIALWIDGET_0(out_valid))) {
-        fesvr->send_word(read(SERIALWIDGET_0(out_bits)));
+        fesvr.send_word(read(SERIALWIDGET_0(out_bits)));
         write(SERIALWIDGET_0(out_ready), 1);
     }
 }
@@ -44,22 +58,22 @@ void serial_t::handle_loadmem_read(fesvr_loadmem_t loadmem) {
         uint32_t* data = (uint32_t*)mpz_export(NULL, &non_zero_beats, -1, sizeof(uint32_t), 0, 0, buf);
         for (size_t j = 0; j < beats_requested; j++) {
             if (j < non_zero_beats) {
-                fesvr->send_word(data[j]);
+                fesvr.send_word(data[j]);
             } else {
-                fesvr->send_word(0);
+                fesvr.send_word(0);
             }
         }
         loadmem.size -= beats_requested * sizeof(uint32_t);
     }
     mpz_clear(buf);
     // Switch back to fesvr for it to process read data
-    fesvr->tick();
+    fesvr.tick();
 }
 
 void serial_t::handle_loadmem_write(fesvr_loadmem_t loadmem) {
     assert(loadmem.size <= 1024);
     static char buf[1024];
-    fesvr->recv_loadmem_data(buf, loadmem.size);
+    fesvr.recv_loadmem_data(buf, loadmem.size);
     mpz_t data;
     mpz_init(data);
     mpz_import(data, (loadmem.size + sizeof(uint32_t) - 1)/sizeof(uint32_t), -1, sizeof(uint32_t), 0, 0, buf); \
@@ -69,10 +83,10 @@ void serial_t::handle_loadmem_write(fesvr_loadmem_t loadmem) {
 
 void serial_t::serial_bypass_via_loadmem() {
     fesvr_loadmem_t loadmem;
-    while (fesvr->has_loadmem_reqs()) {
+    while (fesvr.has_loadmem_reqs()) {
         // Check for reads first as they preceed a narrow write;
-        if (fesvr->recv_loadmem_read_req(loadmem)) handle_loadmem_read(loadmem);
-        if (fesvr->recv_loadmem_write_req(loadmem)) handle_loadmem_write(loadmem);
+        if (fesvr.recv_loadmem_read_req(loadmem)) handle_loadmem_read(loadmem);
+        if (fesvr.recv_loadmem_write_req(loadmem)) handle_loadmem_write(loadmem);
     }
 }
 
@@ -82,10 +96,10 @@ void serial_t::tick() {
     // Collect all the responses from the target
     this->recv();
     // Punt to FESVR
-    if (!fesvr->data_available()) {
-        fesvr->tick();
+    if (!fesvr.data_available()) {
+        fesvr.tick();
     }
-    if (fesvr->has_loadmem_reqs()) {
+    if (fesvr.has_loadmem_reqs()) {
         serial_bypass_via_loadmem();
     }
     if (!terminate()) {

--- a/sim/src/main/cc/endpoints/serial.h
+++ b/sim/src/main/cc/endpoints/serial.h
@@ -23,18 +23,17 @@ struct serial_data_t {
 class serial_t: public endpoint_t
 {
     public:
-        serial_t(simif_t* sim, firesim_fesvr_t* fesvr, uint32_t step_size);
+        serial_t(simif_t* sim, const std::vector<std::string>& args);
         virtual void init();
         virtual void tick();
-        virtual bool terminate(){ return fesvr->done(); }
-        virtual int exit_code(){ return fesvr->exit_code(); }
+        virtual bool terminate(){ return fesvr.done(); }
+        virtual int exit_code(){ return fesvr.exit_code(); }
 
     private:
         simif_t* sim;
-        firesim_fesvr_t* fesvr;
+        firesim_fesvr_t fesvr;
         // Number of target cycles between fesvr interactions
         uint32_t step_size;
-
         // Tell the widget to start enqueuing tokens
         void go();
         // Moves data to and from the widget and fesvr

--- a/sim/src/main/cc/endpoints/serial.h
+++ b/sim/src/main/cc/endpoints/serial.h
@@ -24,12 +24,12 @@ class serial_t: public endpoint_t
 {
     public:
         serial_t(simif_t* sim, firesim_fesvr_t* fesvr, uint32_t step_size);
-        void init();
-        void tick();
-        bool done() { return read(SERIALWIDGET_0(done)); }
-        bool stall() { return false; }
+        virtual void init();
+        virtual void tick();
+        virtual bool terminate(){ return fesvr->done(); }
 
     private:
+        simif_t* sim;
         firesim_fesvr_t* fesvr;
         // Number of target cycles between fesvr interactions
         uint32_t step_size;
@@ -39,6 +39,11 @@ class serial_t: public endpoint_t
         // Moves data to and from the widget and fesvr
         void send(); // FESVR -> Widget
         void recv(); // Widget -> FESVR
+
+        // Helper functions to handoff fesvr requests to the loadmem unit
+        void handle_loadmem_read(fesvr_loadmem_t loadmem);
+        void handle_loadmem_write(fesvr_loadmem_t loadmem);
+        void serial_bypass_via_loadmem();
 };
 
 #endif // __SERIAL_H

--- a/sim/src/main/cc/endpoints/serial.h
+++ b/sim/src/main/cc/endpoints/serial.h
@@ -27,6 +27,7 @@ class serial_t: public endpoint_t
         virtual void init();
         virtual void tick();
         virtual bool terminate(){ return fesvr->done(); }
+        virtual int exit_code(){ return fesvr->exit_code(); }
 
     private:
         simif_t* sim;

--- a/sim/src/main/cc/endpoints/simplenic.cc
+++ b/sim/src/main/cc/endpoints/simplenic.cc
@@ -125,14 +125,6 @@ void simplenic_t::init() {
 #endif // ifdef SIMPLENICWIDGET_0
 }
 
-bool simplenic_t::done() {
-#ifdef SIMPLENICWIDGET_0
-    return read(SIMPLENICWIDGET_0(done));
-#else
-    return true;
-#endif
-}
-
 //#define TOKENVERIFY
 
 // checking for token loss

--- a/sim/src/main/cc/endpoints/simplenic.h
+++ b/sim/src/main/cc/endpoints/simplenic.h
@@ -20,8 +20,7 @@ class simplenic_t: public endpoint_t
 
         virtual void init();
         virtual void tick();
-        virtual bool done();
-        virtual bool stall() { return false; }
+        virtual bool terminate() { return false; };
 
     private:
         simif_t* sim;

--- a/sim/src/main/cc/endpoints/simplenic.h
+++ b/sim/src/main/cc/endpoints/simplenic.h
@@ -21,6 +21,7 @@ class simplenic_t: public endpoint_t
         virtual void init();
         virtual void tick();
         virtual bool terminate() { return false; };
+        virtual int exit_code() { return 0; }
 
     private:
         simif_t* sim;

--- a/sim/src/main/cc/endpoints/uart.cc
+++ b/sim/src/main/cc/endpoints/uart.cc
@@ -24,7 +24,6 @@ void sighand(int s) {
 
 uart_t::uart_t(simif_t* sim): endpoint_t(sim)
 {
-#ifndef _WIN32
     // Don't block on stdin reads if there is nothing typed in
     fcntl(STDIN_FILENO, F_SETFL, fcntl(STDIN_FILENO, F_GETFL) | O_NONBLOCK);
 
@@ -34,7 +33,6 @@ uart_t::uart_t(simif_t* sim): endpoint_t(sim)
     sigemptyset(&sigIntHandler.sa_mask);
     sigIntHandler.sa_flags = 0;
     sigaction(SIGINT, &sigIntHandler, NULL);
-#endif
 }
 
 void uart_t::send() {
@@ -61,7 +59,6 @@ void uart_t::tick() {
     do {
         this->recv();
 
-#ifndef _WIN32
         if (data.in.ready) {
             char inp;
             int readamt;
@@ -80,7 +77,6 @@ void uart_t::tick() {
                 data.in.valid = true;
             }
         }
-#endif
 
         if (data.out.fire()) {
             fprintf(stdout, "%c", data.out.bits);

--- a/sim/src/main/cc/endpoints/uart.h
+++ b/sim/src/main/cc/endpoints/uart.h
@@ -13,6 +13,7 @@ class uart_t: public endpoint_t
         virtual void init() {};
         virtual void tick();
         virtual bool terminate() { return false; }
+        virtual int exit_code() { return 0; }
 
     private:
         serial_data_t<char> data;

--- a/sim/src/main/cc/endpoints/uart.h
+++ b/sim/src/main/cc/endpoints/uart.h
@@ -10,9 +10,9 @@ class uart_t: public endpoint_t
         uart_t(simif_t* sim);
         void send();
         void recv();
+        virtual void init() {};
         virtual void tick();
-        virtual bool done() { return read(UARTWIDGET_0(done)); }
-        bool stall() { return read(UARTWIDGET_0(stall)); }
+        virtual bool terminate() { return false; }
 
     private:
         serial_data_t<char> data;

--- a/sim/src/main/cc/fesvr/firesim_fesvr.h
+++ b/sim/src/main/cc/fesvr/firesim_fesvr.h
@@ -42,6 +42,7 @@ class firesim_fesvr_t : public htif_t
         void idle();
         void reset();
         void load_program() {
+            wait(); // Switch back to commit all pending requests
             is_loadmem = true;
             htif_t::load_program();
             is_loadmem = false;

--- a/sim/src/main/cc/firesim/firesim_f1.cc
+++ b/sim/src/main/cc/firesim/firesim_f1.cc
@@ -14,7 +14,11 @@ class firesim_f1_t:
 #endif
 {
     public:
+#ifdef RTLSIM
         firesim_f1_t(int argc, char** argv): firesim_top_t(argc, argv) {};
+#else
+        firesim_f1_t(int argc, char** argv): simif_f1_t(argc, argv), firesim_top_t(argc, argv) {};
+#endif
 };
 
 int main(int argc, char** argv) {

--- a/sim/src/main/cc/firesim/firesim_f1.cc
+++ b/sim/src/main/cc/firesim/firesim_f1.cc
@@ -4,38 +4,21 @@
 #include "simif_emul.h"
 #endif
 #include "firesim_top.h"
-#include "fesvr/firesim_fesvr.h"
-
-#if defined(SIMULATION_XSIM) || defined(RTLSIM)
-// use a small step size for rtl sim
-#define DESIRED_STEPSIZE (128)
-#else
-#define DESIRED_STEPSIZE (2004765L)
-#endif
-#ifdef RTLSIM
 
 // top for RTL sim
 class firesim_f1_t:
+#ifdef RTLSIM
     public simif_emul_t, public firesim_top_t
-{
-    public:
-        firesim_f1_t(int argc, char** argv, firesim_fesvr_t* fesvr):
-            firesim_top_t(argc, argv, fesvr, DESIRED_STEPSIZE) { }
-};
 #else
-// top for FPGA simulation on F1
-class firesim_f1_t:
     public simif_f1_t, public firesim_top_t
+#endif
 {
     public:
-        firesim_f1_t(int argc, char** argv, firesim_fesvr_t* fesvr):
-            firesim_top_t(argc, argv, fesvr, DESIRED_STEPSIZE), simif_f1_t(argc, argv) { }
+        firesim_f1_t(int argc, char** argv): firesim_top_t(argc, argv) {};
 };
-#endif
 
 int main(int argc, char** argv) {
-    firesim_fesvr_t fesvr(std::vector<std::string>(argv + 1, argv + argc));
-    firesim_f1_t firesim(argc, argv, &fesvr);
+    firesim_f1_t firesim(argc, argv);
     firesim.init(argc, argv);
     firesim.run();
     return firesim.finish();

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -162,16 +162,12 @@ void firesim_top_t::run() {
     }
 
     uint64_t end_time = timestamp();
+    uint64_t end_hcycle = hcycle();
     uint64_t end_cycle = actual_tcycle();
     double sim_time = diff_secs(end_time, start_time);
     double sim_speed = ((double) end_cycle) / (sim_time * 1000.0);
     // always print a newline after target's output
     fprintf(stderr, "\n");
-    if (sim_speed > 1000.0) {
-        fprintf(stderr, "time elapsed: %.1f s, simulation speed = %.2f MHz\n", sim_time, sim_speed / 1000.0);
-    } else {
-        fprintf(stderr, "time elapsed: %.1f s, simulation speed = %.2f KHz\n", sim_time, sim_speed);
-    }
     int exitcode = exit_code();
     if (exitcode) {
         fprintf(stderr, "*** FAILED *** (code = %d) after %llu cycles\n", exitcode, end_cycle);
@@ -180,6 +176,13 @@ void firesim_top_t::run() {
     } else {
         fprintf(stderr, "*** PASSED *** after %llu cycles\n", end_cycle);
     }
+    if (sim_speed > 1000.0) {
+        fprintf(stderr, "time elapsed: %.1f s, simulation speed = %.2f MHz\n", sim_time, sim_speed / 1000.0);
+    } else {
+        fprintf(stderr, "time elapsed: %.1f s, simulation speed = %.2f KHz\n", sim_time, sim_speed);
+    }
+    double fmr = ((double) end_hcycle / end_cycle);
+    fprintf(stderr, "FPGA-Cycles-to-Model-Cycles Ratio (FMR): %.2f\n", fmr);
     expect(!exitcode, NULL);
 
     for (auto e: fpga_models) {

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -142,11 +142,11 @@ void firesim_top_t::run() {
         zero_out_dram();
     }
     fprintf(stderr, "Commencing simulation.\n");
+    uint64_t start_hcycle = hcycle();
+    uint64_t start_time = timestamp();
 
     // Assert reset T=0 -> 50
     target_reset(0, 50);
-
-    uint64_t start_time = timestamp();
 
     while (!simulation_complete() && !has_timed_out()) {
         run_scheduled_tasks();
@@ -157,8 +157,8 @@ void firesim_top_t::run() {
     }
 
     uint64_t end_time = timestamp();
-    uint64_t end_hcycle = hcycle();
     uint64_t end_cycle = actual_tcycle();
+    uint64_t hcycles = hcycle() - start_hcycle;
     double sim_time = diff_secs(end_time, start_time);
     double sim_speed = ((double) end_cycle) / (sim_time * 1000.0);
     // always print a newline after target's output
@@ -176,7 +176,7 @@ void firesim_top_t::run() {
     } else {
         fprintf(stderr, "time elapsed: %.1f s, simulation speed = %.2f KHz\n", sim_time, sim_speed);
     }
-    double fmr = ((double) end_hcycle / end_cycle);
+    double fmr = ((double) hcycles / end_cycle);
     fprintf(stderr, "FPGA-Cycles-to-Model-Cycles Ratio (FMR): %.2f\n", fmr);
     expect(!exitcode, NULL);
 

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -10,8 +10,7 @@
 #include "endpoints/sim_mem.h"
 #include "endpoints/fpga_memory_model.h"
 
-firesim_top_t::firesim_top_t(int argc, char** argv, firesim_fesvr_t* fesvr, uint32_t fesvr_step_size):
-    fesvr(fesvr), fesvr_step_size(fesvr_step_size)
+firesim_top_t::firesim_top_t(int argc, char** argv)
 {
     // fields to populate to pass to endpoints
     char * blkfile = NULL;
@@ -26,12 +25,8 @@ firesim_top_t::firesim_top_t(int argc, char** argv, firesim_fesvr_t* fesvr, uint
         if (arg.find("+max-cycles=") == 0) {
             max_cycles = atoi(arg.c_str()+12);
         }
-
         if (arg.find("+profile-interval=") == 0) {
             profile_interval = atoi(arg.c_str()+18);
-        }
-        if (arg.find("+fesvr-step-size=") == 0) {
-            fesvr_step_size = atoi(arg.c_str()+17);
         }
         if (arg.find("+blkdev=") == 0) {
             blkfile = const_cast<char*>(arg.c_str()) + 8;
@@ -80,7 +75,7 @@ firesim_top_t::firesim_top_t(int argc, char** argv, firesim_fesvr_t* fesvr, uint
     }
 
     add_endpoint(new uart_t(this));
-    add_endpoint(new serial_t(this, fesvr, fesvr_step_size));
+    add_endpoint(new serial_t(this, args));
 
 #ifdef NASTIWIDGET_0
     endpoints.push_back(new sim_mem_t(this, argc, argv));

--- a/sim/src/main/cc/firesim/firesim_top.h
+++ b/sim/src/main/cc/firesim/firesim_top.h
@@ -5,8 +5,9 @@
 #include "fesvr/firesim_fesvr.h"
 #include "endpoints/endpoint.h"
 #include "endpoints/fpga_model.h"
+#include "systematic_scheduler.h"
 
-class firesim_top_t: virtual simif_t
+class firesim_top_t: virtual simif_t, public systematic_scheduler_t
 {
     public:
         firesim_top_t(int argc, char** argv, firesim_fesvr_t* fesvr, uint32_t fesvr_step_size);
@@ -25,25 +26,20 @@ class firesim_top_t: virtual simif_t
         // FPGA-hosted models with programmable registers & instrumentation
         std::vector<FpgaModel*> fpga_models;
 
-
         firesim_fesvr_t* fesvr;
-        uint64_t max_cycles;
 
         // profile interval: # of cycles to advance before profiling instrumentation registers in models
-        // This sets the coarse_step_size in loop
-        uint64_t profile_interval;
+        uint64_t profile_interval = -1;
         uint32_t fesvr_step_size;
+        uint64_t profile_models();
 
         // If set, will write all zeros to fpga dram before commencing simulation
         bool do_zero_out_dram = false;
-        // Main simulation loop
-        // stepsize = number of target cycles between FESVR interactions
-        // coarse_step_size = maximum number of target cycles loop may advance the simulator
-        void loop(size_t step_size, uint64_t coarse_step_size);
 
         // Returns true if any endpoint has signaled for simulation termination
         bool simulation_complete();
-        bool has_timed_out();
+        // Returns the error code of the first endpoint for which it is non-zero
+        int exit_code();
 
 };
 

--- a/sim/src/main/cc/firesim/firesim_top.h
+++ b/sim/src/main/cc/firesim/firesim_top.h
@@ -2,7 +2,6 @@
 #define __FIRESIM_TOP_H
 
 #include "simif.h"
-#include "fesvr/firesim_fesvr.h"
 #include "endpoints/endpoint.h"
 #include "endpoints/fpga_model.h"
 #include "systematic_scheduler.h"
@@ -10,7 +9,7 @@
 class firesim_top_t: virtual simif_t, public systematic_scheduler_t
 {
     public:
-        firesim_top_t(int argc, char** argv, firesim_fesvr_t* fesvr, uint32_t fesvr_step_size);
+        firesim_top_t(int argc, char** argv);
         ~firesim_top_t() { }
 
         void run();
@@ -26,11 +25,8 @@ class firesim_top_t: virtual simif_t, public systematic_scheduler_t
         // FPGA-hosted models with programmable registers & instrumentation
         std::vector<FpgaModel*> fpga_models;
 
-        firesim_fesvr_t* fesvr;
-
         // profile interval: # of cycles to advance before profiling instrumentation registers in models
         uint64_t profile_interval = -1;
-        uint32_t fesvr_step_size;
         uint64_t profile_models();
 
         // If set, will write all zeros to fpga dram before commencing simulation

--- a/sim/src/main/cc/firesim/firesim_top.h
+++ b/sim/src/main/cc/firesim/firesim_top.h
@@ -24,6 +24,8 @@ class firesim_top_t: virtual simif_t
         std::vector<endpoint_t*> endpoints;
         // FPGA-hosted models with programmable registers & instrumentation
         std::vector<FpgaModel*> fpga_models;
+
+
         firesim_fesvr_t* fesvr;
         uint64_t max_cycles;
 
@@ -39,10 +41,10 @@ class firesim_top_t: virtual simif_t
         // coarse_step_size = maximum number of target cycles loop may advance the simulator
         void loop(size_t step_size, uint64_t coarse_step_size);
 
-        // Helper functions to handoff fesvr requests to the loadmem unit
-        void handle_loadmem_read(fesvr_loadmem_t loadmem);
-        void handle_loadmem_write(fesvr_loadmem_t loadmem);
-        void serial_bypass_via_loadmem();
+        // Returns true if any endpoint has signaled for simulation termination
+        bool simulation_complete();
+        bool has_timed_out();
+
 };
 
 #endif // __FIRESIM_TOP_H

--- a/sim/src/main/cc/firesim/systematic_scheduler.cc
+++ b/sim/src/main/cc/firesim/systematic_scheduler.cc
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include "systematic_scheduler.h"
+
+void systematic_scheduler_t::register_task(task_t task, uint64_t first_cycle) {
+   tasks.push_back(task_tuple_t{task, first_cycle});
+}
+
+uint32_t systematic_scheduler_t::get_largest_stepsize() {
+    uint64_t next_cycle = std::min(current_cycle + default_step_size, max_cycles);
+    for (auto &t: tasks) {
+        if (t.next_cycle < next_cycle) {
+            next_cycle = t.next_cycle;
+         }
+     }
+     assert(next_cycle - current_cycle <= MAX_MIDAS_STEP);
+     uint32_t step = next_cycle - current_cycle;
+     assert(step != 0); // Check for forward progress.
+     current_cycle = next_cycle;
+     return step;
+}
+
+void systematic_scheduler_t::run_scheduled_tasks() {
+    for (auto &t: tasks) {
+        if (t.next_cycle == current_cycle) {
+            t.next_cycle += t.task();
+         }
+    }
+}

--- a/sim/src/main/cc/firesim/systematic_scheduler.h
+++ b/sim/src/main/cc/firesim/systematic_scheduler.h
@@ -4,8 +4,8 @@
 #include <functional>
 #include <vector>
 
-// Maximum step size in MIDAS's master is 2^32 - 1.
-constexpr uint64_t MAX_MIDAS_STEP = (1LL << 32) - 1;
+// Maximum step size in MIDAS's master is capped to width of the simulation bus
+constexpr uint64_t MAX_MIDAS_STEP = (1LL << sizeof(data_t) * 8) - 1;
 
 class systematic_scheduler_t
 {
@@ -16,13 +16,15 @@ class systematic_scheduler_t
     } task_tuple_t;
 
     public:
-        //systematic_scheduler_t(uint64_t default_step_size):
-        //    default_step_size(default_step_size) {};
-
+        // Adds a new task to scheduler.
         void register_task(task_t task, uint64_t first_cycle);
+        // Calculates the next simulation step by taking the min of all tasks.next_cycle
         uint32_t get_largest_stepsize();
+        // Assumption: The simulator is idle. (simif::done() == true)
+        // Invokes all tasks that wish to be executed on our current target cycle
         void run_scheduled_tasks();
         uint64_t max_cycles = -1;
+        // As above, assumes the simulator is idle.
         bool has_timed_out() { return current_cycle == max_cycles; };
 
     private:
@@ -30,5 +32,4 @@ class systematic_scheduler_t
         uint64_t current_cycle = 0;
         std::vector<task_tuple_t> tasks;
 };
-
 #endif // __SYSTEMATIC_SCHEDULER_H

--- a/sim/src/main/cc/firesim/systematic_scheduler.h
+++ b/sim/src/main/cc/firesim/systematic_scheduler.h
@@ -1,0 +1,34 @@
+#ifndef __SYSTEMATIC_SCHEDULER_H
+#define __SYSTEMATIC_SCHEDULER_H
+
+#include <functional>
+#include <vector>
+
+// Maximum step size in MIDAS's master is 2^32 - 1.
+constexpr uint64_t MAX_MIDAS_STEP = (1LL << 32) - 1;
+
+class systematic_scheduler_t
+{
+    typedef std::function<uint64_t()> task_t;
+    typedef struct {
+        task_t task;
+        uint64_t next_cycle;
+    } task_tuple_t;
+
+    public:
+        //systematic_scheduler_t(uint64_t default_step_size):
+        //    default_step_size(default_step_size) {};
+
+        void register_task(task_t task, uint64_t first_cycle);
+        uint32_t get_largest_stepsize();
+        void run_scheduled_tasks();
+        uint64_t max_cycles = -1;
+        bool has_timed_out() { return current_cycle == max_cycles; };
+
+    private:
+        uint64_t default_step_size = MAX_MIDAS_STEP;
+        uint64_t current_cycle = 0;
+        std::vector<task_tuple_t> tasks;
+};
+
+#endif // __SYSTEMATIC_SCHEDULER_H

--- a/sim/src/main/cc/midasexamples/GCD.h
+++ b/sim/src/main/cc/midasexamples/GCD.h
@@ -9,12 +9,14 @@ public:
   void run() {
     uint32_t a = 64, b = 48, z = 16; //test vectors
     target_reset();
+    poke(io_a, a);
+    poke(io_b, b);
+    poke(io_e, 1);
+    step(1);
+    poke(io_e, 0);
     do {
-      poke(io_a, a);
-      poke(io_b, b);
-      poke(io_e, cycles() == 0 ? 1 : 0);
       step(1);
-    } while (cycles() <= 1 || peek(io_v) == 0);
+    } while (peek(io_v) == 0);
     expect(io_z, z);
   }
 };

--- a/sim/src/main/cc/midasexamples/PointerChaser.h
+++ b/sim/src/main/cc/midasexamples/PointerChaser.h
@@ -47,6 +47,7 @@ public:
       e->init();
     }
     target_reset(0);
+    int current_cycle = 0;
 
     poke(io_startAddr_bits, address);
     poke(io_startAddr_valid, 1);

--- a/sim/src/main/cc/midasexamples/PointerChaser.h
+++ b/sim/src/main/cc/midasexamples/PointerChaser.h
@@ -55,17 +55,12 @@ public:
       step(1);
     } while (!peek(io_startAddr_ready));
     poke(io_startAddr_valid, 0);
-    poke(io_result_ready, 1);
+    poke(io_result_ready, 0);
     do {
       step(1, false);
-      bool _done;
-      do {
-        _done = done();
-        for (auto e: endpoints) {
-          _done &= e->done();
-          e->tick();
-        }
-      } while(!_done);
+      for (auto e: endpoints) {
+        e->tick();
+      }
     } while (!peek(io_result_valid) && cycles() < max_cycles);
     expect(io_result_bits, result);
   }

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -49,7 +49,7 @@ DRIVER_CC = $(addprefix $(driver_dir)/, $(addsuffix .cc, \
 	firesim/firesim_top fesvr/firesim_fesvr endpoints/serial endpoints/uart \
 	firesim/firesim_f1 endpoints/simplenic endpoints/blockdev)) $(RISCV)/lib/libfesvr.a
 
-TARGET_CXX_FLAGS := -I$(driver_dir) -I$(driver_dir)/firesim -I$(RISCV)/include
+TARGET_CXX_FLAGS := -g -I$(driver_dir) -I$(driver_dir)/firesim -I$(RISCV)/include
 TARGET_LD_FLAGS :=
 
 ####################################

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -45,9 +45,8 @@ $(VERILOG) $(HEADER): $(chisel_srcs) $(timestamps)
 
 driver_dir = $(firesim_base_dir)/src/main/cc
 DRIVER_H = $(shell find $(driver_dir) -name "*.h")
-DRIVER_CC = $(addprefix $(driver_dir)/, $(addsuffix .cc, \
-	firesim/firesim_top fesvr/firesim_fesvr endpoints/serial endpoints/uart \
-	firesim/firesim_f1 endpoints/simplenic endpoints/blockdev)) $(RISCV)/lib/libfesvr.a
+DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, \
+	firesim/* fesvr/* endpoints/*))) $(RISCV)/lib/libfesvr.a
 
 TARGET_CXX_FLAGS := -g -I$(driver_dir) -I$(driver_dir)/firesim -I$(RISCV)/include
 TARGET_LD_FLAGS :=

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -103,7 +103,5 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
   Pulsify(genWORegInit(respBuf.io.enq.valid, "bdev_resp_valid", false.B), pulseLength = 1)
   genROReg(respBuf.io.enq.ready, "bdev_resp_ready")
 
-  genROReg(!tFire, "done")
-
   genCRFile()
 }

--- a/sim/src/main/scala/endpoints/UARTWidget.scala
+++ b/sim/src/main/scala/endpoints/UARTWidget.scala
@@ -38,9 +38,7 @@ class UARTWidget(div: Int)(implicit p: Parameters) extends EndpointWidget()(p) {
   val rxfifo = Module(new Queue(UInt(8.W), 128))
 
   val target = io.hPort.hBits
-  val tFire = io.hPort.toHost.hValid && io.hPort.fromHost.hReady && io.tReset.valid
-  val stall = !txfifo.io.enq.ready
-  val fire = tFire && !stall
+  val fire = io.hPort.toHost.hValid && io.hPort.fromHost.hReady && io.tReset.valid & txfifo.io.enq.ready
   val targetReset = fire & io.tReset.bits
   rxfifo.reset := reset.toBool || targetReset
   txfifo.reset := reset.toBool || targetReset
@@ -127,9 +125,6 @@ class UARTWidget(div: Int)(implicit p: Parameters) extends EndpointWidget()(p) {
   genWOReg(rxfifo.io.enq.bits, "in_bits")
   Pulsify(genWORegInit(rxfifo.io.enq.valid, "in_valid", false.B), pulseLength = 1)
   genROReg(rxfifo.io.enq.ready, "in_ready")
-
-  genROReg(!tFire, "done")
-  genROReg(stall, "stall")
 
   genCRFile()
 }


### PR DESCRIPTION
This is a fairly big change, it can wait until the tracer stuff and other things are pushed into dev.

Overview of changes:
- Reworks endpoint interface
  - Rename done -> terminate. Assert true if the endpoint wants to bring down simulation
  - Add exitcode() -> encodes reason for termination. 0 = pass
- Reworks main loop 
  - add's systematic_scheduler_t, which advances the simulator to earliest cycle possible (removes the need for an explicit stepsize)
  - tasks (task_t (std::function<uint64_t()> that must be run at specific target-cycles can be registered in main class's constructor or init. 
  - tasks return value indicates the number of target-cycles that should be advanced before they should run again
- Moves all FESVR-related code into the serial_t endpoint class. 
- Adds an FMR print that uses new hardware cycle counters

Todos: 
- [x] FPGA-hosted tests (What should be run?)
- [x] Test networked simulation performance