### PR TITLE
Add path to SPEC17 custom runtime config

### DIFF
--- a/docs/Advanced-Usage/Workloads/SPEC-2017.rst
+++ b/docs/Advanced-Usage/Workloads/SPEC-2017.rst
@@ -50,10 +50,10 @@ To Run:
 
 .. code-block:: bash
 
-    firesim launchrunfarm    -c spec17-intspeed.ini
-    firesim infrasetup       -c spec17-intspeed.ini
-    firesim runworkload      -c spec17-intspeed.ini
-    firesim terminaterunfarm -c spec17-intspeed.ini
+    firesim launchrunfarm    -c workloads/spec17-intspeed.ini
+    firesim infrasetup       -c workloads/spec17-intspeed.ini
+    firesim runworkload      -c workloads/spec17-intspeed.ini
+    firesim terminaterunfarm -c workloads/spec17-intspeed.ini
 
 On a single-core rocket-based SoC with a DDR3 + 256 KiB LLC model, with a 160
 MHz host clock, the longest benchmarks (xz, mcf) complete in about 1
@@ -86,10 +86,10 @@ To Run:
 
 .. code-block:: bash
 
-    firesim launchrunfarm    -c spec17-intrate.ini
-    firesim infrasetup       -c spec17-intrate.ini
-    firesim runworkload      -c spec17-intrate.ini
-    firesim terminaterunfarm -c spec17-intrate.ini
+    firesim launchrunfarm    -c workloads/spec17-intrate.ini
+    firesim infrasetup       -c workloads/spec17-intrate.ini
+    firesim runworkload      -c workloads/spec17-intrate.ini
+    firesim terminaterunfarm -c workloads/spec17-intrate.ini
 
 
 Simulation times are host and target dependent. For reference, on a


### PR DESCRIPTION
`ConfigParser` in `runtime_config.py` cannot find the file/opens an empty file without the specified path because when parsing config file, the current working directory is `firesim/deploy` . 
Error received:
```
Traceback (most recent call last):
  File "/home/centos/firesim/deploy/firesim", line 300, in <module>
    main(args)
  File "/home/centos/firesim/deploy/firesim", line 247, in main
    simconf = RuntimeConfig(args)
  File "/home/centos/firesim/deploy/runtools/runtime_config.py", line 198, in __init__
    args.overrideconfigdata)
  File "/home/centos/firesim/deploy/runtools/runtime_config.py", line 160, in __init__
    self.runfarmtag = runtime_dict['runfarm']['runfarmtag']
KeyError: 'runfarm'
```