### PR TITLE
Fix kernel incompatibility

### DIFF
--- a/deploy/awstools/afitools.py
+++ b/deploy/awstools/afitools.py
@@ -65,12 +65,22 @@ def copy_afi_to_all_regions(afi_id, starting_region=None):
 def share_afi_with_users(afi_id, region, useridlist):
     """ share the AFI in Region region with users in userlist. """
     client = boto3.client('ec2', region_name=region)
-    result = client.modify_fpga_image_attribute(
-        FpgaImageId=afi_id,
-        Attribute='loadPermission',
-        OperationType='add',
-        UserIds=useridlist
-    )
+    if "public" in useridlist:
+        rootLogger.info("Sharing AGFI publicly.")
+        result = client.modify_fpga_image_attribute(
+            FpgaImageId=afi_id,
+            Attribute='loadPermission',
+            OperationType='add',
+            UserGroups=['all']
+        )
+    else:
+        rootLogger.info("Sharing AGFI with selected users.")
+        result = client.modify_fpga_image_attribute(
+            FpgaImageId=afi_id,
+            Attribute='loadPermission',
+            OperationType='add',
+            UserIds=useridlist
+        )
     rootLogger.debug(result)
 
 def get_afi_sharing_ids_from_conf(conf):

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -314,6 +314,8 @@ class InstanceDeployManager:
             run('mkdir -p /home/centos/edma/')
             put('../platforms/f1/aws-fpga/sdk/linux_kernel_drivers',
                 '/home/centos/edma/', mirror_local_mode=True)
+            with cd('/home/centos/edma/linux_kernel_drivers/edma/'):
+                run('make')
 
     def unload_edma(self):
         self.instance_logger("Unloading EDMA Driver Kernel Module.")

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,7 +10,7 @@
 # own images.
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-05857663417e23062
+agfi=agfi-083ef86e56214c8ec
 deploytripletoverride=None
 customruntimeconfig=None
 
@@ -35,7 +35,7 @@ deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-0873c6612234cdebc
+agfi=agfi-0ecd398c27432a31d
 deploytripletoverride=None
 customruntimeconfig=None
 
@@ -45,16 +45,16 @@ deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-02b4b8bda1a0ce827
+agfi=agfi-0cfc78f07c15d3c7c
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-lbp]
-agfi=agfi-0beff843fc43a2308
+agfi=agfi-077d1f12a88d6b29a
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-0696b68c19ee2fd7a
+agfi=agfi-0c6ce0050de7813fe
 deploytripletoverride=None
 customruntimeconfig=None

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -285,7 +285,7 @@ you would use:
 A list of AWS account IDs that you want to share the AGFIs listed in
 ``[agfistoshare]`` with when calling the manager's ``shareagfi`` command. You
 should specify names in the form ``usersname=AWSACCTID``. The left-hand-side is
-just for human readability, only the actual account IDs listed here matter.
+just for human readability, only the actual account IDs listed here matter. If you specify ``public=public`` here, the AGFIs are shared publicly, regardless of any other entires that are present.
 
 .. _config-build-recipes:
 

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -84,7 +84,7 @@ listed in :ref:`config-hwdb`) with other users. It will take the
 named hardware configurations that you list in the ``[agfistoshare]`` section of
 ``config_build.ini``, grab the respective AGFIs for each from
 ``config_hwdb.ini``, and share them across all F1 regions with the users listed
-in the ``[sharewithaccounts]`` section of ``config_build.ini``.
+in the ``[sharewithaccounts]`` section of ``config_build.ini``. You can also specify ``public=public`` in ``[sharewithaccounts]`` to make the AGFIs public.
 
 You must own the AGFIs in order to do this -- this will NOT let you share AGFIs
 that someone else owns and gave you access to.


### PR DESCRIPTION
- Run make for the edma driver on each run farm node
- Add ability to share agfis publicly with firesim shareagfi