### PR TITLE
Deterministic, latency-pipe block-device model

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,26 +10,27 @@
 # own images.
 
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-0c62c26523d4c1a4d
+agfi=agfi-0c050337424731b7d
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-0b8ee028b6437c72f
+agfi=agfi-09cc185bdb95ac6e1
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-0d1da847f445d1720
+agfi=agfi-0f1c0c15fb255258a
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-06a904ca0cf47adde
+agfi=agfi-0dea85aed41ad15d7
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-0ac9fb9bd7fcf0b7c
+agfi=agfi-0e97cd5cd7871fad1
 deploytripletoverride=None
 customruntimeconfig=None
+

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -19,7 +19,6 @@
  * Check if we have been given a file to use as a disk, record size and
  * number of sectors to pass to widget */
 blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endpoint_t(sim) {
-    // TODO: what is ntags?
     _ntags = BLOCKDEVWIDGET_0(num_trackers);
     long size;
     long mem_filesize = 0;
@@ -321,13 +320,12 @@ bool blockdev_t::idle() {
 #endif
 }
 
-/* This method is called to run a "cycle" of the block dev:
- * 1) Read information from the block device widget
- * 2) Do software processing
- * 3) Write responses to the block device widget */
+/* This method is called to service functional requests made by the widget.
+ * No target time is modelled here; the widget will stall stimulation if
+ * we have not yet serviced a transaction that is scheduled to be released. */
 void blockdev_t::tick() {
 
-    /* If there's nothing to do early out and save a bunch of MMIO */
+    /* If there's nothing to do, early out and save a bunch of MMIO */
     if (idle()) {
         return;
     }

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -53,16 +53,8 @@ blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endp
         abort();
     }
 
-    if (filename || mem_filesize > 0) {
-
-        if (mem_filesize > 0 ) {
-            size = mem_filesize << SECTOR_SHIFT;
-            _file = fmemopen(NULL, size, "r+");
-        } else {
-            _file = fopen(filename, "r+");
-            size = ftell(_file);
-        }
-
+    if (filename) {
+        _file = fopen(filename, "r+");
         if (!_file) {
             fprintf(stderr, "Could not open %s\n", filename);
             abort();
@@ -71,8 +63,16 @@ blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endp
             perror("fseek");
             abort();
         }
+        size = ftell(_file);
         if (size < 0) {
             perror("ftell");
+            abort();
+        }
+    } else if (mem_filesize > 0 ) {
+        size = mem_filesize << SECTOR_SHIFT;
+        _file = fmemopen(NULL, size, "r+");
+        if (!_file) {
+            perror("fmemopen");
             abort();
         }
     } else {

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -20,7 +20,7 @@
  * number of sectors to pass to widget */
 blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endpoint_t(sim) {
     // TODO: what is ntags?
-    _ntags = 1; // TODO set this automatically Biancolin: Emit this in the header.
+    _ntags = BLOCKDEVWIDGET_0(num_trackers);
     long size;
 
     for (auto &arg: args) {
@@ -33,6 +33,19 @@ blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endp
         if (arg.find("+blkdev-rlatency=") == 0) {
             read_latency = atoi(const_cast<char*>(arg.c_str()) + 17);
         }
+    }
+
+    uint32_t max_latency = (1UL << BLOCKDEVWIDGET_0(latency_bits)) - 1;
+    if (write_latency > max_latency) {
+        fprintf(stderr, "Requested blockdev write latency (%u) exceeds HW limit (%u).\n",
+                write_latency, max_latency);
+        abort();
+    }
+
+    if (read_latency > max_latency) {
+        fprintf(stderr, "Requested blockdev read latency (%u) exceeds HW limit (%u).\n",
+                read_latency, max_latency);
+        abort();
     }
 
     if (filename) {

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -18,11 +18,22 @@
  * Setup software driver state:
  * Check if we have been given a file to use as a disk, record size and
  * number of sectors to pass to widget */
-blockdev_t::blockdev_t(simif_t* sim, char* fname): endpoint_t(sim) {
+blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endpoint_t(sim) {
     // TODO: what is ntags?
     _ntags = 1; // TODO set this automatically Biancolin: Emit this in the header.
     long size;
-    filename = fname;
+
+    for (auto &arg: args) {
+        if (arg.find("+blkdev=") == 0) {
+            filename = const_cast<char*>(arg.c_str()) + 8;
+        }
+        if (arg.find("+blkdev-wlatency=") == 0) {
+            write_latency = atoi(const_cast<char*>(arg.c_str()) + 17);
+        }
+        if (arg.find("+blkdev-rlatency=") == 0) {
+            read_latency = atoi(const_cast<char*>(arg.c_str()) + 17);
+        }
+    }
 
     if (filename) {
         _file = fopen(filename, "r+");
@@ -61,6 +72,8 @@ void blockdev_t::init() {
     // setup blk dev widget
     write(BLOCKDEVWIDGET_0(bdev_nsectors), nsectors());
     write(BLOCKDEVWIDGET_0(bdev_max_req_len), max_request_length());
+    write(BLOCKDEVWIDGET_0(read_latency), read_latency);
+    write(BLOCKDEVWIDGET_0(write_latency), write_latency);
 #endif // #ifdef BLOCKDEVWIDGET_0
 }
 

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -55,8 +55,14 @@ blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endp
 
     if (filename || mem_filesize > 0) {
 
-        _file = (mem_filesize > 0) ? fmemopen(NULL, mem_filesize << SECTOR_SHIFT, "r+"):
-                                     fopen(filename, "r+");
+        if (mem_filesize > 0 ) {
+            size = mem_filesize << SECTOR_SHIFT;
+            _file = fmemopen(NULL, size, "r+");
+        } else {
+            _file = fopen(filename, "r+");
+            size = ftell(_file);
+        }
+
         if (!_file) {
             fprintf(stderr, "Could not open %s\n", filename);
             abort();
@@ -65,7 +71,6 @@ blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args): endp
             perror("fseek");
             abort();
         }
-        size = ftell(_file);
         if (size < 0) {
             perror("ftell");
             abort();

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -20,7 +20,7 @@
  * number of sectors to pass to widget */
 blockdev_t::blockdev_t(simif_t* sim, char* fname): endpoint_t(sim) {
     // TODO: what is ntags?
-    _ntags = 1; // TODO set this automatically
+    _ntags = 1; // TODO set this automatically Biancolin: Emit this in the header.
     long size;
     filename = fname;
 
@@ -114,7 +114,7 @@ void blockdev_t::do_read(struct blkdev_request &req) {
         struct blkdev_data resp;
         resp.data = blk_data[i];
         resp.tag = req.tag;
-        responses.push(resp);
+        read_responses.push(resp);
     }
 }
 
@@ -200,90 +200,87 @@ void blockdev_t::handle_data(struct blkdev_data &data) {
     tracker.size = 0;
 
     /* Send an ack to the block device.
-     * TODO: should a block device do this? */
-    resp.data = 0;
-    resp.tag = data.tag;
-    responses.push(resp);
+     * TODO: should a block device do this?  Biancolin: Yes.*/
+    write_acks.push(data.tag);
 }
 
-/* Read state of the blockdev widget for this "cycle".
- * Called first during each tick */
+/* Read all pending request data from the widget */
 void blockdev_t::recv() {
 #ifdef BLOCKDEVWIDGET_0
-    /* Check if there is a request coming from the target that should be
-     * processed */
-    a_req_valid = read(BLOCKDEVWIDGET_0(bdev_req_valid));
-    if (a_req_valid) {
+    /* Read all pending requests from the widget */
+    while (read(BLOCKDEVWIDGET_0(bdev_req_valid))) {
         /* Take a request from the FPGA and put it in SW processing queues */
         struct blkdev_request req;
         req.write = read(BLOCKDEVWIDGET_0(bdev_req_write));
         req.offset = read(BLOCKDEVWIDGET_0(bdev_req_offset));
         req.len = read(BLOCKDEVWIDGET_0(bdev_req_len));
         req.tag = read(BLOCKDEVWIDGET_0(bdev_req_tag));
+        write(BLOCKDEVWIDGET_0(bdev_req_ready), true);
         requests.push(req);
 #ifdef BLKDEV_DEBUG
         fprintf(stderr, "[disk] got req. write %x, offset %x, len %x, tag %x\n",
                 req.write, req.offset, req.len, req.tag);
 #endif
-        a_req_ready = true;
-    } else {
-        /* no request from target */
-        a_req_ready = false;
     }
 
-    /* Check if there is data coming from the target that should be
-     * processed */
-    a_data_valid = read(BLOCKDEVWIDGET_0(bdev_data_valid));
-    if (a_data_valid) {
+    /* Read all pending data beats from the widget */
+    while (read(BLOCKDEVWIDGET_0(bdev_data_valid))) {
         /* Take a data chunk from the FPGA and put it in SW processing queues */
         struct blkdev_data data;
         data.data = (((uint64_t)read(BLOCKDEVWIDGET_0(bdev_data_data_upper))) << 32)
             | (read(BLOCKDEVWIDGET_0(bdev_data_data_lower)) & 0xFFFFFFFF);
         data.tag = read(BLOCKDEVWIDGET_0(bdev_data_tag));
+        write(BLOCKDEVWIDGET_0(bdev_data_ready), true);
+        req_data.push(data);
 #ifdef BLKDEV_DEBUG
         fprintf(stderr, "[disk] got data. data %llx, tag %x\n", data.data, data.tag);
 #endif
-        req_data.push(data);
-        a_data_ready = true;
-    } else {
-        /* No data from target */
-        a_data_ready = false;
     }
 #endif // #ifdef BLOCKDEVWIDGET_0
 }
 
-/* Write responses for this cycle to the block device widget, set readys to
- * indicate data we consumed from the block device widget this cycle */
+/* This dumps as much read_response and write_ack data onto the widget as possible
+ * In the event the widget buffers fill up; set resp_data_pending, indicating that
+ * we must try again on the next tick() invocation */
 void blockdev_t::send() {
 #ifdef BLOCKDEVWIDGET_0
-    /* Write readies for request/data coming from the FPGA, if we consumed
-     * something
-     * TODO: don't do these writes if a_req_ready,a_data_ready are not true?
-     */
-    write(BLOCKDEVWIDGET_0(bdev_req_ready), a_req_ready);
-    write(BLOCKDEVWIDGET_0(bdev_data_ready), a_data_ready);
 
-    /* If the block device widget is ready to accept data and we have available
-     * responses, send one to the FPGA */
-    a_resp_ready = read(BLOCKDEVWIDGET_0(bdev_resp_ready));
-    if (!responses.empty() && a_resp_ready) {
-        /* Send a response to the FPGA */
-        a_resp_valid = true;
-        struct blkdev_data resp;
-        resp = responses.front();
-        write(BLOCKDEVWIDGET_0(bdev_resp_data_upper), (resp.data >> 32) & 0xFFFFFFFF);
-        write(BLOCKDEVWIDGET_0(bdev_resp_data_lower), resp.data & 0xFFFFFFFF);
-        write(BLOCKDEVWIDGET_0(bdev_resp_tag), resp.tag);
-        write(BLOCKDEVWIDGET_0(bdev_resp_valid), a_resp_valid);
+    /* Return as many write acknowledgements as the blockdev widget can accept */
+    while (!write_acks.empty() && read(BLOCKDEVWIDGET_0(bdev_wack_ready))) {
+        uint32_t tag = write_acks.front();
+        write(BLOCKDEVWIDGET_0(bdev_wack_tag), tag);
+        write(BLOCKDEVWIDGET_0(bdev_wack_valid), true);
 #ifdef BLKDEV_DEBUG
-        fprintf(stderr, "[disk] sending resp. data %llx, tag %x\n", resp.data, resp.tag);
+        fprintf(stderr, "[disk] sending W ack. tag %x\n", tag);
 #endif
-        responses.pop();
-    } else {
-        /* No response to send to the FPGA */
-        a_resp_valid = false;
+        write_acks.pop();
     }
+
+    /* Send as much read reponse data as as the blockdev widget will accept */
+    while (!read_responses.empty() && read(BLOCKDEVWIDGET_0(bdev_rresp_ready))) {
+        struct blkdev_data resp;
+        resp = read_responses.front();
+        write(BLOCKDEVWIDGET_0(bdev_rresp_data_upper), (resp.data >> 32) & 0xFFFFFFFF);
+        write(BLOCKDEVWIDGET_0(bdev_rresp_data_lower), resp.data & 0xFFFFFFFF);
+        write(BLOCKDEVWIDGET_0(bdev_rresp_tag), resp.tag);
+        write(BLOCKDEVWIDGET_0(bdev_rresp_valid), true);
+#ifdef BLKDEV_DEBUG
+        fprintf(stderr, "[disk] sending R resp. data %llx, tag %x\n", resp.data, resp.tag);
+#endif
+        read_responses.pop();
+    }
+
+    /* Mark if finished */
+    resp_data_pending = !read_responses.empty() || !write_acks.empty();
 #endif // #ifdef BLOCKDEVWIDGET_0
+}
+
+bool blockdev_t::idle() {
+#ifdef BLOCKDEVWIDGET_0
+    return !resp_data_pending && !read(BLOCKDEVWIDGET_0(bdev_reqs_pending));
+#else
+    return true;
+#endif
 }
 
 /* This method is called to run a "cycle" of the block dev:
@@ -291,46 +288,48 @@ void blockdev_t::send() {
  * 2) Do software processing
  * 3) Write responses to the block device widget */
 void blockdev_t::tick() {
-    a_req_valid = false;
-    a_req_ready = false;
-    a_data_valid = false;
-    a_data_ready = false;
-    a_resp_valid = false;
-    a_resp_ready = false;
 
-    do {
-        /* Read state of block device widget */
-        this->recv();
+    /* If there's nothing to do early out and save a bunch of MMIO */
+    if (idle()) {
+        return;
+    }
 
-        /* Do software processing of request queues. (requests coming from the
-         * block dev widget) */
-        while (!requests.empty()) {
-            struct blkdev_request &req = requests.front();
-            if (req.write) {
-                /* if write request, setup a write tracker */
-                do_write(req);
-            } else {
-                /* if read request, perform read from file and put data into
-                 * responses queue. */
-                do_read(req);
-            }
-            requests.pop();
-        }
-
-        /* Do software processing of write data queues. (data coming from the
-         * block dev widget).
-         *
-         * If there is data in req_data (from the FPGA) and a tracker has been
-         * properly setup for this write, then call handle_data for this beat
-         * of the write. */
-        while (!req_data.empty() && can_accept(req_data.front())) {
-            handle_data(req_data.front());
-            req_data.pop();
-        }
-
-        /* Write state back to block device widget */
+    /* If there's pending response data from the last invocation of tick(),
+     * write that back first as it might be locking up the simulator */
+    if (resp_data_pending) {
         this->send();
+    }
 
-        /* While: if we did any work during this iteration, do another iter */
-    } while((a_req_valid && a_req_ready) || (a_data_valid && a_data_ready) || (a_resp_valid && a_resp_ready));
+    /* Collect all of the requests sitting in the widget queues */
+    this->recv();
+
+    /* Do software processing of request queues. (requests coming from the
+     * block dev widget) */
+    while (!requests.empty()) {
+        struct blkdev_request &req = requests.front();
+        if (req.write) {
+            /* if write request, setup a write tracker */
+            do_write(req);
+        } else {
+            /* if read request, perform read from file and put data into
+             * read_responses queue. */
+            do_read(req);
+        }
+        requests.pop();
+    }
+
+    /* Do software processing of write data queues. (data coming from the
+     * block dev widget).
+     *
+     * If there is data in req_data (from the FPGA) and a tracker has been
+     * properly setup for this write, then call handle_data for this beat
+     * of the write. */
+    while (!req_data.empty() && can_accept(req_data.front())) {
+        handle_data(req_data.front());
+        req_data.pop();
+    }
+
+    /* Write state back to block device widget */
+    this->send();
 }
+

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -55,6 +55,9 @@ class blockdev_t: public endpoint_t
         bool a_resp_valid;
         bool a_resp_ready;
 
+        // Set if, on the previous tick, we couldn't write back all of our response data
+        bool resp_data_pending = false;
+
         simif_t* sim;
         uint32_t _ntags;
         uint32_t _nsectors;
@@ -62,13 +65,17 @@ class blockdev_t: public endpoint_t
         char * filename;
         std::queue<blkdev_request> requests;
         std::queue<blkdev_data> req_data;
-        std::queue<blkdev_data> responses;
+        std::queue<blkdev_data> read_responses;
+        std::queue<uint32_t> write_acks;
+
         std::vector<blkdev_write_tracker> write_trackers;
 
         void do_read(struct blkdev_request &req);
         void do_write(struct blkdev_request &req);
         bool can_accept(struct blkdev_data &data);
         void handle_data(struct blkdev_data &data);
+        // Returns true if no widget interaction is required
+        bool idle();
 };
 
 #endif // __BLOCKDEV_H

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -34,7 +34,7 @@ struct blkdev_write_tracker {
 class blockdev_t: public endpoint_t
 {
     public:
-        blockdev_t(simif_t* sim, char* filename);
+        blockdev_t(simif_t* sim, const std::vector<std::string>& args);
         ~blockdev_t();
 
         uint32_t nsectors(void) { return _nsectors; }
@@ -62,7 +62,7 @@ class blockdev_t: public endpoint_t
         uint32_t _ntags;
         uint32_t _nsectors;
         FILE *_file;
-        char * filename;
+        char * filename = NULL;
         std::queue<blkdev_request> requests;
         std::queue<blkdev_data> req_data;
         std::queue<blkdev_data> read_responses;
@@ -76,6 +76,10 @@ class blockdev_t: public endpoint_t
         void handle_data(struct blkdev_data &data);
         // Returns true if no widget interaction is required
         bool idle();
+
+        // Default timing model parameters
+        uint32_t read_latency = 4096;
+        uint32_t write_latency = 4096;
 };
 
 #endif // __BLOCKDEV_H

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -13,7 +13,6 @@
 firesim_top_t::firesim_top_t(int argc, char** argv)
 {
     // fields to populate to pass to endpoints
-    char * blkfile = NULL;
     char * niclogfile = NULL;
     char * slotid = NULL;
     uint64_t mac_little_end = 0; // default to invalid mac addr, force user to specify one
@@ -27,9 +26,6 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
         }
         if (arg.find("+profile-interval=") == 0) {
             profile_interval = atoi(arg.c_str()+18);
-        }
-        if (arg.find("+blkdev=") == 0) {
-            blkfile = const_cast<char*>(arg.c_str()) + 8;
         }
         if (arg.find("+niclog=") == 0) {
             niclogfile = const_cast<char*>(arg.c_str()) + 8;
@@ -94,7 +90,7 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
                 argc, argv, "memory_stats.csv"));
 #endif
 
-    add_endpoint(new blockdev_t(this, blkfile));
+    add_endpoint(new blockdev_t(this, args));
     add_endpoint(new simplenic_t(this, slotid, mac_little_end, netbw, netburst, linklatency, niclogfile));
 
     // Add functions you'd like to periodically invoke on a paused simulator here.

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -67,10 +67,21 @@ conf:
 # The desired RTL simulator. supported options: {vcs, verilator}
 EMUL ?= verilator
 
+# Firechip Tests
+fc_test_dir = $(base_dir)/target-rtl/firechip/tests
+fc_test_srcs = $(wildcard $(base_dir)/target-rtl/firechip/tests/*.cc)
+fc_test_hdrs = $(wildcard $(base_dir)/target-rtl/firechip/tests/*.cc)
+
+$(info $(fc_test_srcs))
+
+$(fc_test_dir)/%.riscv: $(fc_test_srcs) $(fc_test_hdrs) $(fc_test_dir)/Makefile
+	make -C $(fc_test_dir)
+
 ifneq ($(filter run% %.run %.out %.vpd %.vcd,$(MAKECMDGOALS)),)
 output_dir := $(OUTPUT_DIR)
 -include $(GENERATED_DIR)/$(DESIGN).d
 endif
+
 
 disasm := 2>
 which_disasm := $(shell which spike-dasm 2> /dev/null)
@@ -78,9 +89,11 @@ ifneq ($(which_disasm),)
         disasm := 3>&1 1>&2 2>&3 | $(which_disasm) $(DISASM_EXTENSION) >
 endif
 
+# Some of the generated suites use specific plus args, that are prefixed with
+# the binary name. These are captured with $($*_ARGS)
 $(OUTPUT_DIR)/%.run: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/% $(EMUL)
@@ -90,6 +103,6 @@ $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/% $(EMUL)
 
 $(OUTPUT_DIR)/%.vpd: $(OUTPUT_DIR)/% $(EMUL)-debug
 	cd $(dir $($(EMUL)_debug)) && \
-	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ +$($*_ARGS) max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	$(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -85,11 +85,11 @@ $(OUTPUT_DIR)/%.run: $(OUTPUT_DIR)/% $(EMUL)
 
 $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	$(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.vpd: $(OUTPUT_DIR)/% $(EMUL)-debug
 	cd $(dir $($(EMUL)_debug)) && \
-	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ +$($*_ARGS) max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	$(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -5,9 +5,11 @@ import chisel3.core._
 import chisel3.util._
 import DataMirror.directionOf
 import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.util.DecoupledHelper
 
 import midas.core._
 import midas.widgets._
+import midas.models.DynamicLatencyPipe
 import testchipip.{BlockDeviceIO, BlockDeviceRequest, BlockDeviceData, BlockDeviceInfo, HasBlockDeviceParameters, BlockDeviceKey}
 
 class SimBlockDev extends Endpoint {
@@ -34,41 +36,167 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
   val tagBits = log2Up(nTrackers)
   val nTrackerBits = log2Up(nTrackers+1)
   val dataBitsPerBeat = 64
-  val dataBeats = (dataBytes * 8) / dataBitsPerBeat
+  val dataBeats = (dataBytes * 8) / dataBitsPerBeat // A transaction is thus dataBeats * len beats long
   val sectorSize = log2Ceil(sectorBits/8)
   val beatIdxBits = log2Ceil(dataBeats)
   val pAddrBits = 32 // TODO: Make configurable somehow
+  // Timing parameters
+  val latencyBits = 24
+  val defaultReadLatency = (1 << 8).U(latencyBits.W)
+  val defaultWriteLatency = (1 << 8).U(latencyBits.W)
 
   val io = IO(new BlockDevWidgetIO)
 
   val reqBuf = Module(new Queue(new BlockDeviceRequest, 10))
   val dataBuf = Module(new Queue(new BlockDeviceData, 32))
-  val respBuf = Module(new Queue(new BlockDeviceData, 32))
+
+  val rRespBuf = Module(new Queue(new BlockDeviceData, 32))
+  val wAckBuf = Module(new Queue(UInt(tagBits.W), 4))
 
   val target = io.hPort.hBits
-  val tFire = io.hPort.toHost.hValid && io.hPort.fromHost.hReady && io.tReset.valid
-  val targetReset = tFire & io.tReset.bits
+  val channelCtrlSignals = Seq(io.hPort.toHost.hValid,
+                               io.hPort.fromHost.hReady,
+                               io.tReset.valid)
+  val rRespStallN = Wire(Bool()) // Unset if the SW model hasn't returned the response data in time
+  val wAckStallN = Wire(Bool())  // As above, but with a write acknowledgement
+  val tFireHelper = DecoupledHelper((channelCtrlSignals ++ Seq(
+                                     reqBuf.io.enq.ready,
+                                     dataBuf.io.enq.ready,
+                                     rRespStallN,
+                                     wAckStallN)):_*)
+
+  val tFire = tFireHelper.fire(false.B) // Dummy argument to get conjunction of all signals
+  // Decoupled helper can't exclude two bools unfortunately...
+  val targetReset = channelCtrlSignals.reduce(_ && _) && io.tReset.bits
 
   reqBuf.reset  := reset.toBool || targetReset
   dataBuf.reset  := reset.toBool || targetReset
-  respBuf.reset  := reset.toBool || targetReset
+  rRespBuf.reset  := reset.toBool || targetReset
+  wAckBuf.reset  := reset.toBool || targetReset
 
-  io.hPort.toHost.hReady := tFire
-  io.hPort.fromHost.hValid := tFire
-  io.tReset.ready := tFire
+  io.hPort.toHost.hReady := tFireHelper.fire(io.hPort.toHost.hValid)
+  io.hPort.fromHost.hValid := tFireHelper.fire(io.hPort.fromHost.hReady)
+  io.tReset.ready := tFireHelper.fire(io.tReset.valid)
 
   reqBuf.io.enq.bits := target.req.bits
-  reqBuf.io.enq.valid := target.req.valid && tFire && !io.tReset.bits
-  target.req.ready := reqBuf.io.enq.ready
+  reqBuf.io.enq.valid := target.req.valid && tFireHelper.fire(reqBuf.io.enq.ready)
+  target.req.ready := true.B
 
   dataBuf.io.enq.bits := target.data.bits
-  dataBuf.io.enq.valid := target.data.valid && tFire && !io.tReset.bits
-  target.data.ready := dataBuf.io.enq.ready
+  dataBuf.io.enq.valid := target.data.valid && tFireHelper.fire(dataBuf.io.enq.ready)
+  target.data.ready := true.B
 
-  target.resp.bits := respBuf.io.deq.bits
-  target.resp.valid := respBuf.io.deq.valid
-  respBuf.io.deq.ready := target.resp.ready && tFire
+  // Begin Timing model
+  val tCycle = RegInit(0.U(latencyBits.W))
+  when (tFire) {
+    tCycle := tCycle + 1.U
+  }
 
+  chisel3.experimental.withReset(reset.toBool || targetReset) {
+    when (tFire) {
+      assert(!target.req.fire || ((dataBeats.U * target.req.bits.len) < ((BigInt(1) << sectorBits) - 1).U),
+             "Transaction length exceeds timing model maximum supported length")
+    }
+
+    // Timing Model -- Write Latency Pipe
+    // Write latency = write-ack cycle - cycle to receive last write beat
+    // Count the beats received for each tracker; they can be interleaved
+
+    val wBeatCounters = Reg(Vec(nTrackers, UInt(sectorBits.W)))
+    val wValid = RegInit(VecInit(Seq.fill(nTrackers)(false.B)))
+
+    val writeLatencyPipe = Module(new DynamicLatencyPipe(UInt(1.W), nTrackers, latencyBits))
+    val writeLatency = genWORegInit(Wire(UInt(latencyBits.W)), "write_latency", defaultWriteLatency)
+    writeLatencyPipe.io.enq.valid := false.B
+    writeLatencyPipe.io.enq.bits := DontCare
+    writeLatencyPipe.io.latency := writeLatency
+    writeLatencyPipe.io.tCycle := tCycle
+
+    val tagMatch = target.data.bits.tag === target.req.bits.tag
+
+    wValid.zip(wBeatCounters).zipWithIndex.foreach { case ((valid, count), idx) =>
+      val wReqFire  = target.req.fire && target.req.bits.write && target.req.bits.tag === idx.U
+      val wDataFire = target.data.fire && target.data.bits.tag === idx.U
+      val wDone = (wDataFire && count === 1.U)
+
+      when (tFire) {
+        // New write request received
+        when(wDone) {
+          assert(valid, "Write data received for unallocated tracker: %d\n", idx.U)
+          writeLatencyPipe.io.enq.valid := true.B
+          valid := false.B
+        }.elsewhen (wReqFire) {
+          valid := true.B
+          count := Mux(wDataFire, dataBeats.U * target.req.bits.len - 1.U, dataBeats.U * target.req.bits.len)
+          // We don't honestly expect len > 2^29 do we..
+        // New data beat received for our tracker
+        }.elsewhen (wDataFire) {
+          count := count - 1.U
+          assert(valid, "Write data received for unallocated tracker: %d\n", idx.U)
+        }
+      }
+    }
+
+    // Timing Model -- Read Latency Pipe
+    // Read latency is simply the number of cycles between read-req and first resp beat
+    val readLatencyPipe = Module(new DynamicLatencyPipe(UInt(sectorBits.W), nTrackers, latencyBits))
+    val readLatency = genWORegInit(Wire(UInt(latencyBits.W)), "read_latency", defaultReadLatency)
+
+    readLatencyPipe.io.enq.valid := tFire && target.req.fire && !target.req.bits.write
+    readLatencyPipe.io.enq.bits := target.req.bits.len
+    readLatencyPipe.io.tCycle := tCycle
+    readLatencyPipe.io.latency := readLatency
+
+    // Scheduler. Prioritize returning write acknowledgements over returning read resps
+    // as they are only a single cycle long
+    val readRespBeatsLeft = RegInit(0.U(sectorBits.W))
+    val returnWrite = RegInit(false.B)
+    val readRespBusy = readRespBeatsLeft =/= 0.U
+    val done = (returnWrite || readRespBeatsLeft === 1.U) && target.resp.fire
+    val idle = !returnWrite && !readRespBusy
+    writeLatencyPipe.io.deq.ready := false.B
+    readLatencyPipe.io.deq.ready  := false.B
+
+    when (tFire) {
+      when (done || idle) {
+        // If a write-response is waiting, return it first
+        when(writeLatencyPipe.io.deq.valid) {
+          returnWrite := true.B
+          writeLatencyPipe.io.deq.ready := true.B
+        }.elsewhen(readLatencyPipe.io.deq.valid) {
+          readRespBeatsLeft := readLatencyPipe.io.deq.bits * dataBeats.U
+          readLatencyPipe.io.deq.ready := true.B
+        }.otherwise {
+          readRespBeatsLeft := 0.U
+          returnWrite := false.B
+        }
+      }.elsewhen(readRespBusy && target.resp.fire) {
+        readRespBeatsLeft := readRespBeatsLeft - 1.U
+      }
+    }
+
+    // Tie functional queues to output, gated with timing model control
+    target.resp.valid  := !idle
+    target.resp.bits.data  := 0.U
+    target.resp.bits.tag  := 0.U
+    // This shouldn't be necessary for a well behaved target, but only drive bits
+    // through when there is valid data in the queue, closing a potential
+    // determinism hole
+    when (rRespBuf.io.deq.valid && readRespBusy) {
+      target.resp.bits.data  := rRespBuf.io.deq.bits.data
+      target.resp.bits.tag  := rRespBuf.io.deq.bits.tag
+    }.elsewhen (wAckBuf.io.deq.valid && returnWrite) {
+      target.resp.bits.tag  := wAckBuf.io.deq.bits
+    }
+
+    wAckStallN := !returnWrite || wAckBuf.io.deq.valid
+    rRespStallN := !readRespBusy || rRespBuf.io.deq.valid
+
+    wAckBuf.io.deq.ready := tFireHelper.fire(wAckStallN) && returnWrite && target.resp.ready
+    rRespBuf.io.deq.ready := tFireHelper.fire(rRespStallN) && readRespBusy && target.resp.ready
+  } // withReset{}
+
+  // Memory mapped registers
   val nsectorReg = Reg(UInt(sectorBits.W))
   val max_req_lenReg = Reg(UInt(sectorBits.W))
   attach(nsectorReg, "bdev_nsectors", WriteOnly)
@@ -76,7 +204,7 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
   target.info.nsectors := nsectorReg
   target.info.max_req_len := max_req_lenReg
 
-  // req
+  // Functional request queue (to CPU)
   genROReg(reqBuf.io.deq.valid, "bdev_req_valid")
   genROReg(reqBuf.io.deq.bits.write, "bdev_req_write")
   genROReg(reqBuf.io.deq.bits.offset, "bdev_req_offset")
@@ -84,24 +212,31 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
   genROReg(reqBuf.io.deq.bits.tag, "bdev_req_tag")
   Pulsify(genWORegInit(reqBuf.io.deq.ready, "bdev_req_ready", false.B), pulseLength = 1)
 
-  // data
+  // Functional data queue (to CPU)
   genROReg(dataBuf.io.deq.valid, "bdev_data_valid")
   genROReg(dataBuf.io.deq.bits.data(63, 32), "bdev_data_data_upper")
   genROReg(dataBuf.io.deq.bits.data(31, 0), "bdev_data_data_lower")
   genROReg(dataBuf.io.deq.bits.tag, "bdev_data_tag")
   Pulsify(genWORegInit(dataBuf.io.deq.ready, "bdev_data_ready", false.B), pulseLength = 1)
 
-  // resp
-  val respDataRegUpper = Reg(UInt((dataBitsPerBeat/2).W))
-  val respDataRegLower = Reg(UInt((dataBitsPerBeat/2).W))
-  val respTag = Reg(UInt(tagBits.W))
-  respBuf.io.enq.bits.data := Cat(respDataRegUpper, respDataRegLower)
-  respBuf.io.enq.bits.tag := respTag
-  attach(respDataRegUpper, "bdev_resp_data_upper", WriteOnly)
-  attach(respDataRegLower, "bdev_resp_data_lower", WriteOnly)
-  attach(respTag, "bdev_resp_tag", WriteOnly)
-  Pulsify(genWORegInit(respBuf.io.enq.valid, "bdev_resp_valid", false.B), pulseLength = 1)
-  genROReg(respBuf.io.enq.ready, "bdev_resp_ready")
+  // Read reponse buffer MMIO IF (from CPU)
+  val rRespDataRegUpper = genWOReg(Wire(UInt((dataBitsPerBeat/2).W)),"bdev_rresp_data_upper")
+  val rRespDataRegLower = genWOReg(Wire(UInt((dataBitsPerBeat/2).W)),"bdev_rresp_data_lower")
+  val rRespTag          = genWOReg(Wire(UInt(tagBits.W)            ),"bdev_rresp_tag")
+  Pulsify(                genWORegInit(rRespBuf.io.enq.valid  ,"bdev_rresp_valid", false.B), pulseLength = 1)
+  genROReg(rRespBuf.io.enq.ready, "bdev_rresp_ready")
+
+  rRespBuf.io.enq.bits.data := Cat(rRespDataRegUpper, rRespDataRegLower)
+  rRespBuf.io.enq.bits.tag := rRespTag
+
+  // Write acknowledgement buffer MMIO IF (from CPU) -- we only need the tag from SW
+  val wAckTag          = genWOReg(Wire(UInt(tagBits.W))            ,"bdev_wack_tag")
+  Pulsify(               genWORegInit(wAckBuf.io.enq.valid   ,"bdev_wack_valid", false.B), pulseLength = 1)
+  genROReg(wAckBuf.io.enq.ready, "bdev_wack_ready")
+  wAckBuf.io.enq.bits := wAckTag
+
+  // Indicates to the CPU-hosted component that we need to be serviced
+  genROReg(reqBuf.io.deq.valid || dataBuf.io.deq.valid, "bdev_reqs_pending")
 
   genCRFile()
 }

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -59,13 +59,15 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
                                io.tReset.valid)
   val rRespStallN = Wire(Bool()) // Unset if the SW model hasn't returned the response data in time
   val wAckStallN = Wire(Bool())  // As above, but with a write acknowledgement
+  val fixMeOnNextRocketBump = true.B
   val tFireHelper = DecoupledHelper((channelCtrlSignals ++ Seq(
                                      reqBuf.io.enq.ready,
                                      dataBuf.io.enq.ready,
+                                     fixMeOnNextRocketBump,
                                      rRespStallN,
                                      wAckStallN)):_*)
 
-  val tFire = tFireHelper.fire(false.B) // Dummy argument to get conjunction of all signals
+  val tFire = tFireHelper.fire(fixMeOnNextRocketBump) // Dummy argument to get conjunction of all signals
   // Decoupled helper can't exclude two bools unfortunately...
   val targetReset = channelCtrlSignals.reduce(_ && _) && io.tReset.bits
 

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -243,4 +243,10 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
   genROReg(~rRespStallN, "bdev_rresp_stalled")
 
   genCRFile()
+
+  override def genHeader(base: BigInt, sb: StringBuilder) {
+    super.genHeader(base, sb)
+    sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_latency_bits", UInt32(latencyBits)))
+    sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_num_trackers", UInt32(nTrackers)))
+  }
 }

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -237,6 +237,8 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
 
   // Indicates to the CPU-hosted component that we need to be serviced
   genROReg(reqBuf.io.deq.valid || dataBuf.io.deq.valid, "bdev_reqs_pending")
+  genROReg(~wAckStallN, "bdev_wack_stalled")
+  genROReg(~rRespStallN, "bdev_rresp_stalled")
 
   genCRFile()
 }

--- a/sim/src/main/scala/firesim/Generator.scala
+++ b/sim/src/main/scala/firesim/Generator.scala
@@ -194,6 +194,7 @@ trait HasTestSuites {
     TestGeneration.addSuites((if (vm) List("v") else List()).flatMap(env => rvu.map(_(env))))
     TestGeneration.addSuite(benchmarks)
     TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
+    TestGeneration.addSuite(BlockdevTestSuite)
   }
 }
 

--- a/sim/src/main/scala/firesim/Generator.scala
+++ b/sim/src/main/scala/firesim/Generator.scala
@@ -195,7 +195,7 @@ trait HasTestSuites {
     TestGeneration.addSuite(benchmarks)
     TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
     TestGeneration.addSuite(FastBlockdevTests)
-    TestGeneration.addSuite(AllBlockdevTests)
+    TestGeneration.addSuite(SlowBlockdevTests)
   }
 }
 

--- a/sim/src/main/scala/firesim/Generator.scala
+++ b/sim/src/main/scala/firesim/Generator.scala
@@ -194,7 +194,8 @@ trait HasTestSuites {
     TestGeneration.addSuites((if (vm) List("v") else List()).flatMap(env => rvu.map(_(env))))
     TestGeneration.addSuite(benchmarks)
     TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
-    TestGeneration.addSuite(BlockdevTestSuite)
+    TestGeneration.addSuite(FastBlockdevTests)
+    TestGeneration.addSuite(AllBlockdevTests)
   }
 }
 

--- a/sim/src/main/scala/firesim/TargetLandTestSuites.scala
+++ b/sim/src/main/scala/firesim/TargetLandTestSuites.scala
@@ -22,5 +22,5 @@ class BlockdevTestSuite(prefix: String, val names: LinkedHashSet[String]) extend
 }
 
 object FastBlockdevTests extends BlockdevTestSuite("fast", LinkedHashSet("blkdev"))
-object AllBlockdevTests extends BlockdevTestSuite("all", LinkedHashSet("blkdev", "big-blkdev"))
+object SlowBlockdevTests extends BlockdevTestSuite("all", LinkedHashSet("big-blkdev"))
 

--- a/sim/src/main/scala/firesim/TargetLandTestSuites.scala
+++ b/sim/src/main/scala/firesim/TargetLandTestSuites.scala
@@ -1,0 +1,32 @@
+
+package firesim.firesim
+
+import scala.collection.mutable.LinkedHashSet
+
+import freechips.rocketchip.system.{TestGeneration, RocketTestSuite}
+
+object BlockdevTestSuite extends RocketTestSuite {
+  val envName = ""
+  // base_dir is is defined in firesim's Makefrag
+  val dir = "$(base_dir)/target-rtl/firechip/tests"
+  val makeTargetName = "blkdev-tests"
+  def kind = "blockdev"
+  // Blockdev tests need an image, which complicates this
+  def additionalArgs = "+blkdev-in-mem=8"
+  override def toString = s"$makeTargetName = \\\n" +
+    // Make variable with the binaries of the suite
+    names.map(n => s"\t$n.riscv").mkString(" \\\n") + "\n" +
+    // Variables with binary specific arguments
+    names.map(n => s"$n.riscv_ARGS=$additionalArgs").mkString(" \n") +
+    postScript
+
+  override def postScript = s"""
+
+$$(base_dir)/target-rtl/firechip/tests/%blkdev.riscv: $$(output_dir)/%blockdev.riscv.ext2
+\tcd make -f $$(base_dir)/target-rtl/firechip/Makefile
+
+""" + super.postScript
+
+  val names = LinkedHashSet("blkdev", "big-blkdev")
+}
+

--- a/sim/src/main/scala/firesim/TargetLandTestSuites.scala
+++ b/sim/src/main/scala/firesim/TargetLandTestSuites.scala
@@ -5,28 +5,22 @@ import scala.collection.mutable.LinkedHashSet
 
 import freechips.rocketchip.system.{TestGeneration, RocketTestSuite}
 
-object BlockdevTestSuite extends RocketTestSuite {
+class BlockdevTestSuite(prefix: String, val names: LinkedHashSet[String]) extends RocketTestSuite {
   val envName = ""
   // base_dir is is defined in firesim's Makefrag
-  val dir = "$(base_dir)/target-rtl/firechip/tests"
-  val makeTargetName = "blkdev-tests"
+  val dir = "$(fc_test_dir)"
+  val makeTargetName = prefix + "-blkdev-tests"
   def kind = "blockdev"
   // Blockdev tests need an image, which complicates this
-  def additionalArgs = "+blkdev-in-mem=8"
+  def additionalArgs = "+blkdev-in-mem=128"
   override def toString = s"$makeTargetName = \\\n" +
     // Make variable with the binaries of the suite
-    names.map(n => s"\t$n.riscv").mkString(" \\\n") + "\n" +
+    names.map(n => s"\t$n.riscv").mkString(" \\\n") + "\n\n" +
     // Variables with binary specific arguments
     names.map(n => s"$n.riscv_ARGS=$additionalArgs").mkString(" \n") +
     postScript
-
-  override def postScript = s"""
-
-$$(base_dir)/target-rtl/firechip/tests/%blkdev.riscv: $$(output_dir)/%blockdev.riscv.ext2
-\tcd make -f $$(base_dir)/target-rtl/firechip/Makefile
-
-""" + super.postScript
-
-  val names = LinkedHashSet("blkdev", "big-blkdev")
 }
+
+object FastBlockdevTests extends BlockdevTestSuite("fast", LinkedHashSet("blkdev"))
+object AllBlockdevTests extends BlockdevTestSuite("all", LinkedHashSet("blkdev", "big-blkdev"))
 

--- a/sim/src/main/scala/firesim/TargetLandTestSuites.scala
+++ b/sim/src/main/scala/firesim/TargetLandTestSuites.scala
@@ -1,13 +1,19 @@
-
+//See LICENSE for license details.
 package firesim.firesim
 
 import scala.collection.mutable.LinkedHashSet
 
 import freechips.rocketchip.system.{TestGeneration, RocketTestSuite}
 
+/* This imports tests from FireChip to test devices that aren't natively
+ * tested by the riscv assembly tests.
+ * Firesim's target-specific makefrag gives the recipes for building the
+ * binaries.
+ */
+
 class BlockdevTestSuite(prefix: String, val names: LinkedHashSet[String]) extends RocketTestSuite {
   val envName = ""
-  // base_dir is is defined in firesim's Makefrag
+  // fc_test_dir is is defined in firesim's Makefrag
   val dir = "$(fc_test_dir)"
   val makeTargetName = prefix + "-blkdev-tests"
   def kind = "blockdev"
@@ -22,5 +28,5 @@ class BlockdevTestSuite(prefix: String, val names: LinkedHashSet[String]) extend
 }
 
 object FastBlockdevTests extends BlockdevTestSuite("fast", LinkedHashSet("blkdev"))
-object SlowBlockdevTests extends BlockdevTestSuite("all", LinkedHashSet("big-blkdev"))
+object SlowBlockdevTests extends BlockdevTestSuite("slow", LinkedHashSet("big-blkdev"))
 

--- a/sim/src/test/scala/firesim/ScalaTestSuite.scala
+++ b/sim/src/test/scala/firesim/ScalaTestSuite.scala
@@ -55,7 +55,7 @@ abstract class FireSimTestSuite(
     behavior of s"${suite.makeTargetName} running on $backend"
     if (isCmdAvailable(backend)) {
       val postfix = suite match {
-        case s: BenchmarkTestSuite => ".riscv"
+        case _: BenchmarkTestSuite | _: BlockdevTestSuite => ".riscv"
         case _ => ""
       }
       val results = suite.names.toSeq sliding (N, N) map { t => 
@@ -91,6 +91,7 @@ abstract class FireSimTestSuite(
   generateTestSuiteMakefrags
   runTest("verilator", "rv64ui-p-simple", false)
   runSuite("verilator")(benchmarks)
+  runSuite("verilator")(FastBlockdevTests)
 }
 
 class RocketF1Tests extends FireSimTestSuite(


### PR DESCRIPTION
This PR provides a deterministic fixed-latency model for the block device (with independently programmable read and write latency). 

This should also save a bunch of MMIO when the block device is idle.

Adds target-land blockdev tests to the generated makefrag, and the ScalaTests. We should consider adding more. 

Todo: 
- [x] Make latencies CML args. Legalize against hardware widths.
- [x] Debug features: Add counters for stall causes / bind stall causes to MMIO regs 
- [x] Pick the right base branch. This maybe should go into the main loop rework. 
- [x] Add block device tests to makefrag & scala tests 
- [ ] Consider increasing tracker count? Or at least testing that. 