### PR TITLE
Reenable boom july 2018

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -24,4 +24,13 @@ agfi=agfi-08e0a4ad02494f1ac
 deploytripletoverride=None
 customruntimeconfig=None
 
-### TODO: BOOM configs will be readded once support is added back to FireChip
+[fireboom-singlecore-nic-ddr3-llc4mb]
+agfi=agfi-0158db44fcbe84c1c
+deploytripletoverride=None
+customruntimeconfig=None
+
+[fireboom-singlecore-no-nic-ddr3-llc4mb]
+agfi=agfi-039147ddc85487581
+deploytripletoverride=None
+customruntimeconfig=None
+

--- a/sim/build.sbt
+++ b/sim/build.sbt
@@ -15,7 +15,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val rocketchip = RootProject(file("target-rtl/firechip/rocket-chip"))
-//lazy val boom       = project in file("target-rtl/firechip/boom") settings commonSettings dependsOn rocketchip
+lazy val boom       = project in file("target-rtl/firechip/boom") settings commonSettings dependsOn rocketchip
 lazy val sifiveip   = project in file("target-rtl/firechip/sifive-blocks") settings commonSettings dependsOn rocketchip
 lazy val testchipip = project in file("target-rtl/firechip/testchipip") settings commonSettings dependsOn rocketchip
 lazy val icenet     = project in file("target-rtl/firechip/icenet") settings commonSettings dependsOn (rocketchip, testchipip)
@@ -24,4 +24,4 @@ lazy val mdf        = RootProject(file("barstools/mdf/scalalib"))
 lazy val barstools  = project in file("barstools/macros") settings commonSettings dependsOn (mdf, rocketchip)
 lazy val midas      = project in file("midas") settings commonSettings dependsOn barstools
 
-lazy val firesim    = project in file(".") settings commonSettings dependsOn (midas, sifiveip, testchipip, icenet/*, boom*/)
+lazy val firesim    = project in file(".") settings commonSettings dependsOn (midas, sifiveip, testchipip, icenet, boom)

--- a/sim/src/main/scala/firesim/Generator.scala
+++ b/sim/src/main/scala/firesim/Generator.scala
@@ -14,7 +14,7 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem.RocketTilesKey
 import freechips.rocketchip.tile.XLen
 
-/*import boom.system.{BoomTilesKey, BoomTestSuites}*/
+import boom.system.{BoomTilesKey, BoomTestSuites}
 
 case class FireSimGeneratorArgs(
   midasFlowKind: String = "midas", // "midas", "strober", "replay"
@@ -61,9 +61,9 @@ trait HasFireSimGeneratorUtilities extends HasGeneratorUtilities with HasTestSui
     implicit val valName = ValName(targetNames.topModuleClass)
     targetNames.topModuleClass match {
       case "FireSim"  => LazyModule(new FireSim()(params)).module
-//      case "FireBoom" => LazyModule(new FireBoom()(params)).module
+      case "FireBoom" => LazyModule(new FireBoom()(params)).module
       case "FireSimNoNIC"  => LazyModule(new FireSimNoNIC()(params)).module
-//      case "FireBoomNoNIC" => LazyModule(new FireBoomNoNIC()(params)).module
+      case "FireBoomNoNIC" => LazyModule(new FireBoomNoNIC()(params)).module
     }
   }
 
@@ -163,11 +163,11 @@ trait HasTestSuites {
 
   def addTestSuites(params: Parameters) {
     val coreParams =
-//      if (params(RocketTilesKey).nonEmpty) {
+      if (params(RocketTilesKey).nonEmpty) {
         params(RocketTilesKey).head.core
-//      } else {
-//        params(BoomTilesKey).head.core
-//      }
+      } else {
+        params(BoomTilesKey).head.core
+      }
     val xlen = params(XLen)
     val vm = coreParams.useVM
     val env = if (vm) List("p","v") else List("p")
@@ -186,8 +186,8 @@ trait HasTestSuites {
     if (coreParams.useAtomics)    TestGeneration.addSuites(env.map(if (xlen == 64) rv64ua else rv32ua))
     if (coreParams.useCompressed) TestGeneration.addSuites(env.map(if (xlen == 64) rv64uc else rv32uc))
     val (rvi, rvu) =
-/*      if (params(BoomTilesKey).nonEmpty) ((if (vm) BoomTestSuites.rv64i else BoomTestSuites.rv64pi), rv64u)
-      else */if (xlen == 64) ((if (vm) rv64i else rv64pi), rv64u)
+      if (params(BoomTilesKey).nonEmpty) ((if (vm) BoomTestSuites.rv64i else BoomTestSuites.rv64pi), rv64u)
+      else if (xlen == 64) ((if (vm) rv64i else rv64pi), rv64u)
       else            ((if (vm) rv32i else rv32pi), rv32u)
 
     TestGeneration.addSuites(rvi.map(_("p")))

--- a/sim/src/main/scala/firesim/TargetConfigs.scala
+++ b/sim/src/main/scala/firesim/TargetConfigs.scala
@@ -5,7 +5,7 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink.BootROMParams
-/*import boom.system.BoomTilesKey*/
+import boom.system.BoomTilesKey
 import testchipip.{WithBlockDevice, BlockDeviceKey, BlockDeviceConfig}
 import sifive.blocks.devices.uart.{PeripheryUARTKey, UARTParams}
 import icenet._
@@ -50,14 +50,13 @@ class WithPerfCounters extends Config((site, here, up) => {
   ))
 })
 
-/*class BoomWithLargeTLBs extends Config((site, here, up) => {
+class BoomWithLargeTLBs extends Config((site, here, up) => {
   case BoomTilesKey => up(BoomTilesKey) map (tile => tile.copy(
     core = tile.core.copy(
       nL2TLBEntries = 1024 // TLB reach = 1024 * 4KB = 4MB
     )
   ))
 })
-*/
 
 /*******************************************************************************
 * Full TARGET_CONFIG configurations. These set parameters of the target being
@@ -100,7 +99,7 @@ class FireSimRocketChipHexaCoreConfig extends Config(new WithNBigCores(6) ++
 class FireSimRocketChipOctaCoreConfig extends Config(new WithNBigCores(8) ++
   new FireSimRocketChipSingleCoreConfig)
 
-/*
+
 class FireSimBoomConfig extends Config(
   new WithBootROM ++
   new WithPeripheryBusFrequency(BigInt(3200000000L)) ++
@@ -111,4 +110,4 @@ class FireSimBoomConfig extends Config(
   new WithBlockDevice ++
   new BoomWithLargeTLBs ++
   // Using a small config because it has 64-bit system bus, and compiles quickly
-  new boom.system.SmallBoomConfig)*/
+  new boom.system.SmallBoomConfig)

--- a/sim/src/main/scala/firesim/Targets.scala
+++ b/sim/src/main/scala/firesim/Targets.scala
@@ -4,7 +4,7 @@ import freechips.rocketchip._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.config.Parameters
-/*import boom.system.{BoomSubsystem, BoomSubsystemModule}*/
+import boom.system.{BoomSubsystem, BoomSubsystemModule}
 import icenet._
 import testchipip._
 import sifive.blocks.devices.uart._
@@ -71,7 +71,7 @@ class FireSimNoNICModuleImp[+L <: FireSimNoNIC](l: L) extends RocketSubsystemMod
     with HasPeripheryBlockDeviceModuleImp
 
 
-/*
+
 class FireBoom(implicit p: Parameters) extends BoomSubsystem
     with CanHaveMisalignedMasterAXI4MemPort
     with HasPeripheryBootROM
@@ -119,4 +119,3 @@ class FireBoomNoNICModuleImp[+L <: FireBoomNoNIC](l: L) extends BoomSubsystemMod
     with HasPeripherySerialModuleImp
     with HasPeripheryUARTModuleImp
     with HasPeripheryBlockDeviceModuleImp
-    */

--- a/target-design/TODO
+++ b/target-design/TODO
@@ -1,4 +1,3 @@
 -have not bumped riscv-tools
--have not fixed boom
 -probably want to bump linux too
 -barstools/mdf are not bumped to master


### PR DESCRIPTION
- restores BOOM support, thanks to @jerryz123 and @pentin-as
- tested on the FPGA, boots linux, ping between nodes
- added pre-built AGFIs, all RC July 2018 AGFIs now public.

Ready for review/merge.