### PR TITLE
Ignore SSH agent forwarding with tmux and screen 

### DIFF
--- a/deploy/ssh-setup.sh
+++ b/deploy/ssh-setup.sh
@@ -14,15 +14,16 @@ _no_agent() {
 }
 
 if _no_agent ; then
-    # Load stored agent connection info.
-    test -r ~/.ssh-agent && \
-        eval "$(<~/.ssh-agent)" >/dev/null
+    {
+        flock -x 3
+        # Load cached agent connection info.
+        source /dev/fd/3
 
-    if _no_agent ; then
-        # Start agent and store agent connection info.
-        (umask 066; ssh-agent > ~/.ssh-agent)
-        eval "$(<~/.ssh-agent)" >/dev/null
-    fi
+        if _no_agent ; then
+            # Start agent and cache agent connection info.
+            eval "$(umask 066 && ssh-agent -s 3>&- | tee /dev/fd/3)" >/dev/null
+        fi
+    } 3<> ~/.ssh-agent
 fi
 
 # if key is available, print success, else add it

--- a/deploy/ssh-setup.sh
+++ b/deploy/ssh-setup.sh
@@ -5,16 +5,20 @@
 
 # adapted from https://stackoverflow.com/a/48509425
 # Ensure agent is running
-ssh-add -l &>/dev/null
-if [ $? -eq 2 ]; then
-    # Could not open a connection to your authentication agent.
 
+_no_agent() {
+    # NOTE: Ignore agent forwarding if running within tmux or screen, as
+    # detaching a session and logging out closes the agent socket.
+    { test -n "${TMUX}${STY}" && test -z "${SSH_AGENT_PID}" ; } ||
+    { ssh-add -l >/dev/null 2>&1 ; test $? -eq 2 ; }
+}
+
+if _no_agent ; then
     # Load stored agent connection info.
     test -r ~/.ssh-agent && \
         eval "$(<~/.ssh-agent)" >/dev/null
 
-    ssh-add -l &>/dev/null
-    if [ $? -eq 2 ]; then
+    if _no_agent ; then
         # Start agent and store agent connection info.
         (umask 066; ssh-agent > ~/.ssh-agent)
         eval "$(<~/.ssh-agent)" >/dev/null


### PR DESCRIPTION
This fixes #70.

Ensure that a local `ssh-agent` instance is always used if running within `tmux` or `screen`.
Previously, a separate instance would not be started when agent forwarding is active.
However, detaching the session and logging out would then close the agent socket, usually causing ongoing manager jobs to fail when attempting to `rsync` results.

The approach for checking whether the communicating agent is local can be fooled if the environment updates `SSH_AUTH_SOCK` without unsetting `SSH_AGENT_PID`.  However, it's fair to say that the user should deal with this alone if s/he concocts such a scenario.  (It is possible through certain kernel interfaces to determine the peer PID at the other endpoint of a Unix socket, but that is overkill.)