### PR TITLE
Add NIC scalatests & change ungenerated run-recipes 

### DIFF
--- a/sim/Makefrag
+++ b/sim/Makefrag
@@ -35,17 +35,6 @@ common_ld_flags := $(TARGET_LD_FLAGS) -lrt
 ####################################
 CONF_NAME ?= runtime.conf
 
-################################################################
-# SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #
-################################################################
-TIMEOUT_CYCLES = 100000000
-SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
-mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
-COMMON_SIM_ARGS ?= $(mem_model_args)
-
-# Arguments used only in MIDAS-level (ML) RTL simulation
-MIDAS_LEVEL_SIM_ARGS ?= +dramsim
-
 ####################################
 # Verilator MIDAS-Level Simulators #
 ####################################

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -61,16 +61,27 @@ conf:
 	$(SBT) $(SBT_FLAGS) \
 	"runMain $(DESIGN_PACKAGE).FireSimRuntimeConfGenerator $(CONF_NAME) $(common_chisel_args)"
 
-################################
-# Verilator/VCS/XSIM execution #
-################################
+################################################################
+# SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #
+################################################################
+TIMEOUT_CYCLES = 100000000
 
 NET_SLOT ?= 0
 NET_LINK_LATENCY ?= 6405
 NET_BW ?= 100
+nic_args = +slotid=$(NET_SLOT) +niclog=niclog +linklatency=$(NET_LINK_LATENCY) +netbw=$(NET_BW) +netburst=8 +nic-loopback
 
-nic_args = +slotid=$(NET_SLOT) +niclog=niclog +linklatency=$(NET_LINK_LATENCY) +netbw=$(NET_BW) +netburst=8
-FPGA_LEVEL_SIM_ARGS ?= $(COMMON_SIM_ARGS) $(nic_args)
+SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
+mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
+COMMON_SIM_ARGS ?= $(mem_model_args) $(nic_args)
+
+# Arguments used only at a particular simulation abstraction
+MIDAS_LEVEL_SIM_ARGS ?= +dramsim +max-cycles=$(TIMEOUT_CYCLES)
+FPGA_LEVEL_SIM_ARGS ?=
+
+################################
+# Verilator/VCS/XSIM execution #
+################################
 
 verilator = $(GENERATED_DIR)/V$(DESIGN)
 verilator_debug = $(GENERATED_DIR)/V$(DESIGN)-debug
@@ -79,19 +90,19 @@ vcs_debug = $(GENERATED_DIR)/$(DESIGN)-debug
 xsim = $(GENERATED_DIR)/$(DESIGN)-$(PLATFORM)
 
 run-verilator: $(verilator)
-	$(verilator) +permissive $(FPGA_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
+	$(verilator) +permissive $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
 
 run-verilator-debug: $(verilator_debug)
-	$(verilator_debug) +permissive $(FPGA_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
+	$(verilator_debug) +permissive $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
 
 run-vcs: $(vcs)
-	$(vcs) +permissive $(FPGA_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
+	$(vcs) +permissive $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
 
 run-vcs-debug: $(vcs_debug)
-	$(vcs_debug) +permissive $(FPGA_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
+	$(vcs_debug) +permissive $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY))
 
 run-xsim: $(xsim)
-	cd $(dir $<) && ./$(notdir $<)  +permissive $(FPGA_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
+	cd $(dir $<) && ./$(notdir $<)  +permissive $(COMMON_SIM_ARGS) $(FPGA_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	+sample=$(notdir $(SIM_BINARY)).sample  +permissive-off $(abspath $(SIM_BINARY))
 
 ############################################
@@ -126,16 +137,16 @@ endif
 # the binary name. These are captured with $($*_ARGS)
 $(OUTPUT_DIR)/%.run: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) +max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	$(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.vpd: $(OUTPUT_DIR)/% $(EMUL)-debug
 	cd $(dir $($(EMUL)_debug)) && \
-	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) max-cycles=$(TIMEOUT_CYCLES) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
 	$(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 

--- a/sim/src/test/scala/firesim/ScalaTestSuite.scala
+++ b/sim/src/test/scala/firesim/ScalaTestSuite.scala
@@ -13,7 +13,6 @@ import freechips.rocketchip.system.DefaultTestSuites._
 
 abstract class FireSimTestSuite(
     val generatorArgs: FireSimGeneratorArgs,
-    simulationArgs: String = "`cat runtime.conf`",
     N: Int = 8
   ) extends firesim.midasexamples.TestSuiteCommon with HasFireSimGeneratorUtilities {
   import scala.concurrent.duration._
@@ -31,7 +30,9 @@ abstract class FireSimTestSuite(
   override lazy val platform = hostParams(midas.Platform)
 
   def invokeMlSimulator(backend: String, name: String, debug: Boolean) = {
-    make(s"${outDir.getAbsolutePath}/${name}.%s".format(if (debug) "vpd" else "out"), s"EMUL=${backend}")
+    make(s"${outDir.getAbsolutePath}/${name}.%s".format(if (debug) "vpd" else "out"),
+         s"EMUL=${backend}"
+         )
   }
 
   def runTest(backend: String, name: String, debug: Boolean) = {
@@ -55,7 +56,7 @@ abstract class FireSimTestSuite(
     behavior of s"${suite.makeTargetName} running on $backend"
     if (isCmdAvailable(backend)) {
       val postfix = suite match {
-        case _: BenchmarkTestSuite | _: BlockdevTestSuite => ".riscv"
+        case _: BenchmarkTestSuite | _: BlockdevTestSuite | _: NICTestSuite => ".riscv"
         case _ => ""
       }
       val results = suite.names.toSeq sliding (N, N) map { t => 
@@ -99,3 +100,8 @@ class RocketF1Tests extends FireSimTestSuite(
 
 class BoomF1Tests extends FireSimTestSuite(
   FireSimGeneratorArgs("FireBoomNoNIC", "FireSimBoomConfig", "FireSimConfig"))
+
+class RocketNICF1Tests extends FireSimTestSuite(
+  FireSimGeneratorArgs("FireSim", "FireSimRocketChipConfig", "FireSimConfig")) {
+  runSuite("verilator")(NICLoopbackTests)
+}


### PR DESCRIPTION
Two changes, does not affect generated RTL. 

Run arguments:
- By default, for all run-recipes i add the NIC args. They'll just get dropped by targets without a NIC. 
- Add +nic-loopback to the default nic-argument list. 
- Updated some to reflect a distinction between FPGA-level and MIDAS-level simulations

NIC:
- Add NIC-based target to the scalatests
- Runs the loopback test