### PR TITLE
Removing Macros + Some endpoints support multiple instantiations of themselves

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,4 @@
+- add remaining frees
+- endpoints that parse their own args need to know which # of that endpoint they are
+- add guards, instantiate 4 copies of stuff
+- fix tracerv widget (and other widgets)

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
 - endpoints that parse their own args need to know which # of that endpoint they are
  -serial endpoint multiple copies support (e.g. which program to load)
 - add guards, instantiate 4 tcopies of stuff
+- UART needs to connect to a pty to support multiple uarts?

--- a/TODO
+++ b/TODO
@@ -1,4 +1,2 @@
-- endpoints that parse their own args need to know which # of that endpoint they are
  -serial endpoint multiple copies support (e.g. which program to load)
-- add guards, instantiate 4 tcopies of stuff
 - UART needs to connect to a pty to support multiple uarts?

--- a/TODO
+++ b/TODO
@@ -1,4 +1,2 @@
-- add remaining frees
 - endpoints that parse their own args need to know which # of that endpoint they are
-- add guards, instantiate 4 copies of stuff
-- fix tracerv widget (and other widgets)
+- add guards, instantiate 4 tcopies of stuff

--- a/TODO
+++ b/TODO
@@ -1,2 +1,3 @@
 - endpoints that parse their own args need to know which # of that endpoint they are
+ -serial endpoint multiple copies support (e.g. which program to load)
 - add guards, instantiate 4 tcopies of stuff

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -83,13 +83,13 @@ class RuntimeHWConfig:
         pre-built runtime config? It kinda contains a mix of pre-built and
         runtime parameters currently. """
 
-        tracefile = "+tracefile=TRACEFILE" if trace_enable else ""
+        tracefile = "+tracefile0=TRACEFILE" if trace_enable else ""
 
         # this monstrosity boots the simulator, inside screen, inside script
         # the sed is in there to get rid of newlines in runtime confs
         driver = self.get_local_driver_binaryname()
         runtimeconf = self.get_local_runtimeconf_binaryname()
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start={trace_start} +trace-end={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval=-1 +profile-interval={profile_interval} +zero-out-dram +shmemportname0={shmemportname} +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start0={trace_start} +trace-end0={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval=-1 +profile-interval={profile_interval} +zero-out-dram +shmemportname0={shmemportname} +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
                 slotid=slotid, driver=driver, runtimeconf=runtimeconf,
                 macaddr=macaddr, blkdev=blkdev, linklatency=linklatency,
                 netbw=netbw, profile_interval=profile_interval,

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -89,7 +89,7 @@ class RuntimeHWConfig:
         # the sed is in there to get rid of newlines in runtime confs
         driver = self.get_local_driver_binaryname()
         runtimeconf = self.get_local_runtimeconf_binaryname()
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr={macaddr} +blkdev={blkdev} +slotid={slotid} +niclog=niclog {tracefile} +trace-start={trace_start} +trace-end={trace_end} +linklatency={linklatency} +netbw={netbw} +profile-interval=-1 +profile-interval={profile_interval} +zero-out-dram +shmemportname={shmemportname} +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog=niclog {tracefile} +trace-start={trace_start} +trace-end={trace_end} +linklatency={linklatency} +netbw={netbw} +profile-interval=-1 +profile-interval={profile_interval} +zero-out-dram +shmemportname={shmemportname} +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
                 slotid=slotid, driver=driver, runtimeconf=runtimeconf,
                 macaddr=macaddr, blkdev=blkdev, linklatency=linklatency,
                 netbw=netbw, profile_interval=profile_interval,

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -89,7 +89,7 @@ class RuntimeHWConfig:
         # the sed is in there to get rid of newlines in runtime confs
         driver = self.get_local_driver_binaryname()
         runtimeconf = self.get_local_runtimeconf_binaryname()
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog=niclog {tracefile} +trace-start={trace_start} +trace-end={trace_end} +linklatency={linklatency} +netbw={netbw} +profile-interval=-1 +profile-interval={profile_interval} +zero-out-dram +shmemportname={shmemportname} +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start={trace_start} +trace-end={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval=-1 +profile-interval={profile_interval} +zero-out-dram +shmemportname0={shmemportname} +permissive-off {bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
                 slotid=slotid, driver=driver, runtimeconf=runtimeconf,
                 macaddr=macaddr, blkdev=blkdev, linklatency=linklatency,
                 netbw=netbw, profile_interval=profile_interval,

--- a/sim/runtest.sh
+++ b/sim/runtest.sh
@@ -6,4 +6,4 @@ RUNBIN=../target-design/firechip/tests/blkdev.riscv
 # generate a fresh test.stuff disk, all zeroed
 dd if=/dev/zero bs=1M count=128 of=test.disk
 
-./generated-src/f1/FireSimRocketChipConfig/FireSim +mm_readLatency=10 +mm_writeLatency=10 +mm_readMaxReqs=4 +mm_writeMaxReqs=4 +blkdev=test.disk $RUNBIN
+./generated-src/f1/FireSimRocketChipConfig/FireSim +mm_readLatency=10 +mm_writeLatency=10 +mm_readMaxReqs=4 +mm_writeMaxReqs=4 +blkdev0=test.disk $RUNBIN

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -27,6 +27,9 @@ blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args, uint3
     long size;
     long mem_filesize = 0;
 
+
+    // construct arg parsing strings here. We basically append the endpoint
+    // number to each of these base strings, to get args like +blkdev0 etc.
     std::string num_equals = std::to_string(blkdevno) + std::string("=");
 
     std::string blkdev_arg =         std::string("+blkdev") + num_equals;

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -3,6 +3,7 @@
 #include "blockdev.h"
 #include <stdio.h>
 #include <string.h>
+#include <string>
 
 /* Block Device Endpoint Driver
  *
@@ -20,25 +21,32 @@
  * Setup software driver state:
  * Check if we have been given a file to use as a disk, record size and
  * number of sectors to pass to widget */
-blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args, uint32_t num_trackers, uint32_t latency_bits, BLOCKDEVWIDGET_struct * mmio_addrs): endpoint_t(sim) {
+blockdev_t::blockdev_t(simif_t* sim, const std::vector<std::string>& args, uint32_t num_trackers, uint32_t latency_bits, BLOCKDEVWIDGET_struct * mmio_addrs, int blkdevno): endpoint_t(sim) {
     this->mmio_addrs = mmio_addrs;
     _ntags = num_trackers;
     long size;
     long mem_filesize = 0;
 
+    std::string num_equals = std::to_string(blkdevno) + std::string("=");
+
+    std::string blkdev_arg =         std::string("+blkdev") + num_equals;
+    std::string blkdevinmem_arg =    std::string("+blkdev-in-mem") + num_equals;
+    std::string blkdevwlatency_arg = std::string("+blkdev-wlatency") + num_equals;
+    std::string blkdevrlatency_arg = std::string("+blkdev-rlatency") + num_equals;
+
     for (auto &arg: args) {
-        if (arg.find("+blkdev=") == 0) {
-            filename = const_cast<char*>(arg.c_str()) + 8;
+        if (arg.find(blkdev_arg) == 0) {
+            filename = const_cast<char*>(arg.c_str()) + blkdev_arg.length();
         }
         // Spoofs a file with fmemopen. Useful for testing
-        if (arg.find("+blkdev-in-mem=") == 0) {
-            mem_filesize = atoi(const_cast<char*>(arg.c_str()) + 15);
+        if (arg.find(blkdevinmem_arg) == 0) {
+            mem_filesize = atoi(const_cast<char*>(arg.c_str()) + blkdevinmem_arg.length());
         }
-        if (arg.find("+blkdev-wlatency=") == 0) {
-            write_latency = atoi(const_cast<char*>(arg.c_str()) + 17);
+        if (arg.find(blkdevwlatency_arg) == 0) {
+            write_latency = atoi(const_cast<char*>(arg.c_str()) + blkdevwlatency_arg.length());
         }
-        if (arg.find("+blkdev-rlatency=") == 0) {
-            read_latency = atoi(const_cast<char*>(arg.c_str()) + 17);
+        if (arg.find(blkdevrlatency_arg) == 0) {
+            read_latency = atoi(const_cast<char*>(arg.c_str()) + blkdevrlatency_arg.length());
         }
     }
 

--- a/sim/src/main/cc/endpoints/blockdev.cc
+++ b/sim/src/main/cc/endpoints/blockdev.cc
@@ -1,3 +1,5 @@
+#ifdef BLOCKDEVWIDGET_struct_guard
+
 #include "blockdev.h"
 #include <stdio.h>
 #include <string.h>
@@ -94,13 +96,11 @@ blockdev_t::~blockdev_t() {
  * Here, we set control regs e.g. for # sectors, allowed request length
  * at boot */
 void blockdev_t::init() {
-#ifdef BLOCKDEVWIDGET_struct_guard
     // setup blk dev widget
     write(this->mmio_addrs->bdev_nsectors, nsectors());
     write(this->mmio_addrs->bdev_max_req_len, max_request_length());
     write(this->mmio_addrs->read_latency, read_latency);
     write(this->mmio_addrs->write_latency, write_latency);
-#endif // #ifdef BLOCKDEVWIDGET_struct_guard
 }
 
 /* Take a read request, get data from the disk file, and fill the beats
@@ -245,7 +245,6 @@ void blockdev_t::handle_data(struct blkdev_data &data) {
 
 /* Read all pending request data from the widget */
 void blockdev_t::recv() {
-#ifdef BLOCKDEVWIDGET_struct_guard
     /* Read all pending requests from the widget */
     while (read(this->mmio_addrs->bdev_req_valid)) {
         /* Take a request from the FPGA and put it in SW processing queues */
@@ -275,15 +274,12 @@ void blockdev_t::recv() {
         fprintf(stderr, "[disk] got data. data %llx, tag %x\n", data.data, data.tag);
 #endif
     }
-#endif // #ifdef BLOCKDEVWIDGET_struct_guard
 }
 
 /* This dumps as much read_response and write_ack data onto the widget as possible
  * In the event the widget buffers fill up; set resp_data_pending, indicating that
  * we must try again on the next tick() invocation */
 void blockdev_t::send() {
-#ifdef BLOCKDEVWIDGET_struct_guard
-
     /* Return as many write acknowledgements as the blockdev widget can accept */
     while (!write_acks.empty() && read(this->mmio_addrs->bdev_wack_ready)) {
         uint32_t tag = write_acks.front();
@@ -311,15 +307,10 @@ void blockdev_t::send() {
 
     /* Mark if finished */
     resp_data_pending = !read_responses.empty() || !write_acks.empty();
-#endif // #ifdef BLOCKDEVWIDGET_struct_guard
 }
 
 bool blockdev_t::idle() {
-#ifdef BLOCKDEVWIDGET_struct_guard
     return !resp_data_pending && !read(this->mmio_addrs->bdev_reqs_pending);
-#else
-    return true;
-#endif
 }
 
 /* This method is called to service functional requests made by the widget.
@@ -371,3 +362,4 @@ void blockdev_t::tick() {
     this->send();
 }
 
+#endif // BLOCKDEVWIDGET_struct_guard

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -34,7 +34,7 @@ struct blkdev_write_tracker {
 class blockdev_t: public endpoint_t
 {
     public:
-        blockdev_t(simif_t* sim, const std::vector<std::string>& args);
+        blockdev_t(simif_t* sim, const std::vector<std::string>& args, uint32_t num_trackers, uint32_t latency_bits, BLOCKDEVWIDGET_struct * mmio_addrs);
         ~blockdev_t();
 
         uint32_t nsectors(void) { return _nsectors; }
@@ -48,6 +48,7 @@ class blockdev_t: public endpoint_t
         virtual int exit_code() { return 0; }
 
     private:
+        BLOCKDEVWIDGET_struct * mmio_addrs;
         bool a_req_valid;
         bool a_req_ready;
         bool a_data_valid;

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -35,7 +35,7 @@ struct blkdev_write_tracker {
 class blockdev_t: public endpoint_t
 {
     public:
-        blockdev_t(simif_t* sim, const std::vector<std::string>& args, uint32_t num_trackers, uint32_t latency_bits, BLOCKDEVWIDGET_struct * mmio_addrs);
+        blockdev_t(simif_t* sim, const std::vector<std::string>& args, uint32_t num_trackers, uint32_t latency_bits, BLOCKDEVWIDGET_struct * mmio_addrs, int blkdevno);
         ~blockdev_t();
 
         uint32_t nsectors(void) { return _nsectors; }

--- a/sim/src/main/cc/endpoints/blockdev.h
+++ b/sim/src/main/cc/endpoints/blockdev.h
@@ -31,6 +31,7 @@ struct blkdev_write_tracker {
     uint64_t data[MAX_REQ_LEN * SECTOR_BEATS];
 };
 
+#ifdef BLOCKDEVWIDGET_struct_guard
 class blockdev_t: public endpoint_t
 {
     public:
@@ -82,5 +83,6 @@ class blockdev_t: public endpoint_t
         uint32_t read_latency = 4096;
         uint32_t write_latency = 4096;
 };
+#endif // BLOCKDEVWIDGET_struct_guard
 
 #endif // __BLOCKDEV_H

--- a/sim/src/main/cc/endpoints/serial.cc
+++ b/sim/src/main/cc/endpoints/serial.cc
@@ -1,3 +1,5 @@
+#ifdef SERIALWIDGET_struct_guard
+
 #include <assert.h>
 #include "serial.h"
 
@@ -114,3 +116,5 @@ void serial_t::tick() {
         go();
     }
 }
+
+#endif // SERIALWIDGET_struct_guard

--- a/sim/src/main/cc/endpoints/serial.cc
+++ b/sim/src/main/cc/endpoints/serial.cc
@@ -7,8 +7,10 @@
 #define DEFAULT_STEPSIZE (2004765L)
 #endif
 
-serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args):
+serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args, SERIALWIDGET_struct * mmio_addrs):
         endpoint_t(sim), sim(sim), fesvr(args) {
+
+    this->mmio_addrs = mmio_addrs;
 
     step_size = DEFAULT_STEPSIZE;
     for (auto &arg: args) {
@@ -18,26 +20,30 @@ serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args):
     }
 }
 
+serial_t::~serial_t() {
+    free(this->mmio_addrs);
+}
+
 void serial_t::init() {
-    write(SERIALWIDGET_0(step_size), step_size);
+    write(this->mmio_addrs->step_size, step_size);
     go();
 }
 
 void serial_t::go() {
-    write(SERIALWIDGET_0(start), 1);
+    write(this->mmio_addrs->start, 1);
 }
 
 void serial_t::send() {
-    while(fesvr.data_available() && read(SERIALWIDGET_0(in_ready))) {
-        write(SERIALWIDGET_0(in_bits), fesvr.recv_word());
-        write(SERIALWIDGET_0(in_valid), 1);
+    while(fesvr.data_available() && read(this->mmio_addrs->in_ready)) {
+        write(this->mmio_addrs->in_bits, fesvr.recv_word());
+        write(this->mmio_addrs->in_valid, 1);
     }
 }
 
 void serial_t::recv() {
-    while(read(SERIALWIDGET_0(out_valid))) {
-        fesvr.send_word(read(SERIALWIDGET_0(out_bits)));
-        write(SERIALWIDGET_0(out_ready), 1);
+    while(read(this->mmio_addrs->out_valid)) {
+        fesvr.send_word(read(this->mmio_addrs->out_bits));
+        write(this->mmio_addrs->out_ready, 1);
     }
 }
 
@@ -92,7 +98,7 @@ void serial_t::serial_bypass_via_loadmem() {
 
 void serial_t::tick() {
     // First, check to see step_size tokens have been enqueued
-    if (!read(SERIALWIDGET_0(done))) return;
+    if (!read(this->mmio_addrs->done)) return;
     // Collect all the responses from the target
     this->recv();
     // Punt to FESVR

--- a/sim/src/main/cc/endpoints/serial.h
+++ b/sim/src/main/cc/endpoints/serial.h
@@ -20,6 +20,7 @@ struct serial_data_t {
     } out;
 };
 
+#ifdef SERIALWIDGET_struct_guard
 class serial_t: public endpoint_t
 {
     public:
@@ -47,5 +48,6 @@ class serial_t: public endpoint_t
         void handle_loadmem_write(fesvr_loadmem_t loadmem);
         void serial_bypass_via_loadmem();
 };
+#endif // SERIALWIDGET_struct_guard
 
 #endif // __SERIAL_H

--- a/sim/src/main/cc/endpoints/serial.h
+++ b/sim/src/main/cc/endpoints/serial.h
@@ -23,13 +23,15 @@ struct serial_data_t {
 class serial_t: public endpoint_t
 {
     public:
-        serial_t(simif_t* sim, const std::vector<std::string>& args);
+        serial_t(simif_t* sim, const std::vector<std::string>& args, SERIALWIDGET_struct * mmio_addrs);
+        ~serial_t();
         virtual void init();
         virtual void tick();
         virtual bool terminate(){ return fesvr.done(); }
         virtual int exit_code(){ return fesvr.exit_code(); }
 
     private:
+        SERIALWIDGET_struct * mmio_addrs;
         simif_t* sim;
         firesim_fesvr_t fesvr;
         // Number of target cycles between fesvr interactions

--- a/sim/src/main/cc/endpoints/simplenic.cc
+++ b/sim/src/main/cc/endpoints/simplenic.cc
@@ -41,7 +41,6 @@ static void simplify_frac(int n, int d, int *nn, int *dd)
 simplenic_t::simplenic_t(simif_t *sim, std::vector<std::string> &args,
         SIMPLENICWIDGET_struct *mmio_addrs): endpoint_t(sim)
 {
-#ifdef SIMPLENICWIDGET_0
     this->mmio_addrs = mmio_addrs;
 
     const char *niclogfile = NULL;

--- a/sim/src/main/cc/endpoints/simplenic.cc
+++ b/sim/src/main/cc/endpoints/simplenic.cc
@@ -169,6 +169,7 @@ simplenic_t::~simplenic_t() {
             munmap(pcis_write_bufs[j], BUFBYTES+EXTRABYTES);
         }
     }
+    free(this->mmio_addrs);
 }
 
 #define ceil_div(n, d) (((n) - 1) / (d) + 1)

--- a/sim/src/main/cc/endpoints/simplenic.cc
+++ b/sim/src/main/cc/endpoints/simplenic.cc
@@ -1,4 +1,4 @@
-#ifdef SIMPLENICWIDGET_struct
+#ifdef SIMPLENICWIDGET_struct_guard
 
 #include "simplenic.h"
 
@@ -61,9 +61,9 @@ simplenic_t::simplenic_t(
     simplify_frac(netbw, MAX_BANDWIDTH, &rlimit_inc, &rlimit_period);
     rlimit_size = netburst;
 
-    printf("using link latency: %d cycles\n", linklatency);
-    printf("using netbw: %d\n", netbw);
-    printf("using netburst: %d\n", netburst);
+    printf("NIC using link latency: %d cycles\n", linklatency);
+    printf("NIC using netbw: %d\n", netbw);
+    printf("NIC using netburst: %d\n", netburst);
 
     this->loopback = loopback;
     this->niclog = NULL;
@@ -297,5 +297,5 @@ void simplenic_t::tick() {
     }
 }
 
-#endif // #ifdef SIMPLENICWIDGET_struct
+#endif // #ifdef SIMPLENICWIDGET_struct_guard
 

--- a/sim/src/main/cc/endpoints/simplenic.h
+++ b/sim/src/main/cc/endpoints/simplenic.h
@@ -12,7 +12,7 @@
 class simplenic_t: public endpoint_t
 {
     public:
-        simplenic_t(simif_t* sim, std::vector<std::string> &args, SIMPLENICWIDGET_struct *addrs);
+        simplenic_t(simif_t* sim, std::vector<std::string> &args, SIMPLENICWIDGET_struct *addrs, int simplenicno);
         ~simplenic_t();
 
         virtual void init();

--- a/sim/src/main/cc/endpoints/simplenic.h
+++ b/sim/src/main/cc/endpoints/simplenic.h
@@ -1,3 +1,4 @@
+
 #ifndef __SIMPLENIC_H
 #define __SIMPLENIC_H
 
@@ -12,10 +13,11 @@
 // IMPORTANT: this must be a multiple of 7
 //#define LINKLATENCY 6405
 
+#ifdef SIMPLENICWIDGET_struct
 class simplenic_t: public endpoint_t
 {
     public:
-        simplenic_t(simif_t* sim, char * slotid, uint64_t mac_little_end, int netbw, int netburst, int linklatency, char * niclogfile, bool loopback, char *shmemportname);
+        simplenic_t(simif_t* sim, char * slotid, uint64_t mac_little_end, int netbw, int netburst, int linklatency, char * niclogfile, bool loopback, char *shmemportname, SIMPLENICWIDGET_struct *addrs);
         ~simplenic_t();
 
         virtual void init();
@@ -31,7 +33,9 @@ class simplenic_t: public endpoint_t
         int rlimit_inc, rlimit_period, rlimit_size;
         int LINKLATENCY;
         FILE * niclog;
-	bool loopback;
+        SIMPLENICWIDGET_struct *mmio_addrs;
+        bool loopback;
 };
+#endif // SIMPLENICWIDGET_struct
 
 #endif // __SIMPLENIC_H

--- a/sim/src/main/cc/endpoints/simplenic.h
+++ b/sim/src/main/cc/endpoints/simplenic.h
@@ -13,7 +13,7 @@
 // IMPORTANT: this must be a multiple of 7
 //#define LINKLATENCY 6405
 
-#ifdef SIMPLENICWIDGET_struct
+#ifdef SIMPLENICWIDGET_struct_guard
 class simplenic_t: public endpoint_t
 {
     public:
@@ -36,6 +36,6 @@ class simplenic_t: public endpoint_t
         SIMPLENICWIDGET_struct *mmio_addrs;
         bool loopback;
 };
-#endif // SIMPLENICWIDGET_struct
+#endif // SIMPLENICWIDGET_struct_guard
 
 #endif // __SIMPLENIC_H

--- a/sim/src/main/cc/endpoints/tracerv.cc
+++ b/sim/src/main/cc/endpoints/tracerv.cc
@@ -1,3 +1,5 @@
+#ifdef TRACERVWIDGET_struct_guard
+
 #include "tracerv.h"
 
 #include <stdio.h>
@@ -25,12 +27,9 @@
 #define TOTAL_WID (VALID_WID + IADDR_WID + INSN_WID + PRIV_WID + EXCP_WID + INT_WID + CAUSE_WID + TVAL_WID)
 #define TRACERV_ADDR 0x100000000L
 
-
-
 tracerv_t::tracerv_t(
     simif_t *sim, std::vector<std::string> &args) : endpoint_t(sim)
 {
-#ifdef TRACERVWIDGET_0
     const char *tracefilename = NULL;
 
     this->tracefile = NULL;
@@ -58,23 +57,18 @@ tracerv_t::tracerv_t(
             abort();
         }
     }
-#endif // #ifdef TRACERVWIDGET_0
 }
 
 tracerv_t::~tracerv_t() {
-#ifdef TRACERVWIDGET_0
     if (this->tracefile) {
         fclose(this->tracefile);
     }
-#endif // #ifdef TRACERVWIDGET_0
 }
 
 void tracerv_t::init() {
-#ifdef TRACERVWIDGET_0
     cur_cycle = 0;
 
     printf("Collect trace from %lu to %lu cycles\n", start_cycle, end_cycle);
-#endif // #ifdef TRACERVWIDGET_0
 }
 
 // defining this stores as human readable hex (e.g. open in VIM)
@@ -82,7 +76,6 @@ void tracerv_t::init() {
 #define HUMAN_READABLE
 
 void tracerv_t::tick() {
-#ifdef TRACERVWIDGET_0
     uint64_t outfull = read(TRACERVWIDGET_0(tracequeuefull));
 
     #define QUEUE_DEPTH 6144
@@ -119,6 +112,6 @@ void tracerv_t::tick() {
         }
         cur_cycle += QUEUE_DEPTH;
     }
-
-#endif // ifdef TRACERVWIDGET_0
 }
+
+#endif // TRACERVWIDGET_struct_guard

--- a/sim/src/main/cc/endpoints/tracerv.cc
+++ b/sim/src/main/cc/endpoints/tracerv.cc
@@ -28,7 +28,7 @@
 #define TRACERV_ADDR 0x100000000L
 
 tracerv_t::tracerv_t(
-    simif_t *sim, std::vector<std::string> &args, TRACERVWIDGET_struct * mmio_addrs) : endpoint_t(sim)
+    simif_t *sim, std::vector<std::string> &args, TRACERVWIDGET_struct * mmio_addrs, int tracerno) : endpoint_t(sim)
 {
     this->mmio_addrs = mmio_addrs;
     const char *tracefilename = NULL;
@@ -37,16 +37,21 @@ tracerv_t::tracerv_t(
     this->start_cycle = 0;
     this->end_cycle = ULONG_MAX;
 
+    std::string num_equals = std::to_string(tracerno) + std::string("=");
+    std::string tracefile_arg =         std::string("+tracefile") + num_equals;
+    std::string tracestart_arg =         std::string("+trace-start") + num_equals;
+    std::string traceend_arg =         std::string("+trace-end") + num_equals;
+
     for (auto &arg: args) {
-        if (arg.find("+tracefile=") == 0) {
-            tracefilename = const_cast<char*>(arg.c_str()) + 11;
+        if (arg.find(tracefile_arg) == 0) {
+            tracefilename = const_cast<char*>(arg.c_str()) + tracefile_arg.length();
         }
-        if (arg.find("+trace-start=") == 0) {
-            char *str = const_cast<char*>(arg.c_str()) + 13;
+        if (arg.find(tracestart_arg) == 0) {
+            char *str = const_cast<char*>(arg.c_str()) + tracestart_arg.length();
             this->start_cycle = atol(str);
         }
-        if (arg.find("+trace-end=") == 0) {
-            char *str = const_cast<char*>(arg.c_str()) + 11;
+        if (arg.find(traceend_arg) == 0) {
+            char *str = const_cast<char*>(arg.c_str()) + traceend_arg.length();
             this->end_cycle = atol(str);
         }
     }

--- a/sim/src/main/cc/endpoints/tracerv.cc
+++ b/sim/src/main/cc/endpoints/tracerv.cc
@@ -64,6 +64,7 @@ tracerv_t::~tracerv_t() {
     if (this->tracefile) {
         fclose(this->tracefile);
     }
+    free(this->mmio_addrs);
 }
 
 void tracerv_t::init() {

--- a/sim/src/main/cc/endpoints/tracerv.cc
+++ b/sim/src/main/cc/endpoints/tracerv.cc
@@ -28,8 +28,9 @@
 #define TRACERV_ADDR 0x100000000L
 
 tracerv_t::tracerv_t(
-    simif_t *sim, std::vector<std::string> &args) : endpoint_t(sim)
+    simif_t *sim, std::vector<std::string> &args, TRACERVWIDGET_struct * mmio_addrs) : endpoint_t(sim)
 {
+    this->mmio_addrs = mmio_addrs;
     const char *tracefilename = NULL;
 
     this->tracefile = NULL;
@@ -76,7 +77,7 @@ void tracerv_t::init() {
 #define HUMAN_READABLE
 
 void tracerv_t::tick() {
-    uint64_t outfull = read(TRACERVWIDGET_0(tracequeuefull));
+    uint64_t outfull = read(this->mmio_addrs->tracequeuefull);
 
     #define QUEUE_DEPTH 6144
     

--- a/sim/src/main/cc/endpoints/tracerv.h
+++ b/sim/src/main/cc/endpoints/tracerv.h
@@ -4,6 +4,7 @@
 #include "endpoints/endpoint.h"
 #include <vector>
 
+#ifdef TRACERVWIDGET_struct_guard
 class tracerv_t: public endpoint_t
 {
     public:
@@ -12,13 +13,14 @@ class tracerv_t: public endpoint_t
 
         virtual void init();
         virtual void tick();
-	virtual bool terminate() { return false; }
-	virtual int exit_code() { return 0; }
+        virtual bool terminate() { return false; }
+        virtual int exit_code() { return 0; }
 
     private:
         simif_t* sim;
         FILE * tracefile;
-	uint64_t start_cycle, end_cycle, cur_cycle;
+        uint64_t start_cycle, end_cycle, cur_cycle;
 };
+#endif // TRACERVWIDGET_struct_guard
 
 #endif // __TRACERV_H

--- a/sim/src/main/cc/endpoints/tracerv.h
+++ b/sim/src/main/cc/endpoints/tracerv.h
@@ -8,7 +8,7 @@
 class tracerv_t: public endpoint_t
 {
     public:
-        tracerv_t(simif_t *sim, std::vector<std::string> &args);
+        tracerv_t(simif_t *sim, std::vector<std::string> &args, TRACERVWIDGET_struct * mmio_addrs);
         ~tracerv_t();
 
         virtual void init();
@@ -17,6 +17,7 @@ class tracerv_t: public endpoint_t
         virtual int exit_code() { return 0; }
 
     private:
+        TRACERVWIDGET_struct * mmio_addrs;
         simif_t* sim;
         FILE * tracefile;
         uint64_t start_cycle, end_cycle, cur_cycle;

--- a/sim/src/main/cc/endpoints/tracerv.h
+++ b/sim/src/main/cc/endpoints/tracerv.h
@@ -8,7 +8,7 @@
 class tracerv_t: public endpoint_t
 {
     public:
-        tracerv_t(simif_t *sim, std::vector<std::string> &args, TRACERVWIDGET_struct * mmio_addrs);
+        tracerv_t(simif_t *sim, std::vector<std::string> &args, TRACERVWIDGET_struct * mmio_addrs, int tracervno);
         ~tracerv_t();
 
         virtual void init();

--- a/sim/src/main/cc/endpoints/uart.cc
+++ b/sim/src/main/cc/endpoints/uart.cc
@@ -1,3 +1,5 @@
+#ifdef UARTWIDGET_struct_guard
+
 #include "uart.h"
 #ifndef _WIN32
 #include <unistd.h>
@@ -94,3 +96,5 @@ void uart_t::tick() {
         data.in.valid = false;
     } while(data.in.fire() || data.out.fire());
 }
+
+#endif // UARTWIDGET_struct_guard

--- a/sim/src/main/cc/endpoints/uart.h
+++ b/sim/src/main/cc/endpoints/uart.h
@@ -7,7 +7,8 @@
 class uart_t: public endpoint_t
 {
     public:
-        uart_t(simif_t* sim);
+        uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs);
+        ~uart_t();
         void send();
         void recv();
         virtual void init() {};
@@ -16,6 +17,7 @@ class uart_t: public endpoint_t
         virtual int exit_code() { return 0; }
 
     private:
+        UARTWIDGET_struct * mmio_addrs;
         serial_data_t<char> data;
 };
 

--- a/sim/src/main/cc/endpoints/uart.h
+++ b/sim/src/main/cc/endpoints/uart.h
@@ -4,6 +4,7 @@
 #include "serial.h"
 #include <signal.h>
 
+#ifdef UARTWIDGET_struct_guard
 class uart_t: public endpoint_t
 {
     public:
@@ -20,5 +21,6 @@ class uart_t: public endpoint_t
         UARTWIDGET_struct * mmio_addrs;
         serial_data_t<char> data;
 };
+#endif // UARTWIDGET_struct_guard
 
 #endif // __UART_H

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -67,7 +67,8 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 #endif
 
 #ifdef TRACERVWIDGET_struct_guard
-    add_endpoint(new tracerv_t(this, args));
+    TRACERVWIDGET_0_substruct_create;
+    add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_0_substruct));
 #endif
 
     // add more endpoints here

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -65,6 +65,14 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
     BLOCKDEVWIDGET_1_substruct_create;
     add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_1_num_trackers, BLOCKDEVWIDGET_1_latency_bits, BLOCKDEVWIDGET_1_substruct, 1));
     #endif
+    #ifdef BLOCKDEVWIDGET_2_PRESENT
+    BLOCKDEVWIDGET_2_substruct_create;
+    add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_2_num_trackers, BLOCKDEVWIDGET_2_latency_bits, BLOCKDEVWIDGET_2_substruct, 2));
+    #endif
+    #ifdef BLOCKDEVWIDGET_3_PRESENT
+    BLOCKDEVWIDGET_3_substruct_create;
+    add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_3_num_trackers, BLOCKDEVWIDGET_3_latency_bits, BLOCKDEVWIDGET_3_substruct, 3));
+    #endif
 #endif
 
 #ifdef SIMPLENICWIDGET_struct_guard

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -77,7 +77,7 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
 #ifdef SIMPLENICWIDGET_struct_guard
     SIMPLENICWIDGET_0_substruct_create;
-    add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_0_substruct));
+    add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_0_substruct, 0));
 #endif
 
 #ifdef TRACERVWIDGET_struct_guard

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -119,9 +119,9 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
     add_endpoint(new blockdev_t(this, args));
 
-#ifdef SIMPLENICWIDGET_struct
+#ifdef SIMPLENICWIDGET_struct_guard
     SIMPLENICWIDGET_0_substruct_create;
-    add_endpoint(new simplenic_t(this, slotid, mac_little_end, netbw, netburst, linklatency, niclogfile, nic_loopback, shmemportname, &SIMPLENICWIDGET_0_substruct));
+    add_endpoint(new simplenic_t(this, slotid, mac_little_end, netbw, netburst, linklatency, niclogfile, nic_loopback, shmemportname, SIMPLENICWIDGET_0_substruct));
 #endif
 
     add_endpoint(new tracerv_t(this, tracefile, trace_start, trace_end));

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -66,7 +66,10 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
     add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_0_substruct));
 #endif
 
+#ifdef TRACERVWIDGET_struct_guard
     add_endpoint(new tracerv_t(this, args));
+#endif
+
     // add more endpoints here
 
     // Add functions you'd like to periodically invoke on a paused simulator here.

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -97,8 +97,15 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
         }
     }
 
-    add_endpoint(new uart_t(this));
-    add_endpoint(new serial_t(this, args));
+
+#ifdef UARTWIDGET_struct_guard
+    UARTWIDGET_0_substruct_create;
+    add_endpoint(new uart_t(this, UARTWIDGET_0_substruct));
+#endif
+#ifdef SERIALWIDGET_struct_guard
+    SERIALWIDGET_0_substruct_create;
+    add_endpoint(new serial_t(this, args, SERIALWIDGET_0_substruct));
+#endif
 
 #ifdef NASTIWIDGET_0
     endpoints.push_back(new sim_mem_t(this, argc, argv));
@@ -117,7 +124,10 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
                 argc, argv, "memory_stats.csv"));
 #endif
 
-    add_endpoint(new blockdev_t(this, args));
+#ifdef BLOCKDEVWIDGET_struct_guard
+    BLOCKDEVWIDGET_0_substruct_create;
+    add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_0_num_trackers, BLOCKDEVWIDGET_0_latency_bits, BLOCKDEVWIDGET_0_substruct));
+#endif
 
 #ifdef SIMPLENICWIDGET_struct_guard
     SIMPLENICWIDGET_0_substruct_create;

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -58,7 +58,7 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
 #ifdef BLOCKDEVWIDGET_struct_guard
     BLOCKDEVWIDGET_0_substruct_create;
-    add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_0_num_trackers, BLOCKDEVWIDGET_0_latency_bits, BLOCKDEVWIDGET_0_substruct));
+    add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_0_num_trackers, BLOCKDEVWIDGET_0_latency_bits, BLOCKDEVWIDGET_0_substruct, 0));
 #endif
 
 #ifdef SIMPLENICWIDGET_struct_guard

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -57,8 +57,14 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 #endif
 
 #ifdef BLOCKDEVWIDGET_struct_guard
+    #ifdef BLOCKDEVWIDGET_0_PRESENT
     BLOCKDEVWIDGET_0_substruct_create;
     add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_0_num_trackers, BLOCKDEVWIDGET_0_latency_bits, BLOCKDEVWIDGET_0_substruct, 0));
+    #endif
+    #ifdef BLOCKDEVWIDGET_1_PRESENT
+    BLOCKDEVWIDGET_1_substruct_create;
+    add_endpoint(new blockdev_t(this, args, BLOCKDEVWIDGET_1_num_trackers, BLOCKDEVWIDGET_1_latency_bits, BLOCKDEVWIDGET_1_substruct, 1));
+    #endif
 #endif
 
 #ifdef SIMPLENICWIDGET_struct_guard

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -31,9 +31,25 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
 
 #ifdef UARTWIDGET_struct_guard
+    #ifdef UARTWIDGET_0_PRESENT
     UARTWIDGET_0_substruct_create;
     add_endpoint(new uart_t(this, UARTWIDGET_0_substruct));
+    #endif
+    #ifdef UARTWIDGET_1_PRESENT
+    UARTWIDGET_1_substruct_create;
+    add_endpoint(new uart_t(this, UARTWIDGET_1_substruct));
+    #endif
+    #ifdef UARTWIDGET_2_PRESENT
+    UARTWIDGET_2_substruct_create;
+    add_endpoint(new uart_t(this, UARTWIDGET_2_substruct));
+    #endif
+    #ifdef UARTWIDGET_3_PRESENT
+    UARTWIDGET_3_substruct_create;
+    add_endpoint(new uart_t(this, UARTWIDGET_3_substruct));
+    #endif
 #endif
+
+    // TODO: Serial multiple copy support
 #ifdef SERIALWIDGET_struct_guard
     SERIALWIDGET_0_substruct_create;
     add_endpoint(new serial_t(this, args, SERIALWIDGET_0_substruct));
@@ -76,13 +92,41 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 #endif
 
 #ifdef SIMPLENICWIDGET_struct_guard
+    #ifdef SIMPLENICWIDGET_0_PRESENT
     SIMPLENICWIDGET_0_substruct_create;
     add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_0_substruct, 0));
+    #endif
+    #ifdef SIMPLENICWIDGET_1_PRESENT
+    SIMPLENICWIDGET_1_substruct_create;
+    add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_1_substruct, 1));
+    #endif
+    #ifdef SIMPLENICWIDGET_2_PRESENT
+    SIMPLENICWIDGET_2_substruct_create;
+    add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_2_substruct, 2));
+    #endif
+    #ifdef SIMPLENICWIDGET_3_PRESENT
+    SIMPLENICWIDGET_3_substruct_create;
+    add_endpoint(new simplenic_t(this, args, SIMPLENICWIDGET_3_substruct, 3));
+    #endif
 #endif
 
 #ifdef TRACERVWIDGET_struct_guard
+    #ifdef TRACERVWIDGET_0_PRESENT
     TRACERVWIDGET_0_substruct_create;
     add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_0_substruct, 0));
+    #endif
+    #ifdef TRACERVWIDGET_1_PRESENT
+    TRACERVWIDGET_1_substruct_create;
+    add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_1_substruct, 1));
+    #endif
+    #ifdef TRACERVWIDGET_2_PRESENT
+    TRACERVWIDGET_2_substruct_create;
+    add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_2_substruct, 2));
+    #endif
+    #ifdef TRACERVWIDGET_3_PRESENT
+    TRACERVWIDGET_3_substruct_create;
+    add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_3_substruct, 3));
+    #endif
 #endif
 
     // add more endpoints here

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -82,7 +82,7 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
 #ifdef TRACERVWIDGET_struct_guard
     TRACERVWIDGET_0_substruct_create;
-    add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_0_substruct));
+    add_endpoint(new tracerv_t(this, args, TRACERVWIDGET_0_substruct, 0));
 #endif
 
     // add more endpoints here

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -118,7 +118,12 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 #endif
 
     add_endpoint(new blockdev_t(this, args));
-    add_endpoint(new simplenic_t(this, slotid, mac_little_end, netbw, netburst, linklatency, niclogfile, nic_loopback, shmemportname));
+
+#ifdef SIMPLENICWIDGET_struct
+    SIMPLENICWIDGET_0_substruct_create;
+    add_endpoint(new simplenic_t(this, slotid, mac_little_end, netbw, netburst, linklatency, niclogfile, nic_loopback, shmemportname, &SIMPLENICWIDGET_0_substruct));
+#endif
+
     add_endpoint(new tracerv_t(this, tracefile, trace_start, trace_end));
     // add more endpoints here
 

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -69,7 +69,7 @@ TIMEOUT_CYCLES = 100000000
 NET_SLOT ?= 0
 NET_LINK_LATENCY ?= 6405
 NET_BW ?= 100
-nic_args = +slotid=$(NET_SLOT) +niclog=niclog +linklatency=$(NET_LINK_LATENCY) +netbw=$(NET_BW) +netburst=8 +nic-loopback
+nic_args = +slotid=$(NET_SLOT) +niclog0=niclog +linklatency0=$(NET_LINK_LATENCY) +netbw0=$(NET_BW) +netburst0=8 +nic-loopback0
 
 SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
 mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))

--- a/sim/src/main/scala/firesim/TargetLandTestSuites.scala
+++ b/sim/src/main/scala/firesim/TargetLandTestSuites.scala
@@ -18,7 +18,7 @@ class BlockdevTestSuite(prefix: String, val names: LinkedHashSet[String]) extend
   val makeTargetName = prefix + "-blkdev-tests"
   def kind = "blockdev"
   // Blockdev tests need an image, which complicates this
-  def additionalArgs = "+blkdev-in-mem0=128 +nic-loopback"
+  def additionalArgs = "+blkdev-in-mem0=128 +nic-loopback0"
   override def toString = s"$makeTargetName = \\\n" +
     // Make variable with the binaries of the suite
     names.map(n => s"\t$n.riscv").mkString(" \\\n") + "\n\n" +
@@ -35,7 +35,7 @@ class NICTestSuite(prefix: String, val names: LinkedHashSet[String]) extends Roc
   val dir = "$(fc_test_dir)"
   val makeTargetName = prefix + "-nic-tests"
   def kind = "nic"
-  def additionalArgs = "+netbw=100 +linklatency=6405 +netburst=8 +slotid=0 +nic-loopback"
+  def additionalArgs = "+netbw0=100 +linklatency0=6405 +netburst0=8 +slotid=0 +nic-loopback0"
   override def toString = s"$makeTargetName = \\\n" +
     names.map(n => s"\t$n.riscv").mkString(" \\\n") + "\n\n" +
     names.map(n => s"$n.riscv_ARGS=$additionalArgs").mkString(" \n") +

--- a/sim/src/main/scala/firesim/TargetLandTestSuites.scala
+++ b/sim/src/main/scala/firesim/TargetLandTestSuites.scala
@@ -18,7 +18,7 @@ class BlockdevTestSuite(prefix: String, val names: LinkedHashSet[String]) extend
   val makeTargetName = prefix + "-blkdev-tests"
   def kind = "blockdev"
   // Blockdev tests need an image, which complicates this
-  def additionalArgs = "+blkdev-in-mem=128 +nic-loopback"
+  def additionalArgs = "+blkdev-in-mem0=128 +nic-loopback"
   override def toString = s"$makeTargetName = \\\n" +
     // Make variable with the binaries of the suite
     names.map(n => s"\t$n.riscv").mkString(" \\\n") + "\n\n" +


### PR DESCRIPTION
- Replace macros with structs (https://github.com/ucb-bar/midas/pull/96)
    - Adds a macro used in firesim_top.cc to create a struct
    - Struct then gets passed into the constructor, provides access to mmio reg addrs
    - endpoint destructor responsible for free()ing struct
- Added TODO list for some missing things that will be in a separate PR
- Start replacing arg parsing for certain endpoints to support multiple instantiations of that endpoint (tracer, NIC, blkdev) in prep for supernode
- Some endpoints need more work to support multiple instantiations (Serial (arg parsing), UART (pty support))