### PR TITLE
UART prep for supernode on master

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,2 +1,1 @@
  -serial endpoint multiple copies support (e.g. which program to load)
-- UART needs to connect to a pty to support multiple uarts?

--- a/sim/src/main/cc/endpoints/uart.cc
+++ b/sim/src/main/cc/endpoints/uart.cc
@@ -55,11 +55,13 @@ uart_t::uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs, int uartno): endpoi
         grantpt(ptyfd);
         unlockpt(ptyfd);
         ptsname_r(ptyfd, slavename, SLAVENAMELEN);
-        if (!slavename) {
-            printf("NULL\n");
-            perror("wat");
-        }
-        printf("UART%d is on PTY: %s\n", uartno, slavename);
+
+        // create symlink for reliable location to find uart pty
+        std::string symlinkname = std::string("uartpty") + std::to_string(uartno);
+        // unlink in case symlink already exists
+        unlink(symlinkname.c_str());
+        symlink(slavename, symlinkname.c_str());
+        printf("UART%d is on PTY: %s, symlinked at %s\n", uartno, slavename, symlinkname.c_str());
         printf("Attach to this UART with sudo screen %s\n", slavename);
         inputfd = ptyfd;
         outputfd = ptyfd;

--- a/sim/src/main/cc/endpoints/uart.cc
+++ b/sim/src/main/cc/endpoints/uart.cc
@@ -1,9 +1,18 @@
 #ifdef UARTWIDGET_struct_guard
 
 #include "uart.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#define _XOPEN_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+
 #ifndef _WIN32
 #include <unistd.h>
-#include <fcntl.h>
+
+// name length limit for ptys
+#define SLAVENAMELEN 256
 
 /* There is no "backpressure" to the user input for sigs. only one at a time
  * non-zero value represents unconsumed special char input.
@@ -24,19 +33,40 @@ void sighand(int s) {
 }
 #endif
 
-uart_t::uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs): endpoint_t(sim)
+uart_t::uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs, int uartno): endpoint_t(sim)
 {
     this->mmio_addrs = mmio_addrs;
 
-    // Don't block on stdin reads if there is nothing typed in
-    fcntl(STDIN_FILENO, F_SETFL, fcntl(STDIN_FILENO, F_GETFL) | O_NONBLOCK);
+    if (uartno == 0) {
+        // signal handler so ctrl-c doesn't kill simulation when UART is attached
+        // to stdin/stdout
+        struct sigaction sigIntHandler;
+        sigIntHandler.sa_handler = sighand;
+        sigemptyset(&sigIntHandler.sa_mask);
+        sigIntHandler.sa_flags = 0;
+        sigaction(SIGINT, &sigIntHandler, NULL);
+        printf("UART0 is here (stdin/stdout).\n");
+        inputfd = STDIN_FILENO;
+        outputfd = STDOUT_FILENO;
+    } else {
+        // for UARTs that are not UART0, use a PTY
+        char slavename[SLAVENAMELEN];
+        int ptyfd = open("/dev/ptmx", O_RDWR);
+        grantpt(ptyfd);
+        unlockpt(ptyfd);
+        ptsname_r(ptyfd, slavename, SLAVENAMELEN);
+        if (!slavename) {
+            printf("NULL\n");
+            perror("wat");
+        }
+        printf("UART%d is on PTY: %s\n", uartno, slavename);
+        printf("Attach to this UART with sudo screen %s\n", slavename);
+        inputfd = ptyfd;
+        outputfd = ptyfd;
+    }
 
-    // signal handler so ctrl-c doesn't kill simulation
-    struct sigaction sigIntHandler;
-    sigIntHandler.sa_handler = sighand;
-    sigemptyset(&sigIntHandler.sa_mask);
-    sigIntHandler.sa_flags = 0;
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    // Don't block on reads if there is nothing typed in
+    fcntl(inputfd, F_SETFL, fcntl(inputfd, F_GETFL) | O_NONBLOCK);
 }
 
 uart_t::~uart_t() {
@@ -72,12 +102,15 @@ void uart_t::tick() {
             int readamt;
             if (specialchar) {
                 // send special character (e.g. ctrl-c)
+                // for stdin handling
+                //
+                // PTY should never trigger this
                 inp = specialchar;
                 specialchar = 0;
                 readamt = 1;
             } else {
-                // else check if we have input on stdin
-                readamt = ::read(STDIN_FILENO, &inp, 1);
+                // else check if we have input
+                readamt = ::read(inputfd, &inp, 1);
             }
 
             if (readamt > 0) {
@@ -87,9 +120,10 @@ void uart_t::tick() {
         }
 
         if (data.out.fire()) {
-            fprintf(stdout, "%c", data.out.bits);
+            ::write(outputfd, &data.out.bits, 1);
             // always flush to get char-by-char output (not line-buffered)
-            fflush(stdout);
+            // TODO: unnecessary once we've switched to write?
+            //fflush(stdout);
         }
 
         this->send();

--- a/sim/src/main/cc/endpoints/uart.h
+++ b/sim/src/main/cc/endpoints/uart.h
@@ -22,6 +22,7 @@ class uart_t: public endpoint_t
         serial_data_t<char> data;
         int inputfd;
         int outputfd;
+        int loggingfd;
 };
 #endif // UARTWIDGET_struct_guard
 

--- a/sim/src/main/cc/endpoints/uart.h
+++ b/sim/src/main/cc/endpoints/uart.h
@@ -8,7 +8,7 @@
 class uart_t: public endpoint_t
 {
     public:
-        uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs);
+        uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs, int uartno);
         ~uart_t();
         void send();
         void recv();
@@ -20,6 +20,8 @@ class uart_t: public endpoint_t
     private:
         UARTWIDGET_struct * mmio_addrs;
         serial_data_t<char> data;
+        int inputfd;
+        int outputfd;
 };
 #endif // UARTWIDGET_struct_guard
 

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -34,19 +34,19 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 #ifdef UARTWIDGET_struct_guard
     #ifdef UARTWIDGET_0_PRESENT
     UARTWIDGET_0_substruct_create;
-    add_endpoint(new uart_t(this, UARTWIDGET_0_substruct));
+    add_endpoint(new uart_t(this, UARTWIDGET_0_substruct, 0));
     #endif
     #ifdef UARTWIDGET_1_PRESENT
     UARTWIDGET_1_substruct_create;
-    add_endpoint(new uart_t(this, UARTWIDGET_1_substruct));
+    add_endpoint(new uart_t(this, UARTWIDGET_1_substruct, 1));
     #endif
     #ifdef UARTWIDGET_2_PRESENT
     UARTWIDGET_2_substruct_create;
-    add_endpoint(new uart_t(this, UARTWIDGET_2_substruct));
+    add_endpoint(new uart_t(this, UARTWIDGET_2_substruct, 2));
     #endif
     #ifdef UARTWIDGET_3_PRESENT
     UARTWIDGET_3_substruct_create;
-    add_endpoint(new uart_t(this, UARTWIDGET_3_substruct));
+    add_endpoint(new uart_t(this, UARTWIDGET_3_substruct, 3));
     #endif
 #endif
 


### PR DESCRIPTION
- UARTs now use PTY if they are not the main UART. main UART (UART0) still uses stdout/stdin so existing non-supernode users are not affected
    - As a result, supernode users no longer have to pipe into a file to interact with console on simulated nodes.
    - To prevent having to launch a ton more screens for now, UARTs != UART0 will write their own uartlog (uartlog1, uartlog2, etc.)