### PR TITLE
Fix bw-test

### DIFF
--- a/deploy/workloads/bw-test-two-instances/bw-test-graph.py
+++ b/deploy/workloads/bw-test-two-instances/bw-test-graph.py
@@ -31,11 +31,11 @@ def compute_bw(packet_data):
         if ts >= END_CYCLE:
             break
         if ts >= window_end:
-            if cur_total > 0:
+            while window_end < ts:
                 cycles.append(window_end)
                 totals.append(cur_total)
-            window_end = (ts // TIME_STEP + 1) * TIME_STEP
-            cur_total = 0
+                window_end += TIME_STEP
+                cur_total = 0
         else:
             cur_total += plen
     cycles.append(window_end)

--- a/deploy/workloads/bw-test-two-instances/bw-test-graph.py
+++ b/deploy/workloads/bw-test-two-instances/bw-test-graph.py
@@ -11,7 +11,9 @@ TIME_STEP = 100000
 CYCLES_PER_NANO = 3.2
 CYCLES_PER_MILLI = CYCLES_PER_NANO * 1e6
 BITS_PER_WORD = 64
-END_CYCLE = 800 * 1000 * 1000
+TEST_PERIOD = 100 * 1000 * 1000
+START_CYCLE = TEST_PERIOD
+END_CYCLE = 9 * TEST_PERIOD
 
 def parse_log(f):
     data = []
@@ -75,7 +77,7 @@ def main():
             series.append(ser)
 
     for i in range(1, 8):
-        cycle = i * END_CYCLE / 8
+        cycle = i * TEST_PERIOD + START_CYCLE
         millis = cycle / CYCLES_PER_MILLI
         plt.axvline(x=millis, color='gray', linewidth=1, linestyle=':')
 
@@ -87,11 +89,13 @@ def main():
     ax.text(108, 145, '40 Gb/s', size='10')
     ax.text(40, 185, '100 Gb/s', size='10')
 
+    start_time = START_CYCLE / CYCLES_PER_MILLI
+    end_time = END_CYCLE / CYCLES_PER_MILLI
 
     #plt.legend(series, ['1 Gb/s', '10 Gb/s', '40 Gb/s', '100 Gb/s'])
     plt.xlabel("Time (ms)", size='10')
     plt.ylabel("Bandwidth (Gb/s)", size='10')
-    plt.axis([0, END_CYCLE / CYCLES_PER_MILLI, 0, 210])
+    plt.axis([start_time, end_time, 0, 210])
     plt.savefig(outputfile)
     plt.show()
 

--- a/target-design/switch/baseport.h
+++ b/target-design/switch/baseport.h
@@ -12,7 +12,7 @@ typedef struct switchpacket switchpacket;
 
 class BasePort {
     public:
-        BasePort(int portNo);
+        BasePort(int portNo, bool throttle);
         void write_flits_to_output();
         virtual void tick() = 0; // some ports need to do management every switching loop
         virtual void tick_pre() = 0; // some ports need to do management every switching loop
@@ -37,9 +37,12 @@ class BasePort {
 
     protected:
         int _portNo;
+        bool _throttle;
 };
 
-BasePort::BasePort(int portNo) : _portNo(portNo) {
+BasePort::BasePort(int portNo, bool throttle)
+    : _portNo(portNo), _throttle(throttle)
+{
 }
 
 // assumes valid
@@ -94,7 +97,9 @@ void BasePort::write_flits_to_output() {
                 write_flit(current_output_buf, flitswritten, thispacket->dat[i]);
                 empty_buf = false;
 
-                if ((i + 1) % throttle_numer == 0)
+                if (!_throttle)
+                    flitswritten++;
+                else if ((i + 1) % throttle_numer == 0)
                     flitswritten += (throttle_denom - throttle_numer + 1);
                 else
                     flitswritten++;

--- a/target-design/switch/shmemport.h
+++ b/target-design/switch/shmemport.h
@@ -13,7 +13,7 @@ class ShmemPort : public BasePort {
         int currentround = 0;
 };
 
-ShmemPort::ShmemPort(int portNo, char * shmemportname, bool uplink) : BasePort(portNo) {
+ShmemPort::ShmemPort(int portNo, char * shmemportname, bool uplink) : BasePort(portNo, !uplink) {
 #define SHMEM_EXTRABYTES 1
 
     // create shared memory regions

--- a/target-design/switch/socketport.h
+++ b/target-design/switch/socketport.h
@@ -14,7 +14,7 @@ class SocketClientPort : public BasePort {
         int clientsocket;
 };
 
-SocketClientPort::SocketClientPort(int portNo, char * serverip, int hostport) : BasePort(portNo) {
+SocketClientPort::SocketClientPort(int portNo, char * serverip, int hostport) : BasePort(portNo, false) {
 
     struct sockaddr_in serv_addr;
 
@@ -96,7 +96,7 @@ class SocketServerPort : public BasePort {
         int serversocket;
 };
 
-SocketServerPort::SocketServerPort(int portNo, int hostport) : BasePort(portNo) {
+SocketServerPort::SocketServerPort(int portNo, int hostport) : BasePort(portNo, false) {
     int server_fd;
     struct sockaddr_in address;
     int opt = 1;

--- a/target-design/switch/sshport.h
+++ b/target-design/switch/sshport.h
@@ -60,7 +60,7 @@ static int tuntap_alloc(const char *dev, int flags) {
 #define DEVNAME_BYTES 128
 #define ceil_div(n, d) (((n) - 1) / (d) + 1)
 
-SSHPort::SSHPort(int portNo) : BasePort(portNo) {
+SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
     char * slotid = NULL; // placeholder for multiple SSH port support if we need it later
     char devname[DEVNAME_BYTES+1];
     devname[0] = '\0';


### PR DESCRIPTION
This changes the switch so that it does not throttle the ports going in between switches. This allows the bw-test-two-instances workload to reproduce the graph from the ISCA paper.