### PR TITLE
Switch to using XDMA instead of EDMA

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -92,8 +92,6 @@ echo "export RISCV=$RISCV" > env.sh
 echo "export PATH=$RISCV/bin:$RDIR/$DTCversion:\$PATH" >> env.sh
 echo "export LD_LIBRARY_PATH=$RISCV/lib" >> env.sh
 
-cd "$RDIR/platforms/f1/aws-fpga/sdk/linux_kernel_drivers/edma"
-make
 cd "$RDIR/platforms/f1/aws-fpga/sdk/linux_kernel_drivers/xdma"
 make
 

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -94,6 +94,8 @@ echo "export LD_LIBRARY_PATH=$RISCV/lib" >> env.sh
 
 cd "$RDIR/platforms/f1/aws-fpga/sdk/linux_kernel_drivers/edma"
 make
+cd "$RDIR/platforms/f1/aws-fpga/sdk/linux_kernel_drivers/xdma"
+make
 
 # commands to run only on EC2
 # see if the instance info page exists. if not, we are not on ec2.

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -324,13 +324,13 @@ class InstanceDeployManager:
             run('mkdir -p /home/centos/edma/')
             put('../platforms/f1/aws-fpga/sdk/linux_kernel_drivers',
                 '/home/centos/edma/', mirror_local_mode=True)
-            with cd('/home/centos/edma/linux_kernel_drivers/edma/'):
+            with cd('/home/centos/edma/linux_kernel_drivers/xdma/'):
                 run('make')
 
     def unload_edma(self):
         self.instance_logger("Unloading EDMA Driver Kernel Module.")
         with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
-            run('sudo rmmod edma-drv')
+            run('sudo rmmod xdma')
 
     def clear_fpgas(self):
         # we always clear ALL fpga slots
@@ -344,25 +344,46 @@ class InstanceDeployManager:
                 run("""until sudo fpga-describe-local-image -S {} -R -H | grep -q "cleared"; do  sleep 1;  done""".format(slotno))
 
     def flash_fpgas(self):
+        dummyagfi = None
         for firesimservernode, slotno in zip(self.parentnode.fpga_slots, range(self.parentnode.get_num_fpga_slots_consumed())):
             if firesimservernode is not None:
                 agfi = firesimservernode.get_agfi()
+                dummyagfi = agfi
                 self.instance_logger("""Flashing FPGA Slot: {} with agfi: {}.""".format(slotno, agfi))
                 with StreamLogger('stdout'), StreamLogger('stderr'):
                     run("""sudo fpga-load-local-image -S {} -I {} -A""".format(
                         slotno, agfi))
+
+        # We only do this because XDMA hangs if some of the FPGAs on the instance
+        # are left in the cleared state. So, if you're only using some of the
+        # FPGAs on an instance, we flash the rest with one of your images
+        # anyway. Since the only interaction we have with an FPGA right now
+        # is over PCIe where the software component is mastering, this can't
+        # break anything.
+        for slotno in range(self.parentnode.get_num_fpga_slots_consumed(), self.parentnode.get_num_fpga_slots_max()):
+            self.instance_logger("""Flashing FPGA Slot: {} with dummy agfi: {}.""".format(slotno, dummyagfi))
+            with StreamLogger('stdout'), StreamLogger('stderr'):
+                run("""sudo fpga-load-local-image -S {} -I {} -A""".format(
+                    slotno, dummyagfi))
+
         for firesimservernode, slotno in zip(self.parentnode.fpga_slots, range(self.parentnode.get_num_fpga_slots_consumed())):
             if firesimservernode is not None:
                 self.instance_logger("""Checking for Flashed FPGA Slot: {} with agfi: {}.""".format(slotno, agfi))
                 with StreamLogger('stdout'), StreamLogger('stderr'):
                     run("""until sudo fpga-describe-local-image -S {} -R -H | grep -q "loaded"; do  sleep 1;  done""".format(slotno))
 
+        for slotno in range(self.parentnode.get_num_fpga_slots_consumed(), self.parentnode.get_num_fpga_slots_max()):
+            self.instance_logger("""Checking for Flashed FPGA Slot: {} with agfi: {}.""".format(slotno, dummyagfi))
+            with StreamLogger('stdout'), StreamLogger('stderr'):
+                run("""until sudo fpga-describe-local-image -S {} -R -H | grep -q "loaded"; do  sleep 1;  done""".format(slotno))
+
+
     def load_edma(self):
         """ load the edma kernel module. """
         self.instance_logger("Loading EDMA Driver Kernel Module.")
         # TODO: can make these values automatically be chosen based on link lat
         with StreamLogger('stdout'), StreamLogger('stderr'):
-            run("sudo insmod /home/centos/edma/linux_kernel_drivers/edma/edma-drv.ko single_transaction_size=65536 transient_buffer_size=67108864 edma_queue_depth=1024 poll_mode=1")
+            run("sudo insmod /home/centos/edma/linux_kernel_drivers/xdma/xdma.ko poll_mode=1")
 
     def start_ila_server(self):
         """ start the vivado hw_server and virtual jtag on simulation instance.) """


### PR DESCRIPTION
One catch is that we always have to flash all of the FPGAs on an instance, otherwise XDMA hangs. See
comment in run_farm.py. See performance results below:

latency
--------
old (edma):
[[0.021875, 2.05], [0.5009374999999999, 21.78], [0.9996875, 26.3], [2.0015625, 29.14], [2.9990625, 30.26], [4.0009375, 30.91], [5.000624999999999, 31.92], [6.0003125, 32.87], [7.0, 33.11], [7.9996875, 34.01], [8.999375, 34.03], [9.999062499999999, 34.31]]

new (xdma):
[(0.021875, 2.39), (0.5009374999999999, 26.13), (0.9996875, 31.41), (2.0015625, 35.97), (2.9990625, 37.85), (4.0009375, 38.98), (5.000624999999999, 39.71), (6.0003125, 40.17), (7.0, 40.39), (7.9996875, 40.72), (8.999375, 40.75), (9.999062499999999, 40.89)]

scale (truncated)
-------
old (edma):
[(64, 8.84), (32, 27.54), (16, 28.77), (8, 29.74), (4, 33.32), (2, 35.4), (1, 37.02)]

new (xdma):
[(64, 9.3), (32, 34.58), (16, 35.06), (8, 35.93), (4, 40.09), (2, 43.1), (1, 44.49)]