### PR TITLE
Enable autoclonetype on widget bundles; fix chisel3 imports

### DIFF
--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -24,7 +24,7 @@ class SimBlockDev(
   override def widgetName = "BlockDevWidget"
 }
 
-class BlockDevWidgetIO(implicit p: Parameters) extends EndpointWidgetIO()(p) {
+class BlockDevWidgetIO(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
   val hPort = Flipped(HostPort(new BlockDeviceIO))
   val dma = None
   val address = None

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -1,9 +1,9 @@
 package firesim
 package endpoints
 
-import chisel3.core._
+import chisel3._
 import chisel3.util._
-import DataMirror.directionOf
+import chisel3.experimental.{DataMirror, Direction}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.DecoupledHelper
 
@@ -17,7 +17,7 @@ class SimBlockDev(
   extends Endpoint {
   def matchType(data: Data) = data match {
     case channel: BlockDeviceIO =>
-      directionOf(channel.req.valid) == ActualDirection.Output
+      DataMirror.directionOf(channel.req.valid) == Direction.Output
     case _ => false
   }
   def widget(p: Parameters) = new BlockDevWidget()(p)

--- a/sim/src/main/scala/endpoints/SerialWidget.scala
+++ b/sim/src/main/scala/endpoints/SerialWidget.scala
@@ -21,7 +21,7 @@ class SimSerialIO extends Endpoint {
   override def widgetName = "SerialWidget"
 }
 
-class SerialWidgetIO(implicit p: Parameters) extends EndpointWidgetIO()(p) {
+class SerialWidgetIO(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
   val w = testchipip.SerialAdapter.SERIAL_IF_WIDTH
   val hPort = Flipped(HostPort(new SerialIO(w)))
   val dma = None

--- a/sim/src/main/scala/endpoints/SerialWidget.scala
+++ b/sim/src/main/scala/endpoints/SerialWidget.scala
@@ -4,9 +4,9 @@ package endpoints
 import midas.core._
 import midas.widgets._
 
-import chisel3.core._
+import chisel3._
 import chisel3.util._
-import DataMirror.directionOf
+import chisel3.experimental.{DataMirror, Direction}
 import freechips.rocketchip.config.Parameters
 
 import testchipip.SerialIO
@@ -14,7 +14,7 @@ import testchipip.SerialIO
 class SimSerialIO extends Endpoint {
   def matchType(data: Data) = data match {
     case channel: SerialIO =>
-      directionOf(channel.out.valid) == ActualDirection.Output
+      DataMirror.directionOf(channel.out.valid) == Direction.Output
     case _ => false
   }
   def widget(p: Parameters) = new SerialWidget()(p)

--- a/sim/src/main/scala/endpoints/SimpleNICWidget.scala
+++ b/sim/src/main/scala/endpoints/SimpleNICWidget.scala
@@ -1,10 +1,9 @@
 package firesim
 package endpoints
 
-import chisel3.core._
+import chisel3._
 import chisel3.util._
-import chisel3.Module
-import DataMirror.directionOf
+import chisel3.experimental.{DataMirror, Direction}
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.util._
@@ -96,14 +95,14 @@ class NICToHostToken extends Bundle {
 class SimSimpleNIC extends Endpoint {
   def matchType(data: Data) = data match {
     case channel: NICIOvonly =>
-      directionOf(channel.out.valid) == ActualDirection.Output
+      DataMirror.directionOf(channel.out.valid) == Direction.Output
     case _ => false
   }
   def widget(p: Parameters) = new SimpleNICWidget()(p)
   override def widgetName = "SimpleNICWidget"
 }
 
-class SimpleNICWidgetIO(implicit p: Parameters) extends EndpointWidgetIO()(p) {
+class SimpleNICWidgetIO(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
   val hPort = Flipped(HostPort(new NICIOvonly))
   val dma = if (!p(LoopbackNIC)) {
     Some(Flipped(new NastiIO()(

--- a/sim/src/main/scala/endpoints/TracerVWidget.scala
+++ b/sim/src/main/scala/endpoints/TracerVWidget.scala
@@ -1,10 +1,8 @@
 package firesim
 package endpoints
 
-import chisel3.core._
+import chisel3._
 import chisel3.util._
-import chisel3.Module
-import DataMirror.directionOf
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.util._

--- a/sim/src/main/scala/endpoints/TracerVWidget.scala
+++ b/sim/src/main/scala/endpoints/TracerVWidget.scala
@@ -40,7 +40,7 @@ class SimTracerV extends Endpoint {
   override def widgetName = "TracerVWidget"
 }
 
-class TracerVWidgetIO(tracerParams: Parameters, num_traces: Int)(implicit p: Parameters) extends EndpointWidgetIO()(p) {
+class TracerVWidgetIO(val tracerParams: Parameters, val num_traces: Int)(implicit p: Parameters) extends EndpointWidgetIO()(p) {
   val hPort = Flipped(HostPort(new TraceOutputTop(num_traces)(tracerParams)))
   val dma = Some(Flipped(new NastiIO()(
       p.alterPartial({ case NastiKey => p(DMANastiKey) }))))

--- a/sim/src/main/scala/endpoints/UARTWidget.scala
+++ b/sim/src/main/scala/endpoints/UARTWidget.scala
@@ -4,9 +4,9 @@ package endpoints
 import midas.core._
 import midas.widgets._
 
-import chisel3.core._
+import chisel3._
 import chisel3.util._
-import DataMirror.directionOf
+import chisel3.experimental.{DataMirror, Direction}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem.PeripheryBusKey
 import sifive.blocks.devices.uart.{UARTPortIO, PeripheryUARTKey}
@@ -14,7 +14,7 @@ import sifive.blocks.devices.uart.{UARTPortIO, PeripheryUARTKey}
 class SimUART extends Endpoint {
   def matchType(data: Data) = data match {
     case channel: UARTPortIO =>
-      directionOf(channel.txd) == ActualDirection.Output
+      DataMirror.directionOf(channel.txd) == Direction.Output
     case _ => false
   }
   def widget(p: Parameters) = {


### PR DESCRIPTION
See ucb-bar/midas#102.

This cleans up the output from MIDAS compilation substantially. I made sure the output verilog was the same from commit to commit by diffing the verilog for a networked target. I also cleaned up the chisel imports in FireSim's endpoints to be a little more standard (and futureproof). 