### PR TITLE
DRY out DMA-related transport

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build.ini
+++ b/deploy/sample-backup-configs/sample_config_build.ini
@@ -23,7 +23,7 @@ fireboom-singlecore-no-nic-ddr3-llc4mb
 fireboom-singlecore-nic-ddr3-llc4mb
 #firesim-supernode-singlecore-nic-ddr3-llc4mb
 #firesim-supernode-quadcore-nic-ddr3-llc4mb
-#firesim-supernode-singlecore-nic-lbp
+firesim-supernode-singlecore-nic-lbp
 
 
 [agfistoshare]
@@ -39,7 +39,7 @@ fireboom-singlecore-no-nic-ddr3-llc4mb
 fireboom-singlecore-nic-ddr3-llc4mb
 #firesim-supernode-singlecore-nic-ddr3-llc4mb
 #firesim-supernode-quadcore-nic-ddr3-llc4mb
-#firesim-supernode-singlecore-nic-lbp
+firesim-supernode-singlecore-nic-lbp
 
 [sharewithaccounts]
 somebodysname=123456789012

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,27 +10,27 @@
 # own images.
 
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-0fce1c408a09e4494
+agfi=agfi-05c7620b62b901690
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-0f2f34654cd0ab18d
+agfi=agfi-07f3c2762e4349327
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-061a910e29f9fcf98
+agfi=agfi-0c078780eadb4203b
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-0b2ea0c33bfcf3cea
+agfi=agfi-0e9945a181069cc67
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-04b7cc253fbf128eb
+agfi=agfi-05ca0d174e131e124
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/src/main/scala/endpoints/BlockDevWidget.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.{DataMirror, Direction}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.DecoupledHelper
 
-import midas.core._
+import midas.core.{HostPort, IsRationalClockRatio, UnityClockRatio}
 import midas.widgets._
 import midas.models.DynamicLatencyPipe
 import testchipip.{BlockDeviceIO, BlockDeviceRequest, BlockDeviceData, BlockDeviceInfo, HasBlockDeviceParameters, BlockDeviceKey}

--- a/sim/src/main/scala/endpoints/SerialWidget.scala
+++ b/sim/src/main/scala/endpoints/SerialWidget.scala
@@ -1,7 +1,7 @@
 package firesim
 package endpoints
 
-import midas.core._
+import midas.core.{HostPort}
 import midas.widgets._
 
 import chisel3._

--- a/sim/src/main/scala/endpoints/SimpleNICWidget.scala
+++ b/sim/src/main/scala/endpoints/SimpleNICWidget.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.util._
 
-import midas.core._
+import midas.core.{HostPort}
 import midas.widgets._
 import testchipip.{StreamIO, StreamChannel}
 import icenet.{NICIOvonly, RateLimiterSettings}

--- a/sim/src/main/scala/endpoints/SimpleNICWidget.scala
+++ b/sim/src/main/scala/endpoints/SimpleNICWidget.scala
@@ -110,13 +110,7 @@ class SimSimpleNIC extends Endpoint {
 
 class SimpleNICWidgetIO(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
   val hPort = Flipped(HostPort(new NICIOvonly))
-  override val dma = if (!p(LoopbackNIC)) {
-    Some(Flipped(new NastiIO()(
-      p.alterPartial({ case NastiKey => p(DMANastiKey) }))))
-  } else None
-  override val dmaSize = BigInt((BIG_TOKEN_WIDTH / 8) * TOKEN_QUEUE_DEPTH)
 }
-
 
 class BigTokenToNICTokenAdapter extends Module {
   val io = IO(new Bundle {
@@ -215,41 +209,20 @@ class HostToNICTokenGenerator(nTokens: Int)(implicit p: Parameters) extends Modu
   when (seedDone) { state := s_forward }
 }
 
-class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p) {
+class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
+    with BidirectionalDMA {
   val io = IO(new SimpleNICWidgetIO)
+
+  lazy val fromHostCPUQueueDepth = TOKEN_QUEUE_DEPTH
+  lazy val toHostCPUQueueDepth   = TOKEN_QUEUE_DEPTH
+  // Biancolin: Need to look into this
+  lazy val dmaSize = BigInt((BIG_TOKEN_WIDTH / 8) * TOKEN_QUEUE_DEPTH)
 
   val htnt_queue = Module(new Queue(new HostToNICToken, 10))
   val ntht_queue = Module(new Queue(new NICToHostToken, 10))
 
   val bigtokenToNIC = Module(new BigTokenToNICTokenAdapter)
   val NICtokenToBig = Module(new NICTokenToBigTokenAdapter)
-
-  val incomingPCISdat = Module(new SplitSeqQueue)
-  val outgoingPCISdat = Module(new SplitSeqQueue)
-
-  // incoming/outgoing queue counts to replace ready/valid for batching
-  val incomingCount = RegInit(0.U(32.W))
-  val outgoingCount = RegInit(0.U(32.W))
-
-  when (incomingPCISdat.io.enq.fire() && incomingPCISdat.io.deq.fire()) {
-    incomingCount := incomingCount
-  } .elsewhen (incomingPCISdat.io.enq.fire()) {
-    incomingCount := incomingCount + 1.U
-  } .elsewhen (incomingPCISdat.io.deq.fire()) {
-    incomingCount := incomingCount - 1.U
-  } .otherwise {
-    incomingCount := incomingCount
-  }
-
-  when (outgoingPCISdat.io.enq.fire() && outgoingPCISdat.io.deq.fire()) {
-    outgoingCount := outgoingCount
-  } .elsewhen (outgoingPCISdat.io.enq.fire()) {
-    outgoingCount := outgoingCount + 1.U
-  } .elsewhen (outgoingPCISdat.io.deq.fire()) {
-    outgoingCount := outgoingCount - 1.U
-  } .otherwise {
-    outgoingCount := outgoingCount
-  }
 
   val target = io.hPort.hBits
   val tFire = io.hPort.toHost.hValid && io.hPort.fromHost.hReady && io.tReset.valid
@@ -305,89 +278,7 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p) {
     attach(rlimitSettings, "rlimit_settings", WriteOnly)
   }
 
-  // check to see if pcis has valid output instead of waiting for timeouts
-  attach(outgoingPCISdat.io.deq.valid, "pcis_out_valid", ReadOnly)
-  // check to see if pcis is ready to accept data instead of forcing writes
-  attach(incomingPCISdat.io.deq.valid, "pcis_in_busy", ReadOnly)
-
-  attach(outgoingCount, "outgoing_count", ReadOnly)
-  attach(incomingCount, "incoming_count", ReadOnly)
-
   genROReg(!tFire, "done")
 
   genCRFile()
-
-  val PCIS_BYTES = 64
-
-  io.dma.map { dma =>
-    // TODO, will these queues bottleneck us?
-    val aw_queue = Queue(dma.aw, 10)
-    val w_queue = Queue(dma.w, 10)
-    val ar_queue = Queue(dma.ar, 10)
-
-    assert(!ar_queue.valid || ar_queue.bits.size === log2Ceil(PCIS_BYTES).U)
-    assert(!aw_queue.valid || aw_queue.bits.size === log2Ceil(PCIS_BYTES).U)
-    assert(!w_queue.valid  || w_queue.bits.strb === ~0.U(PCIS_BYTES.W))
-
-    val writeHelper = DecoupledHelper(
-      aw_queue.valid,
-      w_queue.valid,
-      dma.b.ready,
-      incomingPCISdat.io.enq.ready
-    )
-
-    val readHelper = DecoupledHelper(
-      ar_queue.valid,
-      dma.r.ready,
-      outgoingPCISdat.io.deq.valid
-    )
-
-    val writeBeatCounter = RegInit(0.U(9.W))
-    val lastWriteBeat = writeBeatCounter === aw_queue.bits.len
-    when (w_queue.fire()) {
-      writeBeatCounter := Mux(lastWriteBeat, 0.U, writeBeatCounter + 1.U)
-    }
-
-    val readBeatCounter = RegInit(0.U(9.W))
-    val lastReadBeat = readBeatCounter === ar_queue.bits.len
-    when (dma.r.fire()) {
-      readBeatCounter := Mux(lastReadBeat, 0.U, readBeatCounter + 1.U)
-    }
-
-    dma.b.bits.resp := 0.U(2.W)
-    dma.b.bits.id := aw_queue.bits.id
-    dma.b.bits.user := aw_queue.bits.user
-    dma.b.valid := writeHelper.fire(dma.b.ready, lastWriteBeat)
-    aw_queue.ready := writeHelper.fire(aw_queue.valid, lastWriteBeat)
-    w_queue.ready := writeHelper.fire(w_queue.valid)
-
-    incomingPCISdat.io.enq.valid := writeHelper.fire(incomingPCISdat.io.enq.ready)
-    incomingPCISdat.io.enq.bits := w_queue.bits.data
-
-    outgoingPCISdat.io.deq.ready := readHelper.fire(outgoingPCISdat.io.deq.valid)
-
-    dma.r.valid := readHelper.fire(dma.r.ready)
-    dma.r.bits.data := outgoingPCISdat.io.deq.bits
-    dma.r.bits.resp := 0.U(2.W)
-    dma.r.bits.last := lastReadBeat
-    dma.r.bits.id := ar_queue.bits.id
-    dma.r.bits.user := ar_queue.bits.user
-    ar_queue.ready := readHelper.fire(ar_queue.valid, lastReadBeat)
-  }
-
-  //when (outgoingPCISdat.io.enq.fire()) {
-  //  printf("outgoing ENQ FIRE\n")
-  //}
-
-  //when (outgoingPCISdat.io.deq.fire()) {
-  //  printf("outgoing DEQ FIRE\n")
-  //}
-
-  //when (incomingPCISdat.io.enq.fire()) {
-  //  printf("incoming ENQ FIRE\n")
-  //}
-
-  //when (incomingPCISdat.io.deq.fire()) {
-  //  printf("incoming DEQ FIRE\n")
-  //}
 }

--- a/sim/src/main/scala/endpoints/SimpleNICWidget.scala
+++ b/sim/src/main/scala/endpoints/SimpleNICWidget.scala
@@ -213,6 +213,7 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
     with BidirectionalDMA {
   val io = IO(new SimpleNICWidgetIO)
 
+  // DMA mixin parameters
   lazy val fromHostCPUQueueDepth = TOKEN_QUEUE_DEPTH
   lazy val toHostCPUQueueDepth   = TOKEN_QUEUE_DEPTH
   // Biancolin: Need to look into this

--- a/sim/src/main/scala/endpoints/TracerVWidget.scala
+++ b/sim/src/main/scala/endpoints/TracerVWidget.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.rocket.TracedInstruction
 import freechips.rocketchip.subsystem.RocketTilesKey
 import freechips.rocketchip.tile.TileKey
 
-import midas.core._
+import midas.core.{HostPort}
 import midas.widgets._
 import testchipip.{StreamIO, StreamChannel}
 import icenet.{NICIOvonly, RateLimiterSettings}

--- a/sim/src/main/scala/endpoints/UARTWidget.scala
+++ b/sim/src/main/scala/endpoints/UARTWidget.scala
@@ -1,7 +1,7 @@
 package firesim
 package endpoints
 
-import midas.core._
+import midas.core.{HostPort}
 import midas.widgets._
 
 import chisel3._

--- a/sim/src/main/scala/firesim/SimConfigs.scala
+++ b/sim/src/main/scala/firesim/SimConfigs.scala
@@ -3,7 +3,7 @@ package firesim.firesim
 import freechips.rocketchip.config.{Parameters, Config, Field}
 
 import midas.{EndpointKey, MemModelKey}
-import midas.core.{SimAXI4MemIO, ReciprocalClockRatio, EndpointMap}
+import midas.widgets.{SimAXI4MemIO, EndpointMap}
 import midas.models._
 import midas.MemModelKey
 
@@ -50,14 +50,14 @@ class WithBlockDevWidget extends Config((site, here, up) => {
 
 class WithTracerVWidget extends Config((site, here, up) => {
   case midas.EndpointKey => up(midas.EndpointKey) ++
-    midas.core.EndpointMap(Seq(new SimTracerV))
+    EndpointMap(Seq(new SimTracerV))
 })
 
 // Instantiates an AXI4 memory model that executes (1 / clockDivision) of the frequency
 // of the RTL transformed model (Rocket Chip)
 class WithDefaultMemModel(clockDivision: Int = 1) extends Config((site, here, up) => {
   case EndpointKey => up(EndpointKey) ++ EndpointMap(Seq(
-    new SimAXI4MemIO(ReciprocalClockRatio(clockDivision))))
+    new SimAXI4MemIO(midas.core.ReciprocalClockRatio(clockDivision))))
   case LlcKey => None
   // Only used if a DRAM model is requested
   case DramOrganizationKey => DramOrganizationParams(maxBanks = 8, maxRanks = 4, dramSize = BigInt(1) << 34)


### PR DESCRIPTION
Related: ucb-bar/midas#110. 

Uses the PR above to DRY-out DMA-based endpoints. 