### PR TITLE
Driver kill

### DIFF
--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -159,7 +159,7 @@ class RuntimeHWConfig:
 
     def get_kill_simulation_command(self):
         driver = self.get_local_driver_binaryname()
-        # Note that pkill only works for names <15 characters
+        # Note that pkill only works for names <=15 characters
         return """sudo pkill -SIGKILL {driver}""".format(driver=driver[:15])
 
 

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -159,7 +159,8 @@ class RuntimeHWConfig:
 
     def get_kill_simulation_command(self):
         driver = self.get_local_driver_binaryname()
-        return """sudo pkill -SIGKILL {driver}""".format(driver=driver)
+        # Note that pkill only works for names <15 characters
+        return """sudo pkill -SIGKILL {driver}""".format(driver=driver[:15])
 
 
     def build_fpga_driver(self):


### PR DESCRIPTION
If the hw image name is long, the driver process name might exceed 15 characters. pkill/pgrep can only match the first 15 characters (a limitation from /proc/PID/status). Anyway, truncating the name allows it to match, whether or not the name was long (I think it's safe to assume there won't be anything with the same prefix running).

Testing:
workload: two bare-metal binaries, one prints and exits, the other infinite loops
agfis:
  * memblade (driver name = FireSimMemBlade-f1)
  * firesim-quadcore-nic-ddr3-llc4mb (driver name = FireSim-f1)
