### PR TITLE
Print synthesis improvements & bug fixes

### DIFF
--- a/docs/Advanced-Usage/Debugging/Debugging-Hardware-Using-ILA.rst
+++ b/docs/Advanced-Usage/Debugging/Debugging-Hardware-Using-ILA.rst
@@ -19,23 +19,21 @@ appropriately sized ILA instance.
 Annotating Signals
 ------------------------
 
-In order to annotate a signal, we must import ``midas.targetutils.FpgaDebugAnnotation``.
-We then simply add a relevant ``FpgaDebugAnnotation(<selected_signal>)`` with the
-desired signal as an argument.
-
-Example:
+In order to annotate a signal, we must import the
+``midas.targetutils.FpgaDebug`` annotator. FpgaDebug's apply method accepts a
+vararg of chisel3.Data. Invoke it as follows:
 
 ::
 
-    import midas.targetutils.FpgaDebugAnnotation
+    import midas.targetutils.FpgaDebug
 
     class SomeModuleIO(implicit p: Parameters) extends SomeIO()(p){
        val out1 = Output(Bool())
        val in1 = Input(Bool())
-       chisel3.experimental.annotate(FpgaDebugAnnotation(out1))
+       FpgaDebug(out1, in1)
     }
 
-These annotations can be used throughout FireSim, including in MIDAS and
+You can annotate signals throughout FireSim, including in MIDAS and
 Rocket-Chip Chisel sources, with the only exception being the Chisel3 sources
 themselves (eg. in Chisel3.util.Queue).
 

--- a/docs/Advanced-Usage/Debugging/printf-synthesis.rst
+++ b/docs/Advanced-Usage/Debugging/printf-synthesis.rst
@@ -41,7 +41,7 @@ endpoint driver, which will be automatically instantiated in FireSim driver.
 
 Runtime Arguments
 -----------------
-**+printfile**
+**+print-file**
     Specifies the file into which the synthesized printf log should written.
 
 **+print-start**

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -137,16 +137,16 @@ endif
 # the binary name. These are captured with $($*_ARGS)
 $(OUTPUT_DIR)/%.run: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	$(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.vpd: $(OUTPUT_DIR)/% $(EMUL)-debug
 	cd $(dir $($(EMUL)_debug)) && \
-	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) \
+	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	$(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -112,10 +112,10 @@ class RiscF1Test extends TutorialSuite("Risc", midas.F1, 64)
 class RiscSRAMF1Test extends TutorialSuite("RiscSRAM", midas.F1, 64)
 class AssertModuleF1Test extends TutorialSuite("AssertModule", midas.F1)
 class PrintfModuleF1Test extends TutorialSuite("PrintfModule", midas.F1,
-  simulationArgs = Seq("+print-human-readable", "+printfile=synthprinttest.out")) {
+  simulationArgs = Seq("+print-human-readable", "+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }
 class NarrowPrintfModuleF1Test extends TutorialSuite("NarrowPrintfModule", midas.F1,
-  simulationArgs = Seq("+print-human-readable", "+printfile=synthprinttest.out")) {
+  simulationArgs = Seq("+print-human-readable", "+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }


### PR DESCRIPTION
This bumps MIDAS for a number of print-synthesis bug fixes and QoL improvements.  It also adds an annotator object for FpgaDebug because i was too lazy to use the existing style. 

Associated PR: ucb-bar/midas#111

One disturbing discovery i had was that DMA reads could drop beats when the destination buffer spanned page boundaries. I'm unsure why this hasn't been a problem for NIC / TracerV. I opened an issue (firesim/firesim#208).  I tried aligning the buffer to an 8 byte boundary and that was still insufficient. Maybe we should consider adding an alignment check in simif_t::pull. @sagark 