### PR TITLE
[WIP] Parameterized NIC

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -436,6 +436,8 @@ class FireSimSwitchNode(FireSimNode):
         self.switch_link_latency = link_latency
         self.switch_switching_latency = switching_latency
         self.switch_bandwidth = bandwidth
+        self.switch_flit_width = None
+        self.switch_max_bandwidth = None
 
         # switch_builder is a class designed to emit a particular switch model.
         # it should take self and then be able to emit a particular switch model's

--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -33,7 +33,7 @@ class FireSimTopologyWithPasses:
 
     def __init__(self, user_topology_name, no_net_num_nodes, run_farm, hwdb,
                  defaulthwconfig, workload, defaultlinklatency, defaultswitchinglatency,
-                 defaultnetbandwidth, defaultprofileinterval,
+                 defaultflitwidth, defaultnetbandwidth, defaultprofileinterval,
                  defaulttraceenable, defaulttracestart, defaulttraceend,
                  terminateoncompletion):
         self.passes_used = []
@@ -46,6 +46,7 @@ class FireSimTopologyWithPasses:
         self.defaulthwconfig = defaulthwconfig
         self.defaultlinklatency = defaultlinklatency
         self.defaultswitchinglatency = defaultswitchinglatency
+        self.defaultflitwidth = defaultflitwidth
         self.defaultnetbandwidth = defaultnetbandwidth
         self.defaultprofileinterval = defaultprofileinterval
         self.defaulttraceenable = defaulttraceenable
@@ -276,6 +277,12 @@ class FireSimTopologyWithPasses:
             if isinstance(node, FireSimSwitchNode):
                 if node.switch_link_latency is None:
                     node.switch_link_latency = self.defaultlinklatency
+                if node.switch_flit_width is None:
+                    flitWidth = self.defaultflitwidth
+                    procSpeed = 3.2 # Assumed speed of the processor running on FSim
+                    node.switch_flit_width = flitWidth
+                    # flitWidth*procSpeed rounded to nearest 100
+                    node.switch_max_bandwidth = int((flitWidth*procSpeed) - ((flitWidth*procSpeed) % 100))
                 if node.switch_switching_latency is None:
                     node.switch_switching_latency = self.defaultswitchinglatency
                 if node.switch_bandwidth is None:

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -100,7 +100,7 @@ class RuntimeHWConfig:
         # the sed is in there to get rid of newlines in runtime confs
         driver = self.get_local_driver_binaryname()
         runtimeconf = self.get_local_runtimeconf_binaryname()
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start0={trace_start} +trace-end0={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval={profile_interval} +zero-out-dram +shmemportname0={shmemportname} +permissive-off +prog0={bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start0={trace_start} +trace-end0={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval={profile_interval} +shmemportname0={shmemportname} +permissive-off +prog0={bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
                 slotid=slotid, driver=driver, runtimeconf=runtimeconf,
                 macaddr=macaddr, blkdev=blkdev, linklatency=linklatency,
                 netbw=netbw, profile_interval=profile_interval,

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -245,6 +245,7 @@ class InnerRuntimeConfiguration:
         self.no_net_num_nodes = int(runtime_dict['targetconfig']['no_net_num_nodes'])
         self.linklatency = int(runtime_dict['targetconfig']['linklatency'])
         self.switchinglatency = int(runtime_dict['targetconfig']['switchinglatency'])
+        self.flitwidth = int(runtime_dict['targetconfig']['flitwidth'])
         self.netbandwidth = int(runtime_dict['targetconfig']['netbandwidth'])
         self.profileinterval = int(runtime_dict['targetconfig']['profileinterval'])
         # Default values
@@ -302,7 +303,7 @@ class RuntimeConfig:
             self.innerconf.topology, self.innerconf.no_net_num_nodes,
             self.runfarm, self.runtimehwdb, self.innerconf.defaulthwconfig,
             self.workload, self.innerconf.linklatency,
-            self.innerconf.switchinglatency, self.innerconf.netbandwidth,
+            self.innerconf.switchinglatency, self.innerconf.flitwidth, self.innerconf.netbandwidth,
             self.innerconf.profileinterval, self.innerconf.trace_enable,
             self.innerconf.trace_start, self.innerconf.trace_end,
             self.innerconf.terminateoncompletion)

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -100,7 +100,7 @@ class RuntimeHWConfig:
         # the sed is in there to get rid of newlines in runtime confs
         driver = self.get_local_driver_binaryname()
         runtimeconf = self.get_local_runtimeconf_binaryname()
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start0={trace_start} +trace-end0={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval={profile_interval} +shmemportname0={shmemportname} +permissive-off +prog0={bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +macaddr0={macaddr} +blkdev0={blkdev} +slotid={slotid} +niclog0=niclog {tracefile} +trace-start0={trace_start} +trace-end0={trace_end} +linklatency0={linklatency} +netbw0={netbw} +profile-interval={profile_interval} +zero-out-dram +shmemportname0={shmemportname} +permissive-off +prog0={bootbin} && stty intr ^c' uartlog"; sleep 1""".format(
                 slotid=slotid, driver=driver, runtimeconf=runtimeconf,
                 macaddr=macaddr, blkdev=blkdev, linklatency=linklatency,
                 netbw=netbw, profile_interval=profile_interval,

--- a/deploy/runtools/switch_model_config.py
+++ b/deploy/runtools/switch_model_config.py
@@ -63,6 +63,7 @@ class AbstractSwitchToSwitchConfig:
         constructedstring += self.get_numclientsconfig()
         constructedstring += self.get_portsetup()
         constructedstring += self.get_mac2port()
+        constructedstring += self.get_networkparameters()
         return constructedstring
 
     # produce mac2port array portion of config
@@ -105,6 +106,17 @@ class AbstractSwitchToSwitchConfig:
     #define NUMDOWNLINKS {}
     #define NUMUPLINKS {}
     #endif""".format(totalports, numdownlinks, numuplinks)
+        return retstr
+
+    def get_networkparameters(self):
+        """ emit flit width and max bandwidth for switch """
+        flitwidth = self.fsimswitchnode.switch_flit_width
+        maxbandwidth = self.fsimswitchnode.switch_max_bandwidth
+
+        retstr = """
+    #define FLIT_SIZE_BITS ({})
+    #define MAX_BW ({})
+    """.format(flitwidth, maxbandwidth)
         return retstr
 
     def get_portsetup(self):

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -17,7 +17,7 @@ topology=example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 # This references a section from config_hwconfigs.ini

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -17,7 +17,8 @@ topology=example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 # This references a section from config_hwconfigs.ini

--- a/deploy/workloads/bw-test-config.ini
+++ b/deploy/workloads/bw-test-config.ini
@@ -14,7 +14,7 @@ topology=example_16config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/bw-test-config.ini
+++ b/deploy/workloads/bw-test-config.ini
@@ -14,7 +14,8 @@ topology=example_16config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/bw-test-two-instances/bw-test-graph.py
+++ b/deploy/workloads/bw-test-two-instances/bw-test-graph.py
@@ -6,7 +6,7 @@ import numpy as np
 import re
 import sys
 
-DATA_RE = re.compile(r"^packet timestamp: (\d+), len: (\d+)\r$")
+DATA_RE = re.compile(r".*packet timestamp: (\d+), len: (\d+)")
 TIME_STEP = 100000
 CYCLES_PER_NANO = 3.2
 CYCLES_PER_MILLI = CYCLES_PER_NANO * 1e6

--- a/deploy/workloads/bw-test-two-instances/switchpatch.patch
+++ b/deploy/workloads/bw-test-two-instances/switchpatch.patch
@@ -1,27 +1,41 @@
 diff --git a/target-design/switch/baseport.h b/target-design/switch/baseport.h
-index 8252b64..152461e 100644
+index 863d96e..3807097 100644
 --- a/target-design/switch/baseport.h
 +++ b/target-design/switch/baseport.h
-@@ -86,7 +86,7 @@ void BasePort::write_flits_to_output() {
+@@ -90,11 +90,11 @@ void BasePort::write_flits_to_output() {
              uint64_t timestampdiff = outputtimestamp > basetime ? outputtimestamp - basetime : 0L;
              flitswritten = std::max(flitswritten, timestampdiff);
  
--            printf("intended timestamp: %ld, actual timestamp: %ld, diff %ld\n", outputtimestamp, basetime + flitswritten, (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
-+            //printf("intended timestamp: %ld, actual timestamp: %ld, diff %ld\n", outputtimestamp, basetime + flitswritten, (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
+-            printf("[BASE_PORT %d]: intended timestamp: %ld, actual timestamp: %ld, diff %ld\n",
+-                    _portNo,
+-                    outputtimestamp,
+-                    basetime + flitswritten,
+-                    (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
++            //printf("[BASE_PORT %d]: intended timestamp: %ld, actual timestamp: %ld, diff %ld\n",
++            //        _portNo,
++            //        outputtimestamp,
++            //        basetime + flitswritten,
++            //        (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
+ 
              int i = thispacket->amtread;
              for (;(i < thispacket->amtwritten) && (flitswritten < LINKLATENCY); i++) {
-                 write_last_flit(current_output_buf, flitswritten, i == (thispacket->amtwritten-1));
-@@ -100,6 +100,8 @@ void BasePort::write_flits_to_output() {
-                     flitswritten++;
+@@ -112,10 +112,10 @@ void BasePort::write_flits_to_output() {
              }
              if (i == thispacket->amtwritten) {
-+		printf("packet timestamp: %ld, len: %ld\n",
-+			basetime + flitswritten, thispacket->amtwritten);
                  // we finished sending this packet, so get rid of it
+-                //printf("[BASE_PORT %d]: packet timestamp: %ld, len: %ld\n",
+-                //        _portNo,
+-                //        basetime + flitswritten,
+-                //        thispacket->amtwritten);
++                printf("[BASE_PORT %d]: packet timestamp: %ld, len: %ld\n",
++                        _portNo,
++                        basetime + flitswritten,
++                        thispacket->amtwritten);
                  outputqueue.pop();
+                 free(thispacket->dat);
                  free(thispacket);
 diff --git a/target-design/switch/switch.cc b/target-design/switch/switch.cc
-index 8626e4a..eb56216 100644
+index 01da3fb..df8ef7f 100644
 --- a/target-design/switch/switch.cc
 +++ b/target-design/switch/switch.cc
 @@ -11,7 +11,7 @@
@@ -33,14 +47,14 @@ index 8626e4a..eb56216 100644
  
  #ifdef IGNORE_PRINTF
  #define printf(fmt, ...) (0)
-@@ -163,8 +163,8 @@ while (!pqueue.empty()) {
+@@ -172,8 +172,8 @@ while (!pqueue.empty()) {
      switchpacket * tsp = pqueue.top().switchpack;
      pqueue.pop();
-     uint16_t send_to_port = get_port_from_flit(tsp->dat[0], 0 /* junk remove arg */);
--    printf("packet for port: %x\n", send_to_port);
--    printf("packet timestamp: %ld\n", tsp->timestamp);
-+    //printf("packet for port: %x\n", send_to_port);
-+    //printf("packet timestamp: %ld\n", tsp->timestamp);
+     uint16_t send_to_port = get_port_from_flit(tsp->dat, 0 /* junk remove arg */);
+-    printf("[SWITCH] packet for port: %x\n", send_to_port);
+-    printf("[SWITCH] packet timestamp: %ld\n", tsp->timestamp);
++    //printf("[SWITCH] packet for port: %x\n", send_to_port);
++    //printf("[SWITCH] packet timestamp: %ld\n", tsp->timestamp);
      if (send_to_port == BROADCAST_ADJUSTED) {
  #define ADDUPLINK (NUMUPLINKS > 0 ? 1 : 0)
-         // this will only send broadcasts to the first (zeroeth) uplink.
+         //printf("[SWITCH]: Broadcast\n");

--- a/deploy/workloads/memcached-thread-imbalance-config.ini
+++ b/deploy/workloads/memcached-thread-imbalance-config.ini
@@ -14,7 +14,7 @@ topology=triple_example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/memcached-thread-imbalance-config.ini
+++ b/deploy/workloads/memcached-thread-imbalance-config.ini
@@ -14,7 +14,8 @@ topology=triple_example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/ping-latency-config.ini
+++ b/deploy/workloads/ping-latency-config.ini
@@ -14,7 +14,7 @@ topology=example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/ping-latency-config.ini
+++ b/deploy/workloads/ping-latency-config.ini
@@ -14,7 +14,8 @@ topology=example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/run-bw-test.sh
+++ b/deploy/workloads/run-bw-test.sh
@@ -14,9 +14,10 @@ if [ "$1" == "withlaunch" ]; then
 fi
 
 ORIGDIR=$(pwd)
-cd ../../
-git apply $ORIGDIR/bw-test-two-instances/switchpatch.patch
-cd $ORIGDIR
+
+#cd ../../
+#git apply $ORIGDIR/bw-test-two-instances/switchpatch.patch
+#cd $ORIGDIR
 
 bandwidths=( 1 10 40 100 )
 
@@ -42,9 +43,9 @@ done
 
 python $ORIGDIR/bw-test-two-instances/bw-test-graph.py $(pwd)/$resultsdir
 
-cd $ORIGDIR
-cd ../../
-git apply -R $ORIGDIR/bw-test-two-instances/switchpatch.patch
+#cd $ORIGDIR
+#cd ../../
+#git apply -R $ORIGDIR/bw-test-two-instances/switchpatch.patch
 
 firesim terminaterunfarm -c workloads/bw-test-config.ini --forceterminate
 

--- a/deploy/workloads/run-bw-test.sh
+++ b/deploy/workloads/run-bw-test.sh
@@ -15,9 +15,9 @@ fi
 
 ORIGDIR=$(pwd)
 
-#cd ../../
-#git apply $ORIGDIR/bw-test-two-instances/switchpatch.patch
-#cd $ORIGDIR
+cd ../../
+git apply $ORIGDIR/bw-test-two-instances/switchpatch.patch
+cd $ORIGDIR
 
 bandwidths=( 1 10 40 100 )
 
@@ -43,9 +43,9 @@ done
 
 python $ORIGDIR/bw-test-two-instances/bw-test-graph.py $(pwd)/$resultsdir
 
-#cd $ORIGDIR
-#cd ../../
-#git apply -R $ORIGDIR/bw-test-two-instances/switchpatch.patch
+cd $ORIGDIR
+cd ../../
+git apply -R $ORIGDIR/bw-test-two-instances/switchpatch.patch
 
 firesim terminaterunfarm -c workloads/bw-test-config.ini --forceterminate
 

--- a/deploy/workloads/run-ping-latency.sh
+++ b/deploy/workloads/run-ping-latency.sh
@@ -16,6 +16,10 @@ fi
 ORIGDIR=$(pwd)
 
 latencies=( 70 3199 6405 9597 12803 16002 19201 22400 25599 28798 31997 )
+
+# for 256b flit testing (bounded by 6144 token queue depth):
+#latencies=( 70 800 1603 3199 6000 )
+
 # for script testing:
 # latencies=( 31997 )
 

--- a/deploy/workloads/run-simperf-test-latency.sh
+++ b/deploy/workloads/run-simperf-test-latency.sh
@@ -16,6 +16,10 @@ fi
 ORIGDIR=$(pwd)
 
 latencies=( 70 1603 3199 6405 9597 12803 16002 19201 22400 25599 28798 31997 )
+
+# for 256b flit testing (bounded by 6144 token queue depth):
+#latencies=( 70 800 1603 3199 5000 6000 )
+
 # for script testing:
 #latencies=( 3199 6405 9597 12803 16002 19201 22400 25599 28798 31997 )
 

--- a/deploy/workloads/simperf-test-latency-config.ini
+++ b/deploy/workloads/simperf-test-latency-config.ini
@@ -14,7 +14,7 @@ topology=example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/simperf-test-latency-config.ini
+++ b/deploy/workloads/simperf-test-latency-config.ini
@@ -14,7 +14,8 @@ topology=example_8config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/simperf-test-scale-config.ini
+++ b/deploy/workloads/simperf-test-scale-config.ini
@@ -14,7 +14,8 @@ topology=example_256config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/simperf-test-scale-config.ini
+++ b/deploy/workloads/simperf-test-scale-config.ini
@@ -14,7 +14,7 @@ topology=example_256config
 no_net_num_nodes=2
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-nic-ddr3-llc4mb

--- a/deploy/workloads/spec17-intrate.ini
+++ b/deploy/workloads/spec17-intrate.ini
@@ -15,7 +15,7 @@ no_net_num_nodes=10
 # These are unused
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-no-nic-ddr3-llc4mb

--- a/deploy/workloads/spec17-intrate.ini
+++ b/deploy/workloads/spec17-intrate.ini
@@ -15,7 +15,8 @@ no_net_num_nodes=10
 # These are unused
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 defaulthwconfig=firesim-quadcore-no-nic-ddr3-llc4mb

--- a/deploy/workloads/spec17-intspeed.ini
+++ b/deploy/workloads/spec17-intspeed.ini
@@ -15,7 +15,7 @@ no_net_num_nodes=11
 # These are unused
 linklatency=6405
 switchinglatency=10
-netbandwidth=200
+netbandwidth=800
 profileinterval=-1
 
 # Need not be single core.

--- a/deploy/workloads/spec17-intspeed.ini
+++ b/deploy/workloads/spec17-intspeed.ini
@@ -15,7 +15,8 @@ no_net_num_nodes=11
 # These are unused
 linklatency=6405
 switchinglatency=10
-netbandwidth=800
+flitwidth=64
+netbandwidth=200
 profileinterval=-1
 
 # Need not be single core.

--- a/sim/src/main/cc/endpoints/simplenic.cc
+++ b/sim/src/main/cc/endpoints/simplenic.cc
@@ -13,11 +13,11 @@
 #include <sys/mman.h>
 
 // PARAMETERS FOR NETWORK SIZE
-// Note: These must all change at once AND change with the
-//       flit size in the RTL and switch code
-#define MAX_BANDWIDTH        (800) // This is FLIT_SIZE*PROC_SPEED rounded to the nearest 100
-#define MAX_BANDWIDTH_BITS    (10) // This is the amount of bits to hold the MAX_BANDWIDTH value
-#define FLIT_WIDTH_BITS      (256) // Size of the network interface
+// Note: This is configured by SimpleNICWidget.scala
+//       which in turn determines these params from TargetConfig.scala
+// MAX_BANDWIDTH     : This is FLIT_SIZE*PROC_SPEED rounded to the nearest 100
+// MAX_BANDWIDTH_BITS: This is the amount of bits to hold the MAX_BANDWIDTH value
+// FLIT_WIDTH_BITS   : Size of the network interface
 
 // DO NOT MODIFY PARAMS BELOW THIS LINE
 #define PCIE_WIDTH_BITS                    (512) // Size of the PCIE interface
@@ -134,6 +134,8 @@ simplenic_t::simplenic_t(simif_t *sim, std::vector<std::string> &args,
     printf("using rlimit_inc: %d\n", rlimit_inc);
     printf("using rlimit_period: %d\n", rlimit_period);
     printf("using MAX_BANDWIDTH: %d\n", MAX_BANDWIDTH);
+    printf("using MAX_BANDWIDTH_BITS: %d\n", MAX_BANDWIDTH_BITS);
+    printf("using FLIT_WIDTH_BITS: %d\n", FLIT_WIDTH_BITS);
 
     if (niclogfile) {
         this->niclog = fopen(niclogfile, "w");

--- a/sim/src/main/cc/endpoints/simplenic.cc
+++ b/sim/src/main/cc/endpoints/simplenic.cc
@@ -227,7 +227,7 @@ void simplenic_t::tick() {
     struct timespec tstart, tend;
 
     //#define DEBUG_NIC_PRINT
-    #define TOKENVERIFY
+    //#define TOKENVERIFY
     #ifdef TOKENVERIFY
         #define niclog_printArray(in, amtpass) int amt = amtpass; \
         while(--amt > 0){ niclog_printf("%02x.", *((unsigned char*)(in + amt))); }; \

--- a/sim/src/main/cc/endpoints/simplenic.h
+++ b/sim/src/main/cc/endpoints/simplenic.h
@@ -5,9 +5,6 @@
 #include "endpoints/endpoint.h"
 #include <vector>
 
-// TODO this should not be hardcoded here.
-#define MAX_BANDWIDTH 200
-
 #ifdef SIMPLENICWIDGET_struct_guard
 class simplenic_t: public endpoint_t
 {

--- a/sim/src/main/scala/endpoints/SimpleNICWidget.scala
+++ b/sim/src/main/scala/endpoints/SimpleNICWidget.scala
@@ -17,20 +17,23 @@ import icenet.IceNetConsts._
 import icenet.IceNetConfig
 import junctions.{NastiIO, NastiKey}
 
-object TokenQueueConsts {
+object PCIeConsts {
   val BIGTOKEN_WIDTH_BITS = 512
-  val TOKEN_QUEUE_DEPTH = 6144
 }
-import TokenQueueConsts._
+import PCIeConsts._
 
 case class SimpleNICWidgetConfig(TOKEN_WIDTH_BITS: Int = 64){
   val TOKENS_PER_BIGTOKEN = (BIGTOKEN_WIDTH_BITS / (TOKEN_WIDTH_BITS + 3))
   val BIGTOKEN_PADDING = (BIGTOKEN_WIDTH_BITS - (TOKENS_PER_BIGTOKEN * (TOKEN_WIDTH_BITS + 3)))
 }
 
-case object NICWidgetKey extends Field[SimpleNICWidgetConfig]
-
 case object LoopbackNIC extends Field[Boolean]
+// Note: This helps determine the max link latency by the following equation
+//       NICTokenQueueDepth * SMALLTOKENS_PER_BIGTOKEN = MAX_LINK_LATENCY_CYCLES
+//       So if there is a  64b flit then ... 6144 * 7 = 43,008 max cycles
+//          if there is a 128b flit then ... 6144 * 3 = 18,432 max cycles
+//          if there is a 256b flit then ... 6144 * 1 =  6,144 max cycles
+case object NICTokenQueueDepth extends Field[Int]
 
 /* on a NIC token transaction:
  * 1) simulation driver feeds an empty token to start:
@@ -52,137 +55,135 @@ class ReadyValidLast extends Bundle {
   val valid = Bool()
 }
 
-class BIGToken(implicit p: Parameters) extends Bundle {
-  val data = Vec(p(NICWidgetKey).TOKENS_PER_BIGTOKEN, UInt(p(NICWidgetKey).TOKEN_WIDTH_BITS.W))
-  val rvls = Vec(p(NICWidgetKey).TOKENS_PER_BIGTOKEN, new ReadyValidLast())
-  val pad = UInt(p(NICWidgetKey).BIGTOKEN_PADDING.W)
+class BIGToken(netConfig: SimpleNICWidgetConfig) extends Bundle {
+  val data = Vec(netConfig.TOKENS_PER_BIGTOKEN, UInt(netConfig.TOKEN_WIDTH_BITS.W))
+  val rvls = Vec(netConfig.TOKENS_PER_BIGTOKEN, new ReadyValidLast())
+  val pad = UInt(netConfig.BIGTOKEN_PADDING.W)
 
-  override def cloneType: this.type = (new BIGToken).asInstanceOf[this.type]
+  override def cloneType: this.type = (new BIGToken(netConfig)).asInstanceOf[this.type]
 }
 
-class HostToNICToken(implicit p: Parameters) extends Bundle {
-  val data_in = new StreamChannel(p(NICWidgetKey).TOKEN_WIDTH_BITS)
+class HostToNICToken(netConfig: SimpleNICWidgetConfig) extends Bundle { val data_in = new StreamChannel(netConfig.TOKEN_WIDTH_BITS)
   val data_in_valid = Bool()
   val data_out_ready = Bool()
 
-  override def cloneType: this.type = (new HostToNICToken).asInstanceOf[this.type]
+  override def cloneType: this.type = (new HostToNICToken(netConfig)).asInstanceOf[this.type]
 }
 
-class NICToHostToken(implicit p: Parameters) extends Bundle {
-  val data_out = new StreamChannel(p(NICWidgetKey).TOKEN_WIDTH_BITS)
+class NICToHostToken(netConfig: SimpleNICWidgetConfig) extends Bundle {
+  val data_out = new StreamChannel(netConfig.TOKEN_WIDTH_BITS)
   val data_out_valid = Bool()
   val data_in_ready = Bool()
 
-  override def cloneType: this.type = (new NICToHostToken).asInstanceOf[this.type]
+  override def cloneType: this.type = (new NICToHostToken(netConfig)).asInstanceOf[this.type]
 }
 
 class SimSimpleNIC extends Endpoint {
+  var netFlitWidth = 64 // dummy flit width (overriden by target)
+
   def matchType(data: Data) = data match {
-    case channel: NICIOvonly =>
+    case channel: NICIOvonly => {
+      netFlitWidth = channel.netIfWidthBits // get the flit width from the target
       DataMirror.directionOf(channel.out.valid) == Direction.Output
+    }
     case _ => false
   }
-  def widget(p: Parameters) = new SimpleNICWidget()(p)
+  def widget(p: Parameters) = new SimpleNICWidget(netFlitWidth)(p)
   override def widgetName = "SimpleNICWidget"
 }
 
-class SimpleNICWidgetIO(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
-  val netConfig = new IceNetConfig(NET_IF_WIDTH_BITS = p(NICWidgetKey).TOKEN_WIDTH_BITS)
-  val hPort = Flipped(HostPort(new NICIOvonly(netConfig)))
+class SimpleNICWidgetIO(netIfWidthBits: Int)(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
+  val hPort = Flipped(HostPort(new NICIOvonly(netIfWidthBits)))
 }
 
 /**
  * Take a BigToken, split it into individual tokens and return it one by one
  */
-class BigTokenToNICTokenAdapter(implicit p: Parameters) extends Module {
-
-  val config = p(NICWidgetKey)
+class BigTokenToNICTokenAdapter(netConfig: SimpleNICWidgetConfig) extends Module {
 
   val io = IO(new Bundle {
-    val htnt = DecoupledIO(new HostToNICToken)
+    val htnt = DecoupledIO(new HostToNICToken(netConfig))
     val pcie_in = Flipped(DecoupledIO(UInt(BIGTOKEN_WIDTH_BITS.W)))
   })
 
-  val pcieBundled = (new BIGToken).fromBits(io.pcie_in.bits)
+  val pcieBundled = (new BIGToken(netConfig)).fromBits(io.pcie_in.bits)
 
   val xactHelper = DecoupledHelper(io.htnt.ready, io.pcie_in.valid)
 
   val loopIter = RegInit(0.U(32.W))
   when (io.htnt.fire()) {
-    loopIter := Mux(loopIter === (config.TOKENS_PER_BIGTOKEN - 1).U, 0.U, loopIter + 1.U)
+    loopIter := Mux(loopIter === (netConfig.TOKENS_PER_BIGTOKEN - 1).U, 0.U, loopIter + 1.U)
   }
 
   io.htnt.bits.data_in.data := pcieBundled.data(loopIter)
-  io.htnt.bits.data_in.keep := ((BigInt(1) << (config.TOKEN_WIDTH_BITS/8)) - 1).U
+  io.htnt.bits.data_in.keep := ((BigInt(1) << (netConfig.TOKEN_WIDTH_BITS/8)) - 1).U
   io.htnt.bits.data_in.last := pcieBundled.rvls(loopIter).data_last
   io.htnt.bits.data_in_valid := pcieBundled.rvls(loopIter).valid
   io.htnt.bits.data_out_ready := pcieBundled.rvls(loopIter).ready
   io.htnt.valid := xactHelper.fire(io.htnt.ready)
-  io.pcie_in.ready := xactHelper.fire(io.pcie_in.valid, loopIter === (config.TOKENS_PER_BIGTOKEN - 1).U)
+  io.pcie_in.ready := xactHelper.fire(io.pcie_in.valid, loopIter === (netConfig.TOKENS_PER_BIGTOKEN - 1).U)
 }
 
 /**
  * Take multiple NICTokens and convert them into a single BigToken to send over PCIE
  */
-class NICTokenToBigTokenAdapter(implicit p: Parameters) extends Module {
-
-  val config = p(NICWidgetKey)
+class NICTokenToBigTokenAdapter(netConfig: SimpleNICWidgetConfig) extends Module {
 
   val io = IO(new Bundle {
-    val ntht = Flipped(DecoupledIO(new NICToHostToken))
+    val ntht = Flipped(DecoupledIO(new NICToHostToken(netConfig)))
     val pcie_out = DecoupledIO(UInt(BIGTOKEN_WIDTH_BITS.W))
   })
 
-  // step one, buffer config.TOKENS_PER_BIGTOKEN elems into registers. note that the last element is here 
+  // step one, buffer netConfig.TOKENS_PER_BIGTOKEN elems into registers. note that the last element is here 
   // just for convenience. in reality, it is not used since we're bypassing to
   // remove a cycle of latency
-  val NTHT_BUF = Reg(Vec(config.TOKENS_PER_BIGTOKEN, new NICToHostToken))
+  val NTHT_BUF = Reg(Vec(netConfig.TOKENS_PER_BIGTOKEN, new NICToHostToken(netConfig)))
   val specialCounter = RegInit(0.U(32.W))
 
   when (io.ntht.valid) {
     NTHT_BUF(specialCounter) := io.ntht.bits
   }
 
-  io.ntht.ready := (specialCounter === (config.TOKENS_PER_BIGTOKEN - 1).U && io.pcie_out.ready) || (specialCounter =/= (config.TOKENS_PER_BIGTOKEN - 1).U)
-  io.pcie_out.valid := specialCounter === (config.TOKENS_PER_BIGTOKEN - 1).U && io.ntht.valid
-  when ((specialCounter =/= (config.TOKENS_PER_BIGTOKEN - 1).U) && io.ntht.valid) {
+  io.ntht.ready := (specialCounter === (netConfig.TOKENS_PER_BIGTOKEN - 1).U && io.pcie_out.ready) || (specialCounter =/= (netConfig.TOKENS_PER_BIGTOKEN - 1).U)
+  io.pcie_out.valid := specialCounter === (netConfig.TOKENS_PER_BIGTOKEN - 1).U && io.ntht.valid
+  when ((specialCounter =/= (netConfig.TOKENS_PER_BIGTOKEN - 1).U) && io.ntht.valid) {
     specialCounter := specialCounter + 1.U
-  } .elsewhen ((specialCounter === (config.TOKENS_PER_BIGTOKEN - 1).U) && io.ntht.valid && io.pcie_out.ready) {
+  } .elsewhen ((specialCounter === (netConfig.TOKENS_PER_BIGTOKEN - 1).U) && io.ntht.valid && io.pcie_out.ready) {
     specialCounter := 0.U
   } .otherwise {
     specialCounter := specialCounter
   }
-  // step two, connect (config.TOKENS_PER_BIGTOKEN - 1) elems + latest one to output (config.TOKENS_PER_BIGTOKEN items)
+  // step two, connect (netConfig.TOKENS_PER_BIGTOKEN - 1) elems + latest one to output (netConfig.TOKENS_PER_BIGTOKEN items)
   // TODO: attach pcie_out to data
 
   // debug check to help check we're not losing tokens somewhere
-  val token_trace_counter = RegInit(0.U(config.BIGTOKEN_PADDING.W))
+  val token_trace_counter = RegInit(0.U(netConfig.BIGTOKEN_PADDING.W))
   when (io.pcie_out.fire()) {
     token_trace_counter := token_trace_counter + 1.U
   } .otherwise {
     token_trace_counter := token_trace_counter
   }
 
-  val out = Wire(new BIGToken)
-  for (i <- 0 until (config.TOKENS_PER_BIGTOKEN - 1)) {
+  val out = Wire(new BIGToken(netConfig))
+  for (i <- 0 until (netConfig.TOKENS_PER_BIGTOKEN - 1)) {
     out.data(i) := NTHT_BUF(i).data_out.data
     out.rvls(i).data_last := NTHT_BUF(i).data_out.last
     out.rvls(i).ready := NTHT_BUF(i).data_in_ready
     out.rvls(i).valid := NTHT_BUF(i).data_out_valid
   }
-  out.data((config.TOKENS_PER_BIGTOKEN - 1))           := io.ntht.bits.data_out.data
-  out.rvls((config.TOKENS_PER_BIGTOKEN - 1)).data_last := io.ntht.bits.data_out.last
-  out.rvls((config.TOKENS_PER_BIGTOKEN - 1)).ready     := io.ntht.bits.data_in_ready
-  out.rvls((config.TOKENS_PER_BIGTOKEN - 1)).valid     := io.ntht.bits.data_out_valid
+  out.data((netConfig.TOKENS_PER_BIGTOKEN - 1))           := io.ntht.bits.data_out.data
+  out.rvls((netConfig.TOKENS_PER_BIGTOKEN - 1)).data_last := io.ntht.bits.data_out.last
+  out.rvls((netConfig.TOKENS_PER_BIGTOKEN - 1)).ready     := io.ntht.bits.data_in_ready
+  out.rvls((netConfig.TOKENS_PER_BIGTOKEN - 1)).valid     := io.ntht.bits.data_out_valid
   out.pad := token_trace_counter
 
   io.pcie_out.bits := out.asUInt
 }
 
-class HostToNICTokenGenerator(nTokens: Int)(implicit p: Parameters) extends Module {
+class HostToNICTokenGenerator(nTokens: Int, netConfig: SimpleNICWidgetConfig) extends Module {
   val io = IO(new Bundle {
-    val out = Decoupled(new HostToNICToken)
-    val in = Flipped(Decoupled(new NICToHostToken))
+    val out = Decoupled(new HostToNICToken(netConfig))
+    val in = Flipped(Decoupled(new NICToHostToken(netConfig)))
   })
 
   val s_init :: s_seed :: s_forward :: Nil = Enum(3)
@@ -200,21 +201,23 @@ class HostToNICTokenGenerator(nTokens: Int)(implicit p: Parameters) extends Modu
   when (seedDone) { state := s_forward }
 }
 
-class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
+class SimpleNICWidget(netIfWidthBits: Int)(implicit p: Parameters) extends EndpointWidget()(p)
     with BidirectionalDMA {
-  val io = IO(new SimpleNICWidgetIO)
+  val io = IO(new SimpleNICWidgetIO(netIfWidthBits))
+
+  val netConfig = new SimpleNICWidgetConfig(netIfWidthBits)
 
   // DMA mixin parameters
-  lazy val fromHostCPUQueueDepth = TOKEN_QUEUE_DEPTH
-  lazy val toHostCPUQueueDepth   = TOKEN_QUEUE_DEPTH
+  lazy val fromHostCPUQueueDepth = p(NICTokenQueueDepth)
+  lazy val toHostCPUQueueDepth   = p(NICTokenQueueDepth)
   // Biancolin: Need to look into this
-  lazy val dmaSize = BigInt((BIGTOKEN_WIDTH_BITS / 8) * TOKEN_QUEUE_DEPTH)
+  lazy val dmaSize = BigInt((BIGTOKEN_WIDTH_BITS / 8) * p(NICTokenQueueDepth))
 
-  val htnt_queue = Module(new Queue(new HostToNICToken, 10))
-  val ntht_queue = Module(new Queue(new NICToHostToken, 10))
+  val htnt_queue = Module(new Queue(new HostToNICToken(netConfig), 10))
+  val ntht_queue = Module(new Queue(new NICToHostToken(netConfig), 10))
 
-  val bigtokenToNIC = Module(new BigTokenToNICTokenAdapter)
-  val NICtokenToBig = Module(new NICTokenToBigTokenAdapter)
+  val bigtokenToNIC = Module(new BigTokenToNICTokenAdapter(netConfig))
+  val NICtokenToBig = Module(new NICTokenToBigTokenAdapter(netConfig))
 
   val target = io.hPort.hBits
   val tFire = io.hPort.toHost.hValid && io.hPort.fromHost.hReady && io.tReset.valid
@@ -225,7 +228,7 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
 //  ntht_queue.reset := reset //|| targetReset
 
   if (p(LoopbackNIC)) {
-    val tokenGen = Module(new HostToNICTokenGenerator(10))
+    val tokenGen = Module(new HostToNICTokenGenerator(10, netConfig))
     htnt_queue.io.enq <> tokenGen.io.out
     tokenGen.io.in <> ntht_queue.io.deq
     NICtokenToBig.io.ntht.valid := false.B
@@ -261,9 +264,9 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
     val macAddrRegUpper = Reg(UInt(32.W))
     val macAddrRegLower = Reg(UInt(32.W))
     val rlimitSettings = Reg(UInt(32.W))
-    val netConfig = new IceNetConfig(NET_IF_WIDTH_BITS = p(NICWidgetKey).TOKEN_WIDTH_BITS)
+    val iceNetConfig = new IceNetConfig(NET_IF_WIDTH_BITS = netConfig.TOKEN_WIDTH_BITS)
 
-    target.rlimit := (new RateLimiterSettings(netConfig)).fromBits(rlimitSettings)
+    target.rlimit := (new RateLimiterSettings(iceNetConfig)).fromBits(rlimitSettings)
     target.macAddr := Cat(macAddrRegUpper, macAddrRegLower)
 
     attach(macAddrRegUpper, "macaddr_upper", WriteOnly)
@@ -274,4 +277,21 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
   genROReg(!tFire, "done")
 
   genCRFile()
+
+
+  // Write configuration specific parameters to a auto generated header
+  // so that simplenic can get the right parameters
+  //
+  // netMaxBandwidth: This is netIfWidthBits*assumedProcSpeed(3.2Ghz) rounded to the nearest 100
+  // netMaxBwBits: This is the amount of bits to hold the netMaxBandwidth value
+  val assumedProcSpeed = 3.2
+  val netMaxBandwidth = ((netIfWidthBits*assumedProcSpeed) - ((netIfWidthBits*assumedProcSpeed) % 100)).asInstanceOf[Int]
+  val netMaxBwBits = log2Ceil(netMaxBandwidth)
+
+  override def genHeader(base: BigInt, sb: StringBuilder) {
+    super.genHeader(base, sb)
+    sb.append(CppGenerationUtils.genMacro(s"FLIT_WIDTH_BITS", UInt32(netIfWidthBits)))
+    sb.append(CppGenerationUtils.genMacro(s"MAX_BANDWIDTH", UInt32(netMaxBandwidth)))
+    sb.append(CppGenerationUtils.genMacro(s"MAX_BANDWIDTH_BITS", UInt32(netMaxBwBits)))
+  }
 }

--- a/sim/src/main/scala/endpoints/SimpleNICWidget.scala
+++ b/sim/src/main/scala/endpoints/SimpleNICWidget.scala
@@ -13,14 +13,22 @@ import midas.widgets._
 import testchipip.{StreamIO, StreamChannel}
 import icenet.{NICIOvonly, RateLimiterSettings}
 import icenet.IceNIC._
+import icenet.IceNetConsts._
+import icenet.IceNetConfig
 import junctions.{NastiIO, NastiKey}
 
 object TokenQueueConsts {
-  val TOKENS_PER_BIG_TOKEN = 7
-  val BIG_TOKEN_WIDTH = (TOKENS_PER_BIG_TOKEN + 1) * 64
+  val BIGTOKEN_WIDTH_BITS = 512
   val TOKEN_QUEUE_DEPTH = 6144
 }
 import TokenQueueConsts._
+
+case class SimpleNICWidgetConfig(TOKEN_WIDTH_BITS: Int = 64){
+  val TOKENS_PER_BIGTOKEN = (BIGTOKEN_WIDTH_BITS / (TOKEN_WIDTH_BITS + 3))
+  val BIGTOKEN_PADDING = (BIGTOKEN_WIDTH_BITS - (TOKENS_PER_BIGTOKEN * (TOKEN_WIDTH_BITS + 3)))
+}
+
+case object NICWidgetKey extends Field[SimpleNICWidgetConfig]
 
 case object LoopbackNIC extends Field[Boolean]
 
@@ -44,22 +52,28 @@ class ReadyValidLast extends Bundle {
   val valid = Bool()
 }
 
-class BIGToken extends Bundle {
-  val data = Vec(7, UInt(64.W))
-  val rvls = Vec(7, new ReadyValidLast())
-  val pad = UInt(43.W)
+class BIGToken(implicit p: Parameters) extends Bundle {
+  val data = Vec(p(NICWidgetKey).TOKENS_PER_BIGTOKEN, UInt(p(NICWidgetKey).TOKEN_WIDTH_BITS.W))
+  val rvls = Vec(p(NICWidgetKey).TOKENS_PER_BIGTOKEN, new ReadyValidLast())
+  val pad = UInt(p(NICWidgetKey).BIGTOKEN_PADDING.W)
+
+  override def cloneType: this.type = (new BIGToken).asInstanceOf[this.type]
 }
 
-class HostToNICToken extends Bundle {
-  val data_in = new StreamChannel(64)
+class HostToNICToken(implicit p: Parameters) extends Bundle {
+  val data_in = new StreamChannel(p(NICWidgetKey).TOKEN_WIDTH_BITS)
   val data_in_valid = Bool()
   val data_out_ready = Bool()
+
+  override def cloneType: this.type = (new HostToNICToken).asInstanceOf[this.type]
 }
 
-class NICToHostToken extends Bundle {
-  val data_out = new StreamChannel(64)
+class NICToHostToken(implicit p: Parameters) extends Bundle {
+  val data_out = new StreamChannel(p(NICWidgetKey).TOKEN_WIDTH_BITS)
   val data_out_valid = Bool()
   val data_in_ready = Bool()
+
+  override def cloneType: this.type = (new NICToHostToken).asInstanceOf[this.type]
 }
 
 class SimSimpleNIC extends Endpoint {
@@ -73,13 +87,20 @@ class SimSimpleNIC extends Endpoint {
 }
 
 class SimpleNICWidgetIO(implicit val p: Parameters) extends EndpointWidgetIO()(p) {
-  val hPort = Flipped(HostPort(new NICIOvonly))
+  val netConfig = new IceNetConfig(NET_IF_WIDTH_BITS = p(NICWidgetKey).TOKEN_WIDTH_BITS)
+  val hPort = Flipped(HostPort(new NICIOvonly(netConfig)))
 }
 
-class BigTokenToNICTokenAdapter extends Module {
+/**
+ * Take a BigToken, split it into individual tokens and return it one by one
+ */
+class BigTokenToNICTokenAdapter(implicit p: Parameters) extends Module {
+
+  val config = p(NICWidgetKey)
+
   val io = IO(new Bundle {
     val htnt = DecoupledIO(new HostToNICToken)
-    val pcie_in = Flipped(DecoupledIO(UInt(512.W)))
+    val pcie_in = Flipped(DecoupledIO(UInt(BIGTOKEN_WIDTH_BITS.W)))
   })
 
   val pcieBundled = (new BIGToken).fromBits(io.pcie_in.bits)
@@ -88,48 +109,54 @@ class BigTokenToNICTokenAdapter extends Module {
 
   val loopIter = RegInit(0.U(32.W))
   when (io.htnt.fire()) {
-    loopIter := Mux(loopIter === 6.U, 0.U, loopIter + 1.U)
+    loopIter := Mux(loopIter === (config.TOKENS_PER_BIGTOKEN - 1).U, 0.U, loopIter + 1.U)
   }
 
   io.htnt.bits.data_in.data := pcieBundled.data(loopIter)
-  io.htnt.bits.data_in.keep := 0xFF.U
+  io.htnt.bits.data_in.keep := ((BigInt(1) << (config.TOKEN_WIDTH_BITS/8)) - 1).U
   io.htnt.bits.data_in.last := pcieBundled.rvls(loopIter).data_last
   io.htnt.bits.data_in_valid := pcieBundled.rvls(loopIter).valid
   io.htnt.bits.data_out_ready := pcieBundled.rvls(loopIter).ready
   io.htnt.valid := xactHelper.fire(io.htnt.ready)
-  io.pcie_in.ready := xactHelper.fire(io.pcie_in.valid, loopIter === 6.U)
+  io.pcie_in.ready := xactHelper.fire(io.pcie_in.valid, loopIter === (config.TOKENS_PER_BIGTOKEN - 1).U)
 }
 
-class NICTokenToBigTokenAdapter extends Module {
+/**
+ * Take multiple NICTokens and convert them into a single BigToken to send over PCIE
+ */
+class NICTokenToBigTokenAdapter(implicit p: Parameters) extends Module {
+
+  val config = p(NICWidgetKey)
+
   val io = IO(new Bundle {
     val ntht = Flipped(DecoupledIO(new NICToHostToken))
-    val pcie_out = DecoupledIO(UInt(512.W))
+    val pcie_out = DecoupledIO(UInt(BIGTOKEN_WIDTH_BITS.W))
   })
 
-  // step one, buffer 7 elems into registers. note that the 7th element is here 
+  // step one, buffer config.TOKENS_PER_BIGTOKEN elems into registers. note that the last element is here 
   // just for convenience. in reality, it is not used since we're bypassing to
   // remove a cycle of latency
-  val NTHT_BUF = Reg(Vec(7, new NICToHostToken))
+  val NTHT_BUF = Reg(Vec(config.TOKENS_PER_BIGTOKEN, new NICToHostToken))
   val specialCounter = RegInit(0.U(32.W))
 
   when (io.ntht.valid) {
     NTHT_BUF(specialCounter) := io.ntht.bits
   }
 
-  io.ntht.ready := (specialCounter === 6.U && io.pcie_out.ready) || (specialCounter =/= 6.U)
-  io.pcie_out.valid := specialCounter === 6.U && io.ntht.valid
-  when ((specialCounter =/= 6.U) && io.ntht.valid) {
+  io.ntht.ready := (specialCounter === (config.TOKENS_PER_BIGTOKEN - 1).U && io.pcie_out.ready) || (specialCounter =/= (config.TOKENS_PER_BIGTOKEN - 1).U)
+  io.pcie_out.valid := specialCounter === (config.TOKENS_PER_BIGTOKEN - 1).U && io.ntht.valid
+  when ((specialCounter =/= (config.TOKENS_PER_BIGTOKEN - 1).U) && io.ntht.valid) {
     specialCounter := specialCounter + 1.U
-  } .elsewhen ((specialCounter === 6.U) && io.ntht.valid && io.pcie_out.ready) {
+  } .elsewhen ((specialCounter === (config.TOKENS_PER_BIGTOKEN - 1).U) && io.ntht.valid && io.pcie_out.ready) {
     specialCounter := 0.U
   } .otherwise {
     specialCounter := specialCounter
   }
-  // step two, connect 6 elems + latest one to output (7 items)
+  // step two, connect (config.TOKENS_PER_BIGTOKEN - 1) elems + latest one to output (config.TOKENS_PER_BIGTOKEN items)
   // TODO: attach pcie_out to data
 
   // debug check to help check we're not losing tokens somewhere
-  val token_trace_counter = RegInit(0.U(43.W))
+  val token_trace_counter = RegInit(0.U(config.BIGTOKEN_PADDING.W))
   when (io.pcie_out.fire()) {
     token_trace_counter := token_trace_counter + 1.U
   } .otherwise {
@@ -137,16 +164,16 @@ class NICTokenToBigTokenAdapter extends Module {
   }
 
   val out = Wire(new BIGToken)
-  for (i <- 0 until 6) {
+  for (i <- 0 until (config.TOKENS_PER_BIGTOKEN - 1)) {
     out.data(i) := NTHT_BUF(i).data_out.data
     out.rvls(i).data_last := NTHT_BUF(i).data_out.last
     out.rvls(i).ready := NTHT_BUF(i).data_in_ready
     out.rvls(i).valid := NTHT_BUF(i).data_out_valid
   }
-  out.data(6) := io.ntht.bits.data_out.data
-  out.rvls(6).data_last := io.ntht.bits.data_out.last
-  out.rvls(6).ready := io.ntht.bits.data_in_ready
-  out.rvls(6).valid := io.ntht.bits.data_out_valid
+  out.data((config.TOKENS_PER_BIGTOKEN - 1))           := io.ntht.bits.data_out.data
+  out.rvls((config.TOKENS_PER_BIGTOKEN - 1)).data_last := io.ntht.bits.data_out.last
+  out.rvls((config.TOKENS_PER_BIGTOKEN - 1)).ready     := io.ntht.bits.data_in_ready
+  out.rvls((config.TOKENS_PER_BIGTOKEN - 1)).valid     := io.ntht.bits.data_out_valid
   out.pad := token_trace_counter
 
   io.pcie_out.bits := out.asUInt
@@ -181,7 +208,7 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
   lazy val fromHostCPUQueueDepth = TOKEN_QUEUE_DEPTH
   lazy val toHostCPUQueueDepth   = TOKEN_QUEUE_DEPTH
   // Biancolin: Need to look into this
-  lazy val dmaSize = BigInt((BIG_TOKEN_WIDTH / 8) * TOKEN_QUEUE_DEPTH)
+  lazy val dmaSize = BigInt((BIGTOKEN_WIDTH_BITS / 8) * TOKEN_QUEUE_DEPTH)
 
   val htnt_queue = Module(new Queue(new HostToNICToken, 10))
   val ntht_queue = Module(new Queue(new NICToHostToken, 10))
@@ -234,8 +261,9 @@ class SimpleNICWidget(implicit p: Parameters) extends EndpointWidget()(p)
     val macAddrRegUpper = Reg(UInt(32.W))
     val macAddrRegLower = Reg(UInt(32.W))
     val rlimitSettings = Reg(UInt(32.W))
+    val netConfig = new IceNetConfig(NET_IF_WIDTH_BITS = p(NICWidgetKey).TOKEN_WIDTH_BITS)
 
-    target.rlimit := (new RateLimiterSettings).fromBits(rlimitSettings)
+    target.rlimit := (new RateLimiterSettings(netConfig)).fromBits(rlimitSettings)
     target.macAddr := Cat(macAddrRegUpper, macAddrRegLower)
 
     attach(macAddrRegUpper, "macaddr_upper", WriteOnly)

--- a/sim/src/main/scala/endpoints/TracerVWidget.scala
+++ b/sim/src/main/scala/endpoints/TracerVWidget.scala
@@ -16,7 +16,9 @@ import testchipip.{StreamIO, StreamChannel}
 import icenet.{NICIOvonly, RateLimiterSettings}
 import icenet.IceNIC._
 import junctions.{NastiIO, NastiKey}
-import TokenQueueConsts._
+import PCIeConsts._
+
+case object TracerVTokenQueueDepth extends Field[Int]
 
 class TraceOutputTop(val numTraces: Int)(implicit val p: Parameters) extends Bundle {
   val traces = Vec(numTraces, new TracedInstruction)
@@ -50,8 +52,8 @@ class TracerVWidget(tracerParams: Parameters, num_traces: Int)(implicit p: Param
   val io = IO(new TracerVWidgetIO(tracerParams, num_traces))
 
   // DMA mixin parameters
-  lazy val toHostCPUQueueDepth  = TOKEN_QUEUE_DEPTH
-  lazy val dmaSize = BigInt((BIGTOKEN_WIDTH_BITS  / 8) * TOKEN_QUEUE_DEPTH)
+  lazy val toHostCPUQueueDepth  = p(TracerVTokenQueueDepth)
+  lazy val dmaSize = BigInt((BIGTOKEN_WIDTH_BITS  / 8) * p(TracerVTokenQueueDepth))
 
   val uint_traces = io.hPort.hBits.traces map (trace => trace.asUInt)
   outgoingPCISdat.io.enq.bits := Cat(uint_traces) //io.hPort.hBits.traces(0).asUInt

--- a/sim/src/main/scala/endpoints/TracerVWidget.scala
+++ b/sim/src/main/scala/endpoints/TracerVWidget.scala
@@ -51,7 +51,7 @@ class TracerVWidget(tracerParams: Parameters, num_traces: Int)(implicit p: Param
 
   // DMA mixin parameters
   lazy val toHostCPUQueueDepth  = TOKEN_QUEUE_DEPTH
-  lazy val dmaSize = BigInt((BIG_TOKEN_WIDTH / 8) * TOKEN_QUEUE_DEPTH)
+  lazy val dmaSize = BigInt((BIGTOKEN_WIDTH_BITS  / 8) * TOKEN_QUEUE_DEPTH)
 
   val uint_traces = io.hPort.hBits.traces map (trace => trace.asUInt)
   outgoingPCISdat.io.enq.bits := Cat(uint_traces) //io.hPort.hBits.traces(0).asUInt

--- a/sim/src/main/scala/firesim/SimConfigs.scala
+++ b/sim/src/main/scala/firesim/SimConfigs.scala
@@ -45,10 +45,10 @@ class WithUARTWidget extends Config((site, here, up) => {
   case EndpointKey => up(EndpointKey) ++ EndpointMap(Seq(new SimUART))
 })
 
-class WithSimpleNICWidget(netIfWidthBits: Int = 64) extends Config((site, here, up) => {
+class WithSimpleNICWidget extends Config((site, here, up) => {
   case EndpointKey => up(EndpointKey) ++ EndpointMap(Seq(new SimSimpleNIC))
+  case NICTokenQueueDepth => 6144
   case LoopbackNIC => false
-  case NICWidgetKey => SimpleNICWidgetConfig(TOKEN_WIDTH_BITS = netIfWidthBits)
 })
 
 class WithBlockDevWidget extends Config((site, here, up) => {
@@ -58,6 +58,7 @@ class WithBlockDevWidget extends Config((site, here, up) => {
 class WithTracerVWidget extends Config((site, here, up) => {
   case midas.EndpointKey => up(midas.EndpointKey) ++
     EndpointMap(Seq(new SimTracerV))
+  case TracerVTokenQueueDepth => 6144
 })
 
 // Instantiates an AXI4 memory model that executes (1 / clockDivision) of the frequency
@@ -186,7 +187,7 @@ class FireSimConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new WithDefaultMemModel ++
   new WithTracerVWidget ++
@@ -208,7 +209,7 @@ class FireSimClockDivConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new WithDefaultMemModel(clockDivision = 2) ++
   new BasePlatformConfig)
@@ -217,7 +218,7 @@ class FireSimDDR3Config extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new FCFS16GBQuadRank ++
   new BasePlatformConfig)
@@ -226,7 +227,7 @@ class FireSimDDR3LLC4MBConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new FCFS16GBQuadRankLLC4MB ++
   new BasePlatformConfig)
@@ -235,7 +236,7 @@ class FireSimDDR3FRFCFSConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new FRFCFS16GBQuadRank ++
   new BasePlatformConfig)
@@ -244,7 +245,7 @@ class FireSimDDR3FRFCFSLLC4MBConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new FRFCFS16GBQuadRankLLC4MB ++
   new BasePlatformConfig)
@@ -265,7 +266,7 @@ class FireSimDDR3FRFCFSLLC4MB3ClockDivConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget(netIfWidthBits = 256) ++
+  new WithSimpleNICWidget ++
   new WithBlockDevWidget ++
   new FRFCFS16GBQuadRankLLC4MB3Div ++
   new BasePlatformConfig)

--- a/sim/src/main/scala/firesim/SimConfigs.scala
+++ b/sim/src/main/scala/firesim/SimConfigs.scala
@@ -45,9 +45,10 @@ class WithUARTWidget extends Config((site, here, up) => {
   case EndpointKey => up(EndpointKey) ++ EndpointMap(Seq(new SimUART))
 })
 
-class WithSimpleNICWidget extends Config((site, here, up) => {
+class WithSimpleNICWidget(netIfWidthBits: Int = 64) extends Config((site, here, up) => {
   case EndpointKey => up(EndpointKey) ++ EndpointMap(Seq(new SimSimpleNIC))
   case LoopbackNIC => false
+  case NICWidgetKey => SimpleNICWidgetConfig(TOKEN_WIDTH_BITS = netIfWidthBits)
 })
 
 class WithBlockDevWidget extends Config((site, here, up) => {
@@ -185,7 +186,7 @@ class FireSimConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new WithDefaultMemModel ++
   new WithTracerVWidget ++
@@ -207,7 +208,7 @@ class FireSimClockDivConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new WithDefaultMemModel(clockDivision = 2) ++
   new BasePlatformConfig)
@@ -216,7 +217,7 @@ class FireSimDDR3Config extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new FCFS16GBQuadRank ++
   new BasePlatformConfig)
@@ -225,7 +226,7 @@ class FireSimDDR3LLC4MBConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new FCFS16GBQuadRankLLC4MB ++
   new BasePlatformConfig)
@@ -234,7 +235,7 @@ class FireSimDDR3FRFCFSConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new FRFCFS16GBQuadRank ++
   new BasePlatformConfig)
@@ -243,7 +244,7 @@ class FireSimDDR3FRFCFSLLC4MBConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new FRFCFS16GBQuadRankLLC4MB ++
   new BasePlatformConfig)
@@ -264,7 +265,7 @@ class FireSimDDR3FRFCFSLLC4MB3ClockDivConfig extends Config(
   new WithDesiredHostFrequency(90) ++
   new WithSerialWidget ++
   new WithUARTWidget ++
-  new WithSimpleNICWidget ++
+  new WithSimpleNICWidget(netIfWidthBits = 256) ++
   new WithBlockDevWidget ++
   new FRFCFS16GBQuadRankLLC4MB3Div ++
   new BasePlatformConfig)

--- a/sim/src/main/scala/firesim/TargetConfigs.scala
+++ b/sim/src/main/scala/firesim/TargetConfigs.scala
@@ -85,7 +85,7 @@ class FireSimRocketChipConfig extends Config(
   new WithExtMemSize(0x400000000L) ++ // 16GB
   new WithoutTLMonitors ++
   new WithUARTKey ++
-  new WithNICKey(netIfWidthBits = 256) ++
+  new WithNICKey(netIfWidthBits = 64) ++
   new WithBlockDevice ++
   new WithRocketL2TLBs(1024) ++
   new WithPerfCounters ++
@@ -142,7 +142,7 @@ class FireSimBoomConfig extends Config(
   new WithExtMemSize(0x400000000L) ++ // 16GB
   new WithoutTLMonitors ++
   new WithUARTKey ++
-  new WithNICKey(netIfWidthBits = 256) ++
+  new WithNICKey(netIfWidthBits = 64) ++
   new WithBlockDevice ++
   new WithBoomL2TLBs(1024) ++
   new WithBoomSynthAssertExcludes ++ // Will do nothing unless assertion synth is enabled

--- a/sim/src/main/scala/firesim/TargetConfigs.scala
+++ b/sim/src/main/scala/firesim/TargetConfigs.scala
@@ -26,8 +26,9 @@ class WithUARTKey extends Config((site, here, up) => {
      nRxEntries = 256))
 })
 
-class WithNICKey extends Config((site, here, up) => {
+class WithNICKey(netIfWidthBits: Int = 64) extends Config((site, here, up) => {
   case NICKey => NICConfig(
+    NET_IF_WIDTH_BITS = netIfWidthBits,
     inBufPackets = 64,
     ctrlQueueDepth = 64)
 })
@@ -84,7 +85,7 @@ class FireSimRocketChipConfig extends Config(
   new WithExtMemSize(0x400000000L) ++ // 16GB
   new WithoutTLMonitors ++
   new WithUARTKey ++
-  new WithNICKey ++
+  new WithNICKey(netIfWidthBits = 256) ++
   new WithBlockDevice ++
   new WithRocketL2TLBs(1024) ++
   new WithPerfCounters ++
@@ -141,7 +142,7 @@ class FireSimBoomConfig extends Config(
   new WithExtMemSize(0x400000000L) ++ // 16GB
   new WithoutTLMonitors ++
   new WithUARTKey ++
-  new WithNICKey ++
+  new WithNICKey(netIfWidthBits = 256) ++
   new WithBlockDevice ++
   new WithBoomL2TLBs(1024) ++
   new WithBoomSynthAssertExcludes ++ // Will do nothing unless assertion synth is enabled

--- a/sim/src/main/scala/firesim/Targets.scala
+++ b/sim/src/main/scala/firesim/Targets.scala
@@ -184,7 +184,8 @@ class SupernodeIO(
     val serial = Vec(nNodes, new SerialIO(serialWidth))
     val mem_axi = Vec(nNodes, bagPrototype.cloneType)
     val bdev = Vec(nNodes, new BlockDeviceIO)
-    val net = Vec(nNodes, new NICIOvonly)
+    val netConfig = new IceNetConfig(NET_IF_WIDTH_BITS = p(NICKey).NET_IF_WIDTH_BITS)
+    val net = Vec(nNodes, new NICIOvonly(netConfig))
     val uart = Vec(nNodes, new UARTPortIO)
 
     override def cloneType = new SupernodeIO(nNodes, serialWidth, bagPrototype).asInstanceOf[this.type]

--- a/sim/src/main/scala/firesim/Targets.scala
+++ b/sim/src/main/scala/firesim/Targets.scala
@@ -184,8 +184,7 @@ class SupernodeIO(
     val serial = Vec(nNodes, new SerialIO(serialWidth))
     val mem_axi = Vec(nNodes, bagPrototype.cloneType)
     val bdev = Vec(nNodes, new BlockDeviceIO)
-    val netConfig = new IceNetConfig(NET_IF_WIDTH_BITS = p(NICKey).NET_IF_WIDTH_BITS)
-    val net = Vec(nNodes, new NICIOvonly(netConfig))
+    val net = Vec(nNodes, new NICIOvonly(p(NICKey).NET_IF_WIDTH_BITS))
     val uart = Vec(nNodes, new UARTPortIO)
 
     override def cloneType = new SupernodeIO(nNodes, serialWidth, bagPrototype).asInstanceOf[this.type]

--- a/target-design/switch/baseport.h
+++ b/target-design/switch/baseport.h
@@ -58,31 +58,16 @@ void BasePort::write_flits_to_output() {
     uint64_t flitswritten = 0;
     uint64_t basetime = this_iter_cycles_start;
     uint64_t maxtime = this_iter_cycles_start + LINKLATENCY;
-    //printf("[BASE_PORT %d]: wfto: basetime(%d) maxtime(%d)\n", _portNo, basetime, maxtime);
 
     bool empty_buf = true;
 
     while (!(outputqueue.empty())) {
         switchpacket *thispacket = outputqueue.front();
 
-        //printf("[BASE_PORT %d]: wfto: outputqueue sp: timestamp(%ld) dat_ptr(%p) amtwritten(%d) amtread(%d) sender(%d)\n",
-        //       _portNo,
-        //       thispacket->timestamp,
-        //       thispacket->dat,
-        //       thispacket->amtwritten,
-        //       thispacket->amtread,
-        //       thispacket->sender);
-
         // first, check timing boundaries.
         uint64_t space_available = LINKLATENCY - flitswritten;
         uint64_t outputtimestamp = thispacket->timestamp;
         uint64_t outputtimestampend = outputtimestamp + thispacket->amtwritten;
-
-        //printf("[BASE_PORT %d]: wfto: space_avail(%d) outtimestamp(%ld) outtimestampend(%ld)\n",
-        //        _portNo,
-        //        space_available,
-        //        outputtimestamp,
-        //        outputtimestampend);
 
         // confirm that a) we are allowed to send this out based on timestamp
         // b) we are allowed to send this out based on available space (TODO fix)
@@ -93,12 +78,6 @@ void BasePort::write_flits_to_output() {
             if ((thispacket->amt_read == 0) && (diff > OUTPUT_BUF_SIZE)) {
                 // this packet would've been dropped due to buffer overflow.
                 // so, drop it.
-                //printf("[BASE_PORT %d]: overflow, drop pack: intended timestamp: %ld, current timestamp: %ld, out bufsize in # flits: %ld, diff: %ld\n",
-                //        _portNo,
-                //        outputtimestamp,
-                //        basetime + flitswritten,
-                //        OUTPUT_BUF_SIZE,
-                //        (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
                 outputqueue.pop();
                 free(thispacket->dat);
                 free(thispacket);
@@ -111,15 +90,14 @@ void BasePort::write_flits_to_output() {
             uint64_t timestampdiff = outputtimestamp > basetime ? outputtimestamp - basetime : 0L;
             flitswritten = std::max(flitswritten, timestampdiff);
 
-            //printf("[BASE_PORT %d]: intended timestamp: %ld, actual timestamp: %ld, diff %ld\n",
-            //        _portNo,
-            //        outputtimestamp,
-            //        basetime + flitswritten,
-            //        (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
+            printf("[BASE_PORT %d]: intended timestamp: %ld, actual timestamp: %ld, diff %ld\n",
+                    _portNo,
+                    outputtimestamp,
+                    basetime + flitswritten,
+                    (int64_t)(basetime + flitswritten) - (int64_t)(outputtimestamp));
 
             int i = thispacket->amtread;
             for (;(i < thispacket->amtwritten) && (flitswritten < LINKLATENCY); i++) {
-                //printf("[BASE_PORT %d]: wfto: iter(%d)\n", _portNo, i);
                 write_last_flit(current_output_buf, flitswritten, i == (thispacket->amtwritten-1));
                 write_valid_flit(current_output_buf, flitswritten);
                 write_flit(current_output_buf, flitswritten, (thispacket->dat + (i*FLIT_SIZE_BYTES)));
@@ -131,24 +109,20 @@ void BasePort::write_flits_to_output() {
                     flitswritten += (throttle_denom - throttle_numer + 1);
                 else
                     flitswritten++;
-
-                //printf("[BASE_PORT %d]: wfto: flitswritten(%d)\n", _portNo, flitswritten);
             }
             if (i == thispacket->amtwritten) {
                 // we finished sending this packet, so get rid of it
-                printf("[BASE_PORT %d]: packet timestamp: %ld, len: %ld\n",
-                        _portNo,
-                        basetime + flitswritten,
-                        thispacket->amtwritten);
+                //printf("[BASE_PORT %d]: packet timestamp: %ld, len: %ld\n",
+                //        _portNo,
+                //        basetime + flitswritten,
+                //        thispacket->amtwritten);
                 outputqueue.pop();
                 free(thispacket->dat);
                 free(thispacket);
-                //printf("[BASE_PORT %d]: wfto: outputqueue popped\n", _portNo);
             } else {
                 // we're not done sending this packet, so mark how much has been sent
                 // for the next time
                 thispacket->amtread = i;
-                //printf("[BASE_PORT %d]: wfto: amtread <- %d\n", _portNo, i);
                 break;
             }
         } else {
@@ -164,6 +138,5 @@ void BasePort::write_flits_to_output() {
 
 // initialize output port fullness for this round
 void BasePort::setup_send_buf() {
-    //printf("baseport: setup_send_buf\n");
     memset(current_output_buf, 0, BUFSIZE_BYTES);
 }

--- a/target-design/switch/flit.h
+++ b/target-design/switch/flit.h
@@ -44,7 +44,6 @@ void printArray(uint8_t* in, uint64_t amt){
 uint8_t* get_flit(uint8_t * recv_buf, int tokenid) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
-    //printf("    gf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
     return (recv_buf + (base * BIGTOKEN_SIZE_BYTES) + (FLIT_SIZE_BYTES * (offset + 1)));
 }
 
@@ -58,7 +57,6 @@ uint8_t* get_flit(uint8_t * recv_buf, int tokenid) {
 void write_flit(uint8_t * send_buf, int tokenid, uint8_t * flit_buf) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
-    //printf("    wf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
     memcpy( send_buf + (base * BIGTOKEN_SIZE_BYTES) + (FLIT_SIZE_BYTES * (offset + 1)), flit_buf, FLIT_SIZE_BYTES );
 }
 
@@ -74,31 +72,8 @@ void write_valid_flit(uint8_t * send_buf, int tokenid) {
 
     uint8_t* bigtoken_ptr = send_buf + (base * BIGTOKEN_SIZE_BYTES);
     int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + (offset * 3);
-    //printf("    NEW:\n");
-    //printf("    wvf: flit: (");
-    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    //printf(") offset(%d) bitoffset(%d)\n",
-    //        offset,
-    //        tokenbitoffset);
     
     *(bigtoken_ptr + (tokenbitoffset / 8)) |= (1 << (tokenbitoffset % 8));
-
-    //printf("        after: flit: (");
-    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    //printf(")\n");
-
-    //uint8_t* lrv = send_buf + (base * BIGTOKEN_SIZE_BYTES);
-    //int bitoffset = 43 + (offset * 3);
-    //printf("    ORIG:\n");
-    //printf("    wvf: flit: (");
-    //printArray(lrv, FLIT_SIZE_BYTES);
-    //printf(") offset(%d) bitoffset(%d)\n",
-    //        offset,
-    //        bitoffset);
-    //*(lrv + (bitoffset / 8)) |= (1 << (bitoffset % 8));
-    //printf("        after: flit: (");
-    //printArray(lrv, FLIT_SIZE_BYTES);
-    //printf(")\n");
 }
 
 /**
@@ -114,31 +89,8 @@ int write_last_flit(uint8_t * send_buf, int tokenid, bool is_last) {
     
     uint8_t* bigtoken_ptr = send_buf + (base * BIGTOKEN_SIZE_BYTES);
     int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + 2 + (offset * 3);
-    //printf("    NEW:\n");
-    //printf("    wlf: flit: (");
-    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    //printf(") offset(%d) bitoffset(%d)\n",
-    //        offset,
-    //        tokenbitoffset);
 
     *(bigtoken_ptr + (tokenbitoffset / 8)) |= (is_last << (tokenbitoffset % 8));
-
-    //printf("        after: flit: (");
-    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    //printf(")\n");
-
-    //uint8_t* lrv = send_buf + (base * BIGTOKEN_SIZE_BYTES);
-    //int bitoffset = 45 + (offset * 3);
-    //printf("    ORIG:\n");
-    //printf("    wlf: flit: (");
-    //printArray(lrv, FLIT_SIZE_BYTES);
-    //printf(") offset(%d) bitoffset(%d)\n",
-    //        offset,
-    //        bitoffset);
-    //*(lrv + (bitoffset / 8)) |= (is_last << (bitoffset % 8));
-    //printf("        after: flit: (");
-    //printArray(lrv, FLIT_SIZE_BYTES);
-    //printf(")\n");
 }
 
 /**
@@ -154,21 +106,8 @@ bool is_valid_flit(uint8_t * recv_buf, int tokenid) {
 
     uint8_t* bigtoken_ptr = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
     int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + (offset * 3);
+
     return (*(bigtoken_ptr + (tokenbitoffset / 8)) >> (tokenbitoffset % 8)) & 0x1;
-
-    //uint8_t* lrv = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
-    //int bitoffset = 43 + (offset * 3);
-
-    ////printf("    ivf: isvflit(%d) <- item3(0x%x) item2(0x%x) item1(0x%x) item0(0x%x) offset(%d) bitoff(%d)\n",
-    ////        (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1,
-    ////        *((uint64_t*)(lrv + (3 * FLIT_SIZE_BYTES))),
-    ////        *((uint64_t*)(lrv + (2 * FLIT_SIZE_BYTES))),
-    ////        *((uint64_t*)(lrv + (1 * FLIT_SIZE_BYTES))),
-    ////        *((uint64_t*)(lrv + (0 * FLIT_SIZE_BYTES))),
-    ////        offset,
-    ////        bitoffset);
-
-    //return (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1;
 }
 
 /**
@@ -184,21 +123,8 @@ bool is_last_flit(uint8_t * recv_buf, int tokenid) {
 
     uint8_t* bigtoken_ptr = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
     int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + 2 + (offset * 3);
+
     return (*(bigtoken_ptr + (tokenbitoffset / 8)) >> (tokenbitoffset % 8)) & 0x1;
-
-    //uint8_t* lrv = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
-    //int bitoffset = 45 + (offset * 3);
-
-    ////printf("    ilf: islflit(%d) <- item3(0x%x) item2(0x%x) item1(0x%x) item0(0x%x) offset(%d) bitoff(%d)\n",
-    ////        (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1,
-    ////        *((uint64_t*)(lrv + (3 * FLIT_SIZE_BYTES))),
-    ////        *((uint64_t*)(lrv + (2 * FLIT_SIZE_BYTES))),
-    ////        *((uint64_t*)(lrv + (1 * FLIT_SIZE_BYTES))),
-    ////        *((uint64_t*)(lrv + (0 * FLIT_SIZE_BYTES))),
-    ////        offset,
-    ////        bitoffset);
-
-    //return (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1;
 }
 
 /**
@@ -210,11 +136,6 @@ bool is_last_flit(uint8_t * recv_buf, int tokenid) {
  */
 uint16_t get_port_from_flit(uint8_t* flit_buf, int current_port) {
 
-    //printf("    gpff: flit: (");
-    //printArray(flit_buf, FLIT_SIZE_BYTES);
-    //printf(")\n");
-
-    // TODO: AJG: Check where in the flit the dest mac is
     uint16_t is_multicast = (*((uint64_t*)flit_buf) >> 16) & 0x1;
     uint16_t flit_low = (*((uint64_t*)flit_buf) >> 48) & 0xFFFF; // indicates dest
     uint16_t sendport = (__builtin_bswap16(flit_low));

--- a/target-design/switch/flit.h
+++ b/target-design/switch/flit.h
@@ -1,74 +1,227 @@
+#ifndef FLIT_H
+#define FLIT_H
+
 #include <stdlib.h>
 
 #define BROADCAST_ADJUSTED (0xffff)
 
 /* ----------------------------------------------------
  * buffer flit operations
- *
  * ----------------------------------------------------
+ */ 
+
+class NetworkFlit {
+    public:
+        NetworkFlit();
+        ~NetworkFlit();
+        uint8_t* data_buffer;
+        bool last;
+};
+
+NetworkFlit::NetworkFlit()
+    : last(false) {
+    printf("NetworkFlit Constructed\n");
+    this->data_buffer = (uint8_t*) malloc(FLIT_SIZE_BYTES);
+}
+
+NetworkFlit::~NetworkFlit() {
+    printf("NetworkFlit Deconstructed\n");
+    free(this->data_buffer);
+}
+
+void printArray(uint8_t* in, uint64_t amt){
+    while(--amt > 0){
+        printf("%02x", *(in + amt));
+    }
+    printf("%02x", *(in));
+}
+
+/**
+ * get a flit from recv_buf, given the token id
+ *
+ * @input recv_buf buffer to read from
+ * @input tokenid id to index into the recv_buf
+ * @output ptr within recv_buf where the FLIT_SIZE_BYTES amt of data is held
  */
-// get a flit from recv_buf, given the token id
-uint64_t get_flit(uint8_t * recv_buf, int tokenid) {
+uint8_t* get_flit(uint8_t * recv_buf, int tokenid) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
-    return *(((uint64_t*)recv_buf) + base * 8 + (offset+1));
+    printf("    gf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
+    return (recv_buf + (base * BIGTOKEN_SIZE_BYTES) + (FLIT_SIZE_BYTES * (offset + 1)));
 }
 
-// write a flit to send_buf
-void write_flit(uint8_t * send_buf, int tokenid, uint64_t flit) {
+/**
+ * write a flit to send_buf
+ *
+ * @input send_buf buffer to write flit data to
+ * @input tokenid id to index into the send_buf
+ * @input flit_buf buffer data to move to the send_buf
+ */
+void write_flit(uint8_t * send_buf, int tokenid, uint8_t * flit_buf) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
-    *(((uint64_t*)send_buf) + base * 8 + (offset+1)) = flit;
+    printf("    wf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
+    memcpy( send_buf + (base * BIGTOKEN_SIZE_BYTES) + (FLIT_SIZE_BYTES * (offset + 1)), flit_buf, FLIT_SIZE_BYTES );
 }
 
-// for a particular tokenid, determine if the flit is valid
-int is_valid_flit(uint8_t * recv_buf, int tokenid) {
-    int base = tokenid / TOKENS_PER_BIGTOKEN;
-    int offset = tokenid % TOKENS_PER_BIGTOKEN;
-
-    uint64_t lrv = ((uint64_t*)recv_buf)[base*8];
-    int bitoffset = 43 + (offset * 3);
-    return (lrv >> bitoffset) & 0x1;
-}
-
-int is_last_flit(uint8_t * recv_buf, int tokenid) {
-    int base = tokenid / TOKENS_PER_BIGTOKEN;
-    int offset = tokenid % TOKENS_PER_BIGTOKEN;
-
-    uint64_t lrv = ((uint64_t*)recv_buf)[base*8];
-    int bitoffset = 45 + (offset * 3);
-    return (lrv >> bitoffset) & 0x1;
-}
-
+/**
+ * write a valid to the flit
+ *
+ * @input send_buf buffer to write the valid bit to
+ * @input tokenid id to index into the send_buf
+ */
 void write_valid_flit(uint8_t * send_buf, int tokenid) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
 
-    uint64_t * lrv = ((uint64_t*)send_buf) + base*8;
-    int bitoffset = 43 + (offset * 3);
-    *lrv |= (1L << bitoffset);
+    uint8_t* bigtoken_ptr = send_buf + (base * BIGTOKEN_SIZE_BYTES);
+    int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + (offset * 3);
+    printf("    NEW:\n");
+    printf("    wvf: flit: (");
+    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    printf(") offset(%d) bitoffset(%d)\n",
+            offset,
+            tokenbitoffset);
+    *(bigtoken_ptr + (tokenbitoffset / 8)) |= (1 << (tokenbitoffset % 8));
+    printf("        after: flit: (");
+    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    printf(")\n");
+
+    //uint8_t* lrv = send_buf + (base * BIGTOKEN_SIZE_BYTES);
+    //int bitoffset = 43 + (offset * 3);
+    //printf("    ORIG:\n");
+    //printf("    wvf: flit: (");
+    //printArray(lrv, FLIT_SIZE_BYTES);
+    //printf(") offset(%d) bitoffset(%d)\n",
+    //        offset,
+    //        bitoffset);
+    //*(lrv + (bitoffset / 8)) |= (1 << (bitoffset % 8));
+    //printf("        after: flit: (");
+    //printArray(lrv, FLIT_SIZE_BYTES);
+    //printf(")\n");
 }
 
-int write_last_flit(uint8_t * send_buf, int tokenid, int is_last) {
+/**
+ * write the last field in the flit
+ *
+ * @input send_buf buffer to write the last bit to
+ * @input tokenid id to index into the send_buf
+ * @input is_last bool to write into the last bit spot
+ */
+int write_last_flit(uint8_t * send_buf, int tokenid, bool is_last) {
+    int base = tokenid / TOKENS_PER_BIGTOKEN;
+    int offset = tokenid % TOKENS_PER_BIGTOKEN;
+    
+    uint8_t* bigtoken_ptr = send_buf + (base * BIGTOKEN_SIZE_BYTES);
+    int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + 2 + (offset * 3);
+    printf("    NEW:\n");
+    printf("    wlf: flit: (");
+    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    printf(") offset(%d) bitoffset(%d)\n",
+            offset,
+            tokenbitoffset);
+    *(bigtoken_ptr + (tokenbitoffset / 8)) |= (is_last << (tokenbitoffset % 8));
+    printf("        after: flit: (");
+    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    printf(")\n");
+
+    //uint8_t* lrv = send_buf + (base * BIGTOKEN_SIZE_BYTES);
+    //int bitoffset = 45 + (offset * 3);
+    //printf("    ORIG:\n");
+    //printf("    wlf: flit: (");
+    //printArray(lrv, FLIT_SIZE_BYTES);
+    //printf(") offset(%d) bitoffset(%d)\n",
+    //        offset,
+    //        bitoffset);
+    //*(lrv + (bitoffset / 8)) |= (is_last << (bitoffset % 8));
+    //printf("        after: flit: (");
+    //printArray(lrv, FLIT_SIZE_BYTES);
+    //printf(")\n");
+}
+
+/**
+ * for a particular tokenid, determine if the flit is valid
+ *
+ * @input recv_buf buffer to read from
+ * @input tokenid id to index into the recv_buf
+ * @output bool indicating whether the flit is valid or not
+ */
+bool is_valid_flit(uint8_t * recv_buf, int tokenid) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
 
-    uint64_t * lrv = ((uint64_t*)send_buf) + base*8;
-    int bitoffset = 45 + (offset * 3);
-    *lrv |= (((uint64_t)is_last) << bitoffset);
+    uint8_t* bigtoken_ptr = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
+    int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + (offset * 3);
+    return (*(bigtoken_ptr + (tokenbitoffset / 8)) >> (tokenbitoffset % 8)) & 0x1;
+
+    //uint8_t* lrv = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
+    //int bitoffset = 43 + (offset * 3);
+
+    ////printf("    ivf: isvflit(%d) <- item3(0x%x) item2(0x%x) item1(0x%x) item0(0x%x) offset(%d) bitoff(%d)\n",
+    ////        (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1,
+    ////        *((uint64_t*)(lrv + (3 * FLIT_SIZE_BYTES))),
+    ////        *((uint64_t*)(lrv + (2 * FLIT_SIZE_BYTES))),
+    ////        *((uint64_t*)(lrv + (1 * FLIT_SIZE_BYTES))),
+    ////        *((uint64_t*)(lrv + (0 * FLIT_SIZE_BYTES))),
+    ////        offset,
+    ////        bitoffset);
+
+    //return (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1;
 }
 
-/* get dest mac from flit, then get port from mac */
-uint16_t get_port_from_flit(uint64_t flit, int current_port) {
-    uint16_t is_multicast = (flit >> 16) & 0x1;
-    uint16_t flit_low = (flit >> 48) & 0xFFFF; // indicates dest
+/**
+ * for a particular tokenid, determine if the flit is the last
+ *
+ * @input recv_buf buffer to read from
+ * @input tokenid id to index into the recv_buf
+ * @output bool indicating whether the flit is valid or not
+ */
+bool is_last_flit(uint8_t * recv_buf, int tokenid) {
+    int base = tokenid / TOKENS_PER_BIGTOKEN;
+    int offset = tokenid % TOKENS_PER_BIGTOKEN;
+
+    uint8_t* bigtoken_ptr = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
+    int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + 2 + (offset * 3);
+    return (*(bigtoken_ptr + (tokenbitoffset / 8)) >> (tokenbitoffset % 8)) & 0x1;
+
+    //uint8_t* lrv = recv_buf + (base * BIGTOKEN_SIZE_BYTES);
+    //int bitoffset = 45 + (offset * 3);
+
+    ////printf("    ilf: islflit(%d) <- item3(0x%x) item2(0x%x) item1(0x%x) item0(0x%x) offset(%d) bitoff(%d)\n",
+    ////        (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1,
+    ////        *((uint64_t*)(lrv + (3 * FLIT_SIZE_BYTES))),
+    ////        *((uint64_t*)(lrv + (2 * FLIT_SIZE_BYTES))),
+    ////        *((uint64_t*)(lrv + (1 * FLIT_SIZE_BYTES))),
+    ////        *((uint64_t*)(lrv + (0 * FLIT_SIZE_BYTES))),
+    ////        offset,
+    ////        bitoffset);
+
+    //return (*(lrv + (bitoffset / 8)) >> (bitoffset % 8)) & 0x1;
+}
+
+/**
+ * get dest mac from flit, then get port from mac
+ *
+ * @input flit_buf buffer data to get the port
+ * @input current_port current port
+ * @output uint16_t representing the port from the mac address
+ */
+uint16_t get_port_from_flit(uint8_t* flit_buf, int current_port) {
+
+    printf("    gpff: flit: (");
+    printArray(flit_buf, FLIT_SIZE_BYTES);
+    printf(")\n");
+
+    // TODO: AJG: Check where in the flit the dest mac is
+    uint16_t is_multicast = (*((uint64_t*)flit_buf) >> 16) & 0x1;
+    uint16_t flit_low = (*((uint64_t*)flit_buf) >> 48) & 0xFFFF; // indicates dest
     uint16_t sendport = (__builtin_bswap16(flit_low));
 
     if (is_multicast)
-	return BROADCAST_ADJUSTED;
+        return BROADCAST_ADJUSTED;
 
     sendport = sendport & 0xFFFF;
-    //printf("mac: %04x\n", sendport);
+    printf("    gpff: mac: %04x\n", sendport);
 
     // At this point, we know the MAC address is not a broadcast address,
     // so we can just look up the port in the mac2port table
@@ -78,9 +231,11 @@ uint16_t get_port_from_flit(uint64_t flit, int current_port) {
         // this has been mapped to "any uplink", so pick one
         int randval = rand() % NUMUPLINKS;
         sendport = randval + NUMDOWNLINKS;
-//        printf("sending to random uplink.\n");
-//        printf("port: %04x\n", sendport);
+        printf("    gpff: sending to random uplink.\n");
+        printf("    gpff: port: %04x\n", sendport);
     }
-    //printf("port: %04x\n", sendport);
+    printf("    gpff: port: %04x\n", sendport);
     return sendport;
 }
+
+#endif

--- a/target-design/switch/flit.h
+++ b/target-design/switch/flit.h
@@ -20,12 +20,10 @@ class NetworkFlit {
 
 NetworkFlit::NetworkFlit()
     : last(false) {
-    printf("NetworkFlit Constructed\n");
     this->data_buffer = (uint8_t*) malloc(FLIT_SIZE_BYTES);
 }
 
 NetworkFlit::~NetworkFlit() {
-    printf("NetworkFlit Deconstructed\n");
     free(this->data_buffer);
 }
 
@@ -46,7 +44,7 @@ void printArray(uint8_t* in, uint64_t amt){
 uint8_t* get_flit(uint8_t * recv_buf, int tokenid) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
-    printf("    gf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
+    //printf("    gf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
     return (recv_buf + (base * BIGTOKEN_SIZE_BYTES) + (FLIT_SIZE_BYTES * (offset + 1)));
 }
 
@@ -60,7 +58,7 @@ uint8_t* get_flit(uint8_t * recv_buf, int tokenid) {
 void write_flit(uint8_t * send_buf, int tokenid, uint8_t * flit_buf) {
     int base = tokenid / TOKENS_PER_BIGTOKEN;
     int offset = tokenid % TOKENS_PER_BIGTOKEN;
-    printf("    wf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
+    //printf("    wf: tokenid(%d) base(%d) offset(%d)\n", tokenid, base, offset);
     memcpy( send_buf + (base * BIGTOKEN_SIZE_BYTES) + (FLIT_SIZE_BYTES * (offset + 1)), flit_buf, FLIT_SIZE_BYTES );
 }
 
@@ -76,16 +74,18 @@ void write_valid_flit(uint8_t * send_buf, int tokenid) {
 
     uint8_t* bigtoken_ptr = send_buf + (base * BIGTOKEN_SIZE_BYTES);
     int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + (offset * 3);
-    printf("    NEW:\n");
-    printf("    wvf: flit: (");
-    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    printf(") offset(%d) bitoffset(%d)\n",
-            offset,
-            tokenbitoffset);
+    //printf("    NEW:\n");
+    //printf("    wvf: flit: (");
+    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    //printf(") offset(%d) bitoffset(%d)\n",
+    //        offset,
+    //        tokenbitoffset);
+    
     *(bigtoken_ptr + (tokenbitoffset / 8)) |= (1 << (tokenbitoffset % 8));
-    printf("        after: flit: (");
-    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    printf(")\n");
+
+    //printf("        after: flit: (");
+    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    //printf(")\n");
 
     //uint8_t* lrv = send_buf + (base * BIGTOKEN_SIZE_BYTES);
     //int bitoffset = 43 + (offset * 3);
@@ -114,16 +114,18 @@ int write_last_flit(uint8_t * send_buf, int tokenid, bool is_last) {
     
     uint8_t* bigtoken_ptr = send_buf + (base * BIGTOKEN_SIZE_BYTES);
     int tokenbitoffset = (FLIT_SIZE_BITS - (TOKENS_PER_BIGTOKEN * 3)) + 2 + (offset * 3);
-    printf("    NEW:\n");
-    printf("    wlf: flit: (");
-    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    printf(") offset(%d) bitoffset(%d)\n",
-            offset,
-            tokenbitoffset);
+    //printf("    NEW:\n");
+    //printf("    wlf: flit: (");
+    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    //printf(") offset(%d) bitoffset(%d)\n",
+    //        offset,
+    //        tokenbitoffset);
+
     *(bigtoken_ptr + (tokenbitoffset / 8)) |= (is_last << (tokenbitoffset % 8));
-    printf("        after: flit: (");
-    printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
-    printf(")\n");
+
+    //printf("        after: flit: (");
+    //printArray(bigtoken_ptr, FLIT_SIZE_BYTES);
+    //printf(")\n");
 
     //uint8_t* lrv = send_buf + (base * BIGTOKEN_SIZE_BYTES);
     //int bitoffset = 45 + (offset * 3);
@@ -208,9 +210,9 @@ bool is_last_flit(uint8_t * recv_buf, int tokenid) {
  */
 uint16_t get_port_from_flit(uint8_t* flit_buf, int current_port) {
 
-    printf("    gpff: flit: (");
-    printArray(flit_buf, FLIT_SIZE_BYTES);
-    printf(")\n");
+    //printf("    gpff: flit: (");
+    //printArray(flit_buf, FLIT_SIZE_BYTES);
+    //printf(")\n");
 
     // TODO: AJG: Check where in the flit the dest mac is
     uint16_t is_multicast = (*((uint64_t*)flit_buf) >> 16) & 0x1;
@@ -221,7 +223,7 @@ uint16_t get_port_from_flit(uint8_t* flit_buf, int current_port) {
         return BROADCAST_ADJUSTED;
 
     sendport = sendport & 0xFFFF;
-    printf("    gpff: mac: %04x\n", sendport);
+    //printf("    gpff: mac: %04x\n", sendport);
 
     // At this point, we know the MAC address is not a broadcast address,
     // so we can just look up the port in the mac2port table
@@ -231,10 +233,10 @@ uint16_t get_port_from_flit(uint8_t* flit_buf, int current_port) {
         // this has been mapped to "any uplink", so pick one
         int randval = rand() % NUMUPLINKS;
         sendport = randval + NUMDOWNLINKS;
-        printf("    gpff: sending to random uplink.\n");
-        printf("    gpff: port: %04x\n", sendport);
+        //printf("    gpff: sending to random uplink.\n");
+        //printf("    gpff: port: %04x\n", sendport);
     }
-    printf("    gpff: port: %04x\n", sendport);
+    //printf("    gpff: port: %04x\n", sendport);
     return sendport;
 }
 

--- a/target-design/switch/shmemport.h
+++ b/target-design/switch/shmemport.h
@@ -34,24 +34,26 @@ ShmemPort::ShmemPort(int portNo, char * shmemportname, bool uplink) : BasePort(p
     }
 
     if (uplink) {
-        fprintf(stdout, "Uplink Port\n");
+        fprintf(stdout, "[SHMEM_PORT %d]: Creating Uplink Port\n", portNo);
         recvdirection = "stn";
         senddirection = "nts";
     } else {
-        fprintf(stdout, "Downlink Port\n");
+        fprintf(stdout, "[SHMEM_PORT %d]: Creating Downlink Port\n", portNo);
         recvdirection = "nts";
         senddirection = "stn";
     }
 
     for (int j = 0; j < 2; j++) {
+        // create the shared mem for the recvbuf
         if (shmemportname) {
-            fprintf(stdout, "Using non-slot-id associated shmemportname:\n");
+            fprintf(stdout, "[SHMEM_PORT %d]: Using non-slot-id associated shmemportname\n", portNo);
             sprintf(name, "/port_%s%s_%d", recvdirection, shmemportname, j);
         } else {
-            fprintf(stdout, "Using slot-id associated shmemportname:\n");
+            fprintf(stdout, "[SHMEM_PORT %d]: Using slot-id associated shmemportname\n", portNo);
             sprintf(name, "/port_%s%d_%d", recvdirection, _portNo, j);
         }
-        fprintf(stdout, "opening/creating shmem region\n%s\n", name);
+        fprintf(stdout, "[SHMEM_PORT %d]: Opening/creating shmem region:\n", portNo);
+        fprintf(stdout, "[SHMEM_PORT %d]:     %s\n", portNo, name);
         shmemfd = shm_open(name, shm_flags, S_IRWXU);
 
         while (shmemfd == -1) {
@@ -84,14 +86,16 @@ ShmemPort::ShmemPort(int portNo, char * shmemportname, bool uplink) : BasePort(p
             memset(recvbufs[j], 0, BUFSIZE_BYTES+SHMEM_EXTRABYTES);
         }
 
+        // create the shared mem for the sendbuf
         if (shmemportname) {
-            fprintf(stdout, "Using non-slot-id associated shmemportname:\n");
+            fprintf(stdout, "[SHMEM_PORT %d]: Using non-slot-id associated shmemportname:\n", portNo);
             sprintf(name, "/port_%s%s_%d", senddirection, shmemportname, j);
         } else {
-            fprintf(stdout, "Using slot-id associated shmemportname:\n");
+            fprintf(stdout, "[SHMEM_PORT %d]: Using slot-id associated shmemportname:\n", portNo);
             sprintf(name, "/port_%s%d_%d", senddirection, _portNo, j);
         }
-        fprintf(stdout, "opening/creating shmem region\n%s\n", name);
+        fprintf(stdout, "[SHMEM_PORT %d]: Opening/creating shmem region\n", portNo);
+        fprintf(stdout, "[SHMEM_PORT %d]:     %s\n", portNo, name);
         shmemfd = shm_open(name, shm_flags, S_IRWXU);
 
         while (shmemfd == -1) {
@@ -128,6 +132,8 @@ ShmemPort::ShmemPort(int portNo, char * shmemportname, bool uplink) : BasePort(p
     // setup "current" bufs. tick will swap for shmem passing
     current_input_buf = recvbufs[0];
     current_output_buf = sendbufs[0];
+
+    fprintf(stdout, "[SHMEM_PORT %d]: Done creating port\n", portNo);
 }
 
 void ShmemPort::send() {

--- a/target-design/switch/socketport.h
+++ b/target-design/switch/socketport.h
@@ -40,6 +40,8 @@ SocketClientPort::SocketClientPort(int portNo, char * serverip, int hostport) : 
         sleep(1);
     }
 
+    fprintf(stdout, "Connection success\n");
+
 
     // setup "current" bufs. tick will swap for shmem passing
     current_input_buf = (uint8_t*)calloc(BUFSIZE_BYTES, 1);

--- a/target-design/switch/sshport.h
+++ b/target-design/switch/sshport.h
@@ -1,4 +1,3 @@
-
 #include <queue>
 
 #include <sys/ioctl.h>
@@ -6,32 +5,30 @@
 #include <linux/if_tun.h>
 
 #define NET_IP_ALIGN 2
-#define ETH_MAX_WORDS 190
 #define ETH_MAX_BYTES 1518
-
-struct network_flit {
-    uint64_t data;
-    bool last;
-};
+#define ETH_MAX_WORDS ((ETH_MAX_BYTES + (FLIT_SIZE_BYTES - 1)) / FLIT_SIZE_BYTES) // Round up based on flit size
+#define ETH_EXTRA_FLITS 10 // Arbitrary amount of padding (in flits)
 
 /* The other side of this port is a TAP interface to the host network. 
  * This allows users to ssh into a simulated cluster */
 class SSHPort : public BasePort {
     public:
         SSHPort(int portNo);
+        ~SSHPort();
         void tick();
         void tick_pre();
         void send();
         void recv();
     private:
         int sshtapfd;
-        uint64_t tap_send_buffer[ETH_MAX_WORDS], tap_recv_buffer[ETH_MAX_WORDS];
+        uint8_t* tap_send_buffer;
+        uint8_t* tap_recv_buffer;
         void *tap_send_frame = ((char *) tap_send_buffer) + NET_IP_ALIGN;
         void *tap_recv_frame = ((char *) tap_recv_buffer) + NET_IP_ALIGN;
         int tap_send_idx = 0, tap_len;
         bool tap_can_send = false;
-        std::queue<network_flit> out_flits;
-        std::queue<network_flit> in_flits;
+        std::queue<NetworkFlit*> out_flits;
+        std::queue<NetworkFlit*> in_flits;
 };
 
 /* open TAP device */
@@ -61,6 +58,7 @@ static int tuntap_alloc(const char *dev, int flags) {
 #define ceil_div(n, d) (((n) - 1) / (d) + 1)
 
 SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
+    printf("SSHPort: Construct\n");
     char * slotid = NULL; // placeholder for multiple SSH port support if we need it later
     char devname[DEVNAME_BYTES+1];
     devname[0] = '\0';
@@ -78,11 +76,20 @@ SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
         abort();
     }
 
+    tap_send_buffer = (uint8_t*) malloc( FLIT_SIZE_BYTES*ETH_MAX_WORDS*sizeof(uint8_t) );
+    tap_recv_buffer = (uint8_t*) malloc( FLIT_SIZE_BYTES*ETH_MAX_WORDS*sizeof(uint8_t) );
     current_input_buf = (uint8_t*) calloc(sizeof(uint8_t), BUFSIZE_BYTES);
     current_output_buf = (uint8_t*) calloc(sizeof(uint8_t), BUFSIZE_BYTES);
 }
 
+SSHPort::~SSHPort() {
+    printf("SSHPort: Deconstruct\n");
+    free(tap_send_buffer);
+    free(tap_recv_buffer);
+}
+
 void SSHPort::send() {
+    printf("SSHPort: Send\n");
     // here, we take data that was written to the port by the switch
     // (data is in current_output_buf)
     // and push it into queues to send into the TAP
@@ -96,9 +103,10 @@ void SSHPort::send() {
     // first, push into out_flits queue
     for (int tokenno = 0; tokenno < NUM_TOKENS; tokenno++) {
         if (is_valid_flit(current_output_buf, tokenno)) {
-            struct network_flit flt;
-            flt.data = get_flit(current_output_buf, tokenno);
-            flt.last = is_last_flit(current_output_buf, tokenno);
+            // put data into out_flit queue
+            NetworkFlit* flt = new NetworkFlit;
+            memcpy(flt->data_buffer, get_flit(current_output_buf, tokenno), FLIT_SIZE_BYTES);
+            flt->last = is_last_flit(current_output_buf, tokenno);
             out_flits.push(flt);
         }
     }
@@ -107,8 +115,9 @@ void SSHPort::send() {
     // next, see if there is data to send
     if (!tap_can_send) {
         while (!out_flits.empty()) {
-            tap_send_buffer[tap_send_idx] = out_flits.front().data;
-            tap_can_send = out_flits.front().last;
+            memcpy(tap_send_buffer + (tap_send_idx*FLIT_SIZE_BYTES), out_flits.front()->data_buffer, FLIT_SIZE_BYTES);
+            tap_can_send = out_flits.front()->last;
+            free(out_flits.front());
             out_flits.pop();
             tap_send_idx++;
             if (tap_can_send)
@@ -117,7 +126,7 @@ void SSHPort::send() {
     }
 
     if (tap_can_send) {
-        tap_len = tap_send_idx * sizeof(uint64_t) - NET_IP_ALIGN;
+        tap_len = (tap_send_idx * FLIT_SIZE_BYTES) - NET_IP_ALIGN;
         if (::write(sshtapfd, tap_send_frame, tap_len) >= 0) {
             tap_send_idx = 0;
             tap_can_send = false;
@@ -132,17 +141,18 @@ void SSHPort::send() {
 }
 
 void SSHPort::recv() {
+    printf("SSHPort: Recv\n");
     // clear the input buf leftover from previous cycle
     memset(current_input_buf, 0x0, BUFSIZE_BYTES);
 
     // pull in flits from the TAP
     tap_len = ::read(sshtapfd, tap_recv_frame, ETH_MAX_BYTES);
     if (tap_len >= 0) {
-        int i, n = ceil_div(tap_len + NET_IP_ALIGN, sizeof(uint64_t));
+        int i, n = ceil_div(tap_len + NET_IP_ALIGN, FLIT_SIZE_BYTES);
         for (i = 0; i < n; i++) {
-            struct network_flit flt;
-            flt.data = tap_recv_buffer[i];
-            flt.last = i == (n - 1);
+            NetworkFlit* flt = new NetworkFlit;
+            memcpy(flt->data_buffer, tap_recv_buffer + (i * FLIT_SIZE_BYTES), FLIT_SIZE_BYTES);
+            flt->last = i == (n - 1);
             in_flits.push(flt);
         }
     } else if (errno != EAGAIN) {
@@ -155,9 +165,10 @@ void SSHPort::recv() {
 
     for (int tokenno = 0; tokenno < NUM_TOKENS; tokenno++) {
         if (!in_flits.empty()) {
-            write_last_flit(current_input_buf, tokenno, in_flits.front().last);
+            write_last_flit(current_input_buf, tokenno, in_flits.front()->last);
             write_valid_flit(current_input_buf, tokenno);
-            write_flit(current_input_buf, tokenno, in_flits.front().data);
+            write_flit(current_input_buf, tokenno, in_flits.front()->data_buffer);
+            free(in_flits.front());
             in_flits.pop();
         }
     }

--- a/target-design/switch/sshport.h
+++ b/target-design/switch/sshport.h
@@ -58,7 +58,6 @@ static int tuntap_alloc(const char *dev, int flags) {
 #define ceil_div(n, d) (((n) - 1) / (d) + 1)
 
 SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
-    //printf("SSHPort: Construct\n");
     char * slotid = NULL; // placeholder for multiple SSH port support if we need it later
     char devname[DEVNAME_BYTES+1];
     devname[0] = '\0';
@@ -83,13 +82,11 @@ SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
 }
 
 SSHPort::~SSHPort() {
-    //printf("SSHPort: Deconstruct\n");
     free(tap_send_buffer);
     free(tap_recv_buffer);
 }
 
 void SSHPort::send() {
-    //printf("SSHPort: Send\n");
     // here, we take data that was written to the port by the switch
     // (data is in current_output_buf)
     // and push it into queues to send into the TAP
@@ -141,7 +138,6 @@ void SSHPort::send() {
 }
 
 void SSHPort::recv() {
-    //printf("SSHPort: Recv\n");
     // clear the input buf leftover from previous cycle
     memset(current_input_buf, 0x0, BUFSIZE_BYTES);
 

--- a/target-design/switch/sshport.h
+++ b/target-design/switch/sshport.h
@@ -58,7 +58,7 @@ static int tuntap_alloc(const char *dev, int flags) {
 #define ceil_div(n, d) (((n) - 1) / (d) + 1)
 
 SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
-    printf("SSHPort: Construct\n");
+    //printf("SSHPort: Construct\n");
     char * slotid = NULL; // placeholder for multiple SSH port support if we need it later
     char devname[DEVNAME_BYTES+1];
     devname[0] = '\0';
@@ -83,13 +83,13 @@ SSHPort::SSHPort(int portNo) : BasePort(portNo, false) {
 }
 
 SSHPort::~SSHPort() {
-    printf("SSHPort: Deconstruct\n");
+    //printf("SSHPort: Deconstruct\n");
     free(tap_send_buffer);
     free(tap_recv_buffer);
 }
 
 void SSHPort::send() {
-    printf("SSHPort: Send\n");
+    //printf("SSHPort: Send\n");
     // here, we take data that was written to the port by the switch
     // (data is in current_output_buf)
     // and push it into queues to send into the TAP
@@ -141,7 +141,7 @@ void SSHPort::send() {
 }
 
 void SSHPort::recv() {
-    printf("SSHPort: Recv\n");
+    //printf("SSHPort: Recv\n");
     // clear the input buf leftover from previous cycle
     memset(current_input_buf, 0x0, BUFSIZE_BYTES);
 

--- a/target-design/switch/switch.cc
+++ b/target-design/switch/switch.cc
@@ -11,7 +11,7 @@
 #include <omp.h>
 #include <cstdlib>
 
-#define IGNORE_PRINTF
+//#define IGNORE_PRINTF
 
 #ifdef IGNORE_PRINTF
 #define printf(fmt, ...) (0)
@@ -54,17 +54,27 @@ int throttle_denom = 1;
 #include "switchconfig.h"
 #undef NUMCLIENTSCONFIG
 
+// PARAMETERS FOR NETWORK SIZE
+// Note: These must all change at once AND change with the
+//       flit size in the RTL and FireSim configs
+#define MAX_BW (800)
+#define FLIT_SIZE_BITS (256)
+
 // DO NOT TOUCH
+#define BIGTOKEN_SIZE_BITS (512)
 #define NUM_TOKENS (LINKLATENCY)
-#define TOKENS_PER_BIGTOKEN (7)
-#define BIGTOKEN_BYTES (64)
+
+#define FLIT_SIZE_BYTES (FLIT_SIZE_BITS / 8)
+#define BIGTOKEN_SIZE_BYTES (BIGTOKEN_SIZE_BITS / 8)
+
+#define TOKENS_PER_BIGTOKEN ((uint16_t)((BIGTOKEN_SIZE_BYTES*8)/(FLIT_SIZE_BITS+3)))
 #define NUM_BIGTOKENS (NUM_TOKENS/TOKENS_PER_BIGTOKEN)
-#define BUFSIZE_BYTES (NUM_BIGTOKENS*BIGTOKEN_BYTES)
+#define BUFSIZE_BYTES (NUM_BIGTOKENS*BIGTOKEN_SIZE_BYTES)
 
 // DO NOT TOUCH
 #define SWITCHLAT_NUM_TOKENS (SWITCHLATENCY)
 #define SWITCHLAT_NUM_BIGTOKENS (SWITCHLAT_NUM_TOKENS/TOKENS_PER_BIGTOKEN)
-#define SWITCHLAT_BUFSIZE_BYTES (SWITCHLAT_NUM_BIGTOKENS*BIGTOKEN_BYTES)
+#define SWITCHLAT_BUFSIZE_BYTES (SWITCHLAT_NUM_BIGTOKENS*BIGTOKEN_SIZE_BYTES)
 
 uint64_t this_iter_cycles_start = 0;
 
@@ -100,11 +110,17 @@ for (int port = 0; port < NUMPORTS; port++) {
 
     for (int tokenno = 0; tokenno < NUM_TOKENS; tokenno++) {
         if (is_valid_flit(input_port_buf, tokenno)) {
-            uint64_t flit = get_flit(input_port_buf, tokenno);
+            uint8_t* flit = get_flit(input_port_buf, tokenno);
+
+            printf("PORT[%d]: inbuf_ptr(%p) postprocess flit: (", port, input_port_buf);
+            printArray(flit, FLIT_SIZE_BYTES);
+            printf(")\n");
 
             switchpacket * sp;
             if (!(current_port->input_in_progress)) {
+                printf("PORT[%d]: current_port->input_in_progress is setup as current flit\n", port);
                 sp = (switchpacket*)calloc(sizeof(switchpacket), 1);
+                sp->dat = (uint8_t*)calloc(FLIT_SIZE_BYTES, ETH_MAX_WORDS + ETH_EXTRA_FLITS);
                 current_port->input_in_progress = sp;
 
                 // here is where we inject switching latency. this is min port-to-port latency
@@ -113,8 +129,9 @@ for (int port = 0; port < NUMPORTS; port++) {
             }
             sp = current_port->input_in_progress;
 
-            sp->dat[sp->amtwritten++] = flit;
+            memcpy( sp->dat + ((sp->amtwritten++) * FLIT_SIZE_BYTES), flit, FLIT_SIZE_BYTES);
             if (is_last_flit(input_port_buf, tokenno)) {
+                printf("switch(%d): last flit, push to inputqueue\n", port);
                 current_port->inputqueue.push(sp);
                 current_port->input_in_progress = NULL;
             }
@@ -151,6 +168,7 @@ std::priority_queue<tspacket> pqueue;
 
 for (int i = 0; i < NUMPORTS; i++) {
     while (!(ports[i]->inputqueue.empty())) {
+        printf("PORT[%d]: inputqueue to pqueue\n", i);
         switchpacket * sp = ports[i]->inputqueue.front();
         ports[i]->inputqueue.pop();
         pqueue.push( tspacket { sp->timestamp, sp });
@@ -160,24 +178,44 @@ for (int i = 0; i < NUMPORTS; i++) {
 // next, put back into individual output queues
 while (!pqueue.empty()) {
     switchpacket * tsp = pqueue.top().switchpack;
+    printf("PORT[None]: pqueue tsp: timestamp(%ld) dat_ptr(%p) amtwritten(%d) amtread(%d) sender(%d)\n",
+           tsp->timestamp,
+           tsp->dat,
+           tsp->amtwritten,
+           tsp->amtread,
+           tsp->sender);
     pqueue.pop();
-    uint16_t send_to_port = get_port_from_flit(tsp->dat[0], 0 /* junk remove arg */);
-    printf("packet for port: %x\n", send_to_port);
-    printf("packet timestamp: %ld\n", tsp->timestamp);
+    uint16_t send_to_port = get_port_from_flit(tsp->dat, 0 /* junk remove arg */);
+    printf("PORT[None]: packet for port: %x\n", send_to_port);
+    printf("PORT[None]: packet timestamp: %ld\n", tsp->timestamp);
     if (send_to_port == BROADCAST_ADJUSTED) {
 #define ADDUPLINK (NUMUPLINKS > 0 ? 1 : 0)
+        printf("switch: broadcast\n");
         // this will only send broadcasts to the first (zeroeth) uplink.
         // on a switch receiving broadcast packet from an uplink, this should
         // automatically prevent switch from sending the broadcast to any uplink
         for (int i = 0; i < NUMDOWNLINKS + ADDUPLINK; i++) {
+            printf("PORT[%d]: numdownlinks(%d), numuplinks(%d), iter(%d)\n", i, NUMDOWNLINKS, ADDUPLINK, i);
             if (i != tsp->sender ) {
                 switchpacket * tsp2 = (switchpacket*)malloc(sizeof(switchpacket));
                 memcpy(tsp2, tsp, sizeof(switchpacket));
+                tsp2->dat = (uint8_t*)malloc(FLIT_SIZE_BYTES*(ETH_MAX_WORDS + ETH_EXTRA_FLITS));
+                memcpy(tsp2->dat, tsp->dat, FLIT_SIZE_BYTES*(ETH_MAX_WORDS + ETH_EXTRA_FLITS));
+                printf("PORT[%d]: outputqueue tsp2: timestamp(%ld) dat_ptr(%p) amtwritten(%d) amtread(%d) sender(%d)\n",
+                       i,
+                       tsp2->timestamp,
+                       tsp2->dat,
+                       tsp2->amtwritten,
+                       tsp2->amtread,
+                       tsp2->sender);
                 ports[i]->outputqueue.push(tsp2);
             }
         }
+        printf("PORT[None]: free pqueue tsp\n");
+        free(tsp->dat);
         free(tsp);
     } else {
+        printf("PORT[None]: push tsp to PORT[%d]\n", send_to_port);
         ports[send_to_port]->outputqueue.push(tsp);
     }
 }
@@ -224,15 +262,15 @@ int main (int argc, char *argv[]) {
     switchlat = atoi(argv[2]);
     bandwidth = atoi(argv[3]);
 
-    simplify_frac(bandwidth, 200, &throttle_numer, &throttle_denom);
+    simplify_frac(bandwidth, MAX_BW, &throttle_numer, &throttle_denom);
 
     fprintf(stdout, "Using link latency: %d\n", LINKLATENCY);
     fprintf(stdout, "Using switching latency: %d\n", SWITCHLATENCY);
     fprintf(stdout, "BW throttle set to %d/%d\n", throttle_numer, throttle_denom);
 
-    if ((LINKLATENCY % 7) != 0) {
+    if ((LINKLATENCY % TOKENS_PER_BIGTOKEN) != 0) {
         // if invalid link latency, error out.
-        fprintf(stdout, "INVALID LINKLATENCY. Currently must be multiple of 7 cycles.\n");
+        fprintf(stdout, "INVALID LINKLATENCY. Currently must be multiple of %d cycles.\n", TOKENS_PER_BIGTOKEN);
         exit(1);
     }
 

--- a/target-design/switch/switch.cc
+++ b/target-design/switch/switch.cc
@@ -11,7 +11,7 @@
 #include <omp.h>
 #include <cstdlib>
 
-//#define IGNORE_PRINTF
+#define IGNORE_PRINTF
 
 #ifdef IGNORE_PRINTF
 #define printf(fmt, ...) (0)
@@ -111,13 +111,8 @@ for (int port = 0; port < NUMPORTS; port++) {
         if (is_valid_flit(input_port_buf, tokenno)) {
             uint8_t* flit = get_flit(input_port_buf, tokenno);
 
-            //printf("PORT[%d]: inbuf_ptr(%p) postprocess flit: (", port, input_port_buf);
-            //printArray(flit, FLIT_SIZE_BYTES);
-            //printf(")\n");
-
             switchpacket * sp;
             if (!(current_port->input_in_progress)) {
-                //printf("PORT[%d]: current_port->input_in_progress is setup as current flit\n", port);
                 sp = (switchpacket*)calloc(sizeof(switchpacket), 1);
                 sp->dat = (uint8_t*)calloc(FLIT_SIZE_BYTES, ETH_MAX_WORDS + ETH_EXTRA_FLITS);
                 current_port->input_in_progress = sp;
@@ -130,7 +125,6 @@ for (int port = 0; port < NUMPORTS; port++) {
 
             memcpy( sp->dat + ((sp->amtwritten++) * FLIT_SIZE_BYTES), flit, FLIT_SIZE_BYTES);
             if (is_last_flit(input_port_buf, tokenno)) {
-                //printf("switch(%d): last flit, push to inputqueue\n", port);
                 current_port->inputqueue.push(sp);
                 current_port->input_in_progress = NULL;
             }
@@ -167,7 +161,6 @@ std::priority_queue<tspacket> pqueue;
 
 for (int i = 0; i < NUMPORTS; i++) {
     while (!(ports[i]->inputqueue.empty())) {
-        //printf("PORT[%d]: inputqueue to pqueue\n", i);
         switchpacket * sp = ports[i]->inputqueue.front();
         ports[i]->inputqueue.pop();
         pqueue.push( tspacket { sp->timestamp, sp });
@@ -177,36 +170,22 @@ for (int i = 0; i < NUMPORTS; i++) {
 // next, put back into individual output queues
 while (!pqueue.empty()) {
     switchpacket * tsp = pqueue.top().switchpack;
-    //printf("PORT[None]: pqueue tsp: timestamp(%ld) dat_ptr(%p) amtwritten(%d) amtread(%d) sender(%d)\n",
-    //       tsp->timestamp,
-    //       tsp->dat,
-    //       tsp->amtwritten,
-    //       tsp->amtread,
-    //       tsp->sender);
     pqueue.pop();
     uint16_t send_to_port = get_port_from_flit(tsp->dat, 0 /* junk remove arg */);
-    //printf("packet for port: %x\n", send_to_port);
-    //printf("packet timestamp: %ld\n", tsp->timestamp);
+    printf("[SWITCH] packet for port: %x\n", send_to_port);
+    printf("[SWITCH] packet timestamp: %ld\n", tsp->timestamp);
     if (send_to_port == BROADCAST_ADJUSTED) {
 #define ADDUPLINK (NUMUPLINKS > 0 ? 1 : 0)
-        printf("[SWITCH]: Broadcast\n");
+        //printf("[SWITCH]: Broadcast\n");
         // this will only send broadcasts to the first (zeroeth) uplink.
         // on a switch receiving broadcast packet from an uplink, this should
         // automatically prevent switch from sending the broadcast to any uplink
         for (int i = 0; i < NUMDOWNLINKS + ADDUPLINK; i++) {
-            //printf("PORT[%d]: numdownlinks(%d), numuplinks(%d), iter(%d)\n", i, NUMDOWNLINKS, ADDUPLINK, i);
             if (i != tsp->sender) {
                 switchpacket * tsp2 = (switchpacket*)malloc(sizeof(switchpacket));
                 memcpy(tsp2, tsp, sizeof(switchpacket));
                 tsp2->dat = (uint8_t*)malloc(FLIT_SIZE_BYTES*(ETH_MAX_WORDS + ETH_EXTRA_FLITS));
                 memcpy(tsp2->dat, tsp->dat, FLIT_SIZE_BYTES*(ETH_MAX_WORDS + ETH_EXTRA_FLITS));
-                //printf("PORT[%d]: outputqueue tsp2: timestamp(%ld) dat_ptr(%p) amtwritten(%d) amtread(%d) sender(%d)\n",
-                //       i,
-                //       tsp2->timestamp,
-                //       tsp2->dat,
-                //       tsp2->amtwritten,
-                //       tsp2->amtread,
-                //       tsp2->sender);
                 ports[i]->outputqueue.push(tsp2);
                 //printf("[SWITCH]: Switch packet sent from PORT %d to PORT %d\n", tsp->sender, i);
             }


### PR DESCRIPTION
Things added
- Added support for a parameterized NIC (64b, 128b, 256b).
- Updated documentation to reflect the changes and how to apply them
- Support in config.ini's and TargetConfigs to change it

Tested with:
- run-bw-test.sh
- run-simperf-test-latency.sh
- run-ping-latency.sh
- example_2config with one instance sending packets to the other

Questions:
- I removed the const of TOKEN_QUEUE_DEPTH in favor of individual queue depths for both TracerV and the NIC. Is this fine or should these be linked/the same?
- Should the benchmark .py's be changed to accommodate the different flit sizes (for ex. `deploy/workloads/bw-test-two-instances/bw-test-graph.py` is "hardcoded" to use 64b flits)