### PR TITLE
Specify mode for O_CREAT

### DIFF
--- a/sim/src/main/cc/endpoints/uart.cc
+++ b/sim/src/main/cc/endpoints/uart.cc
@@ -72,7 +72,7 @@ uart_t::uart_t(simif_t* sim, UARTWIDGET_struct * mmio_addrs, int uartno): endpoi
         // also, for these we want to log output to file here.
         std::string uartlogname = std::string("uartlog") + std::to_string(uartno);
         printf("UART logfile is being written to %s\n", uartlogname.c_str());
-        this->loggingfd = open(uartlogname.c_str(), O_RDWR | O_CREAT);
+        this->loggingfd = open(uartlogname.c_str(), O_RDWR | O_CREAT, 0644);
     }
 
     // Don't block on reads if there is nothing typed in


### PR DESCRIPTION
The `open(2)` call with the `O_CREAT` flag requires a third `mode_t` argument for the file mode:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html

```
g++ -w  -pipe -fPIC -g -I/scratch/a_ou/firesim-internal/sim/src/main/cc -I/scratch/a_ou/firesim-internal/sim/src/main/cc/firesim -I/scratch/a_ou/firesim-internal/riscv-tools-install/include -Wno-unused-variable -I/ecad/tools/synopsys/vcs/current/include -D RTLSIM -std=c++11 -Wall -I/scratch/a_ou/firesim-internal/sim/midas/src/main/cc/dramsim2 -I/scratch/a_ou/firesim-internal/sim/midas/src/main/cc -I/scratch/a_ou/firesim-internal/sim/midas/src/main/cc/utils -include /scratch/a_ou/firesim-internal/sim/generated-src/f1/FireSimNoNIC-FireSimHwachaT1L2C1024Config-FireSimDebugConfig/FireSimNoNIC-const.h -DVCS -I/ecad/tools/synopsys/vcs/current/include -O2 -I/ecad/tools/synopsys/vcs/current/include    -c /scratch/a_ou/firesim-internal/sim/src/main/cc/endpoints/uart.cc
In file included from /usr/include/fcntl.h:289:0,
                 from /scratch/a_ou/firesim-internal/sim/src/main/cc/endpoints/uart.cc:5:
In function 'int open(const char*, int, ...)',
    inlined from 'uart_t::uart_t(simif_t*, UARTWIDGET_struct*, int)' at /scratch/a_ou/firesim-internal/sim/src/main/cc/endpoints/uart.cc:75:31:
/usr/include/x86_64-linux-gnu/bits/fcntl2.h:50:26: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
    __open_missing_mode ();
                          ^
filelist:15: recipe for target 'uart.o' failed
make[3]: *** [uart.o] Error 1
```

(It's not yet clear to me why this error manifests only on the millennium cluster with a Hwacha design.)