### PR TITLE
Additional docs example for RTL simulation

### DIFF
--- a/docs/Advanced-Usage/Debugging/RTL-Simulation.rst
+++ b/docs/Advanced-Usage/Debugging/RTL-Simulation.rst
@@ -102,7 +102,14 @@ Run all RISCV-tools assembly and benchmark tests on a verilated simulator.
     make DESIGN=FireSimNoNIC
     make DESIGN=FireSimNoNIC -j run-asm-tests
     make DESIGN=FireSimNoNIC -j run-bmark-tests
+    
+Run all RISCV-tools assembly and benchmark tests on a verilated simulator with waveform dumping.
 
+::
+
+    make DESIGN=FireSimNoNIC verilator-debug
+    make DESIGN=FireSimNoNIC -j run-asm-tests-debug
+    make DESIGN=FireSimNoNIC -j run-bmark-tests-debug
 
 Run rv64ui-p-simple (a single assembly test) on a verilated simulator.
 


### PR DESCRIPTION
Added an example for running all tests with waveform dumping (need to use run-<asm|bmark>-tests-debug, which is not mentioned in original docs)