### PR TITLE
MIDAS Examples Build Support in Manager

### DIFF
--- a/deploy/buildtools/buildafi.py
+++ b/deploy/buildtools/buildafi.py
@@ -31,24 +31,13 @@ def replace_rtl(conf, buildconfig):
     rootLogger.info("Running replace-rtl to generate verilog for " + str(buildconfig.get_chisel_triplet()))
 
     with prefix('cd ' + ddir + '/../'), prefix('source sourceme-f1-manager.sh'), prefix('export CL_DIR={}/../platforms/f1/aws-fpga/{}'.format(ddir, fpgabuilddir)), prefix('cd sim/'), StreamLogger('stdout'), StreamLogger('stderr'):
-        run("""make DESIGN={} TARGET_CONFIG={} PLATFORM_CONFIG={} replace-rtl""".format(
-        buildconfig.DESIGN, buildconfig.TARGET_CONFIG, buildconfig.PLATFORM_CONFIG))
+        run(buildconfig.make_recipe("replace-rtl"))
         run("""mkdir -p {}/results-build/{}/""".format(ddir, builddir))
         run("""cp $CL_DIR/design/cl_firesim_generated.sv {}/results-build/{}/cl_firesim_generated.sv""".format(ddir, builddir))
 
     # build the fpga driver that corresponds with this version of the RTL
-    build_fpga_driver(buildconfig.get_chisel_triplet())
-
-def build_fpga_driver(triplet):
-    """ Build FPGA driver for running simulation """
-    # TODO there is a duplicate of this in runtools
-    ddir = get_deploy_dir()
-    triplet_pieces = triplet.split("-")
-    design = triplet_pieces[0]
-    target_config = triplet_pieces[1]
-    platform_config = triplet_pieces[2]
     with prefix('cd ' + ddir + '/../'), prefix('source sourceme-f1-manager.sh'), prefix('cd sim/'), StreamLogger('stdout'), StreamLogger('stderr'):
-        run("""make DESIGN={} TARGET_CONFIG={} PLATFORM_CONFIG={} f1""".format(design, target_config, platform_config))
+        run(buildconfig.make_recipe("f1"))
 
 @parallel
 def aws_build(global_build_config, bypass=False):

--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -12,6 +12,7 @@ class BuildConfig:
     """ This represents a SINGLE build configuration. """
     def __init__(self, name, buildconfigdict, launch_time):
         self.name = name
+        self.TARGET_PROJECT = buildconfigdict.get('TARGET_PROJECT')
         self.DESIGN = buildconfigdict['DESIGN']
         self.TARGET_CONFIG = buildconfigdict['TARGET_CONFIG']
         self.PLATFORM_CONFIG = buildconfigdict['PLATFORM_CONFIG']
@@ -24,8 +25,7 @@ class BuildConfig:
         return "BuildConfig obj:\n" + pprint.pformat(vars(self), indent=10)
 
     def get_chisel_triplet(self):
-        return """{}-{}-{}""".format(self.DESIGN, self.TARGET_CONFIG,
-                                     self.PLATFORM_CONFIG)
+        return """{}-{}-{}""".format(self.DESIGN, self.TARGET_CONFIG, self.PLATFORM_CONFIG)
 
     def launch_build_instance(self, build_instance_market,
                           spot_interruption_behavior, spot_max_price):
@@ -54,6 +54,15 @@ class BuildConfig:
         """" Get the name of the local build directory. """
         return """{}-{}-{}""".format(self.launch_time,
                                      self.get_chisel_triplet(), self.name)
+
+    # Builds up a string for a make invocation using the tuple variables
+    def make_recipe(self, recipe):
+        return """make {} DESIGN={} TARGET_CONFIG={} PLATFORM_CONFIG={} {}""".format(
+            "" if self.TARGET_PROJECT is None else "TARGET_PROJECT=" + self.TARGET_PROJECT,
+            self.DESIGN,
+            self.TARGET_CONFIG,
+            self.PLATFORM_CONFIG,
+            recipe)
 
 class GlobalBuildConfig:
     """ Configuration class for builds. This is the "global" configfile, i.e.

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -103,3 +103,12 @@ TARGET_CONFIG=SupernodeFireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=FireSimDDR3FRFCFSLLC4MBConfig75MHz
 instancetype=c4.4xlarge
 deploytriplet=None
+
+# MIDAS Examples -- BUILD SUPPORT ONLY; Can't launch driver correctly on runfarm
+[midasexamples-gcd]
+TARGET_PROJECT=midasexamples
+DESIGN=GCD
+TARGET_CONFIG=NoConfig
+PLATFORM_CONFIG=DefaultF1Config
+instancetype=c4.4xlarge
+deploytriplet=None

--- a/docs/Advanced-Usage/Generating-Different-Targets.rst
+++ b/docs/Advanced-Usage/Generating-Different-Targets.rst
@@ -1,5 +1,5 @@
 Targets
-================
+=======
 
 FireSim generates SoC models by transforming RTL emitted by a Chisel
 generator, such as the Rocket SoC generator. Subject to
@@ -20,6 +20,8 @@ transformed and thus used in FireSim:
 4. Asynchronous reset must only be implemented using Rocket Chip's black box async reset. 
    These are replaced with synchronously reset registers using a FIRRTL transformation.
 
+
+.. _generating-different-targets:
 
 Generating Different Target-RTL
 ---------------------------------

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -330,6 +330,7 @@ This specifies hardware parameters of the simulation environment - for example,
 selecting between a Latency-Bandwidth Pipe or DDR3 memory models.
 These are defined in ``firesim/sim/src/main/scala/firesim/SimConfigs.scala``.
 
+
 ``instancetype``
 """""""""""""""""""
 
@@ -346,6 +347,16 @@ above will be used. See the AGFI Tagging section for more details. Most likely,
 you should leave this set to ``None``. This is usually only used if you have
 proprietary RTL that you bake into an FPGA image, but don't want to share with
 users of the simulator.
+
+``TARGET_PROJECT`` `(Optional)`
+"""""""""""""""""""""""""""""""
+
+This specifies the target project in which the target is defined (this is described
+in greater detail :ref:`here<generating-different-targets>`).  If
+``TARGET_PROJECT`` is undefined the manager will default to ``firesim``.
+Setting ``TARGET_PROJECT`` is required for building the MIDAS examples
+(``TARGET_PROJECT=midasexamples``) with the manager, or for building a
+user-provided target project.
 
 .. _config-hwdb:
 

--- a/sim/src/main/cc/midasexamples/Driver.cc
+++ b/sim/src/main/cc/midasexamples/Driver.cc
@@ -42,8 +42,13 @@ class dut_emul_t:
   public DESIGNDRIVERCLASS
 {
 public:
+#ifdef RTLSIM
   dut_emul_t(int argc, char** argv):
     DESIGNDRIVERCLASS(argc, argv) { }
+#else
+  dut_emul_t(int argc, char** argv): simif_f1_t(argc, argv), DESIGNDRIVERCLASS(argc, argv) { }
+#endif
+
 };
 
 int main(int argc, char** argv)

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -26,11 +26,14 @@ src_path = src/main/scala
 chisel_srcs = $(foreach submodule,$(submodules),$(shell find $(base_dir)/$(submodule)/$(src_path) -name "*.scala"))
 
 common_chisel_args = $(patsubst $(base_dir)/%,%,$(GENERATED_DIR)) $(DESIGN_PACKAGE) $(DESIGN) $(TARGET_CONFIG_PACKAGE) $(TARGET_CONFIG) $(PLATFORM_CONFIG_PACKAGE) $(PLATFORM_CONFIG)
+CONF_NAME ?= runtime.conf
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)
 	$(SBT) $(SBT_FLAGS) \
 	"runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
+	# Remove once runtime conf generation is generalized, and something is always emitted
+	touch $(GENERATED_DIR)/$(CONF_NAME)
 
 ##########################
 # Driver Sources & Flags #

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -1,9 +1,15 @@
 # These point at the main class of the target's Chisel generator
-PROJECT ?= firesim.midasexamples
+DESIGN_PACKAGE ?= firesim.midasexamples
 DESIGN ?= GCD
 
+TARGET_CONFIG_PACKAGE ?= firesim.midasexamples
+TARGET_CONFIG ?= NoConfig
+
+PLATFORM_CONFIG_PACKAGE ?= firesim.midasexamples
+PLATFORM_CONFIG ?= DefaultF1Config
+
 base_dir = $(abspath .)
-name_tuple = $(DESIGN)
+name_tuple    := $(DESIGN)-$(TARGET_CONFIG)-$(PLATFORM_CONFIG)
 GENERATED_DIR := $(base_dir)/generated-src/$(PLATFORM)/$(name_tuple)
 OUTPUT_DIR    := $(base_dir)/output/$(PLATFORM)/$(name_tuple)
 
@@ -19,12 +25,12 @@ submodules = . midas \
 src_path = src/main/scala
 chisel_srcs = $(foreach submodule,$(submodules),$(shell find $(base_dir)/$(submodule)/$(src_path) -name "*.scala"))
 
-
-common_chisel_args = $(patsubst $(base_dir)/%,%,$(GENERATED_DIR)) $(PROJECT) $(DESIGN) $(TARGET_PROJECT) $(TARGET_CONFIG) $(PLATFORM_PROJECT) $(PLATFORM_CONFIG)
+common_chisel_args = $(patsubst $(base_dir)/%,%,$(GENERATED_DIR)) $(DESIGN_PACKAGE) $(DESIGN) $(TARGET_CONFIG_PACKAGE) $(TARGET_CONFIG) $(PLATFORM_CONFIG_PACKAGE) $(PLATFORM_CONFIG)
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
-	cd $(base_dir) && $(SBT) $(SBT_FLAGS) \
-	"runMain $(PROJECT).Generator midas $(DESIGN) $(patsubst $(base_dir)/%,%,$(dir $@)) $(PLATFORM) $(macro_lib)"
+	mkdir -p $(@D)
+	$(SBT) $(SBT_FLAGS) \
+	"runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
 
 ##########################
 # Driver Sources & Flags #

--- a/sim/src/main/scala/firesim/Generator.scala
+++ b/sim/src/main/scala/firesim/Generator.scala
@@ -1,11 +1,11 @@
 package firesim.firesim
 
-import java.io.{File, FileWriter}
+import java.io.{File}
 
 import chisel3.experimental.RawModule
 import chisel3.internal.firrtl.{Circuit, Port}
 
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.{ValName, AutoBundle}
 import freechips.rocketchip.devices.debug.DebugIO
 import freechips.rocketchip.util.{HasGeneratorUtilities, ParsedInputNames, ElaborationArtefacts}
 import freechips.rocketchip.system.DefaultTestSuites._
@@ -16,79 +16,26 @@ import freechips.rocketchip.tile.XLen
 
 import boom.system.{BoomTilesKey, BoomTestSuites}
 
-case class FireSimGeneratorArgs(
-  midasFlowKind: String = "midas", // "midas", "strober", "replay"
-  targetDir: String, // Where generated files should be emitted
-  topModuleProject: String = "firesim.firesim",
-  topModuleClass: String,
-  targetConfigProject: String = "firesim.firesim",
-  targetConfigs: String,
-  platformConfigProject: String = "firesim.firesim",
-  platformConfigs: String) {
+import firesim.util.{GeneratorArgs, HasTargetAgnosticUtilites}
 
-  def targetNames(): ParsedInputNames =
-    ParsedInputNames(targetDir, topModuleProject, topModuleClass, targetConfigProject, targetConfigs)
-
-  def platformNames(): ParsedInputNames =
-    ParsedInputNames(targetDir, "Unused", "Unused", platformConfigProject, platformConfigs)
-
-  def tupleName(): String = s"$topModuleClass-$targetConfigs-$platformConfigs"
-}
-
-object FireSimGeneratorArgs {
-  def apply(a: Seq[String]): FireSimGeneratorArgs = {
-    require(a.size == 8, "Usage: sbt> run [midas | strober | replay] " +
-      "TargetDir TopModuleProjectName TopModuleName ConfigProjectName ConfigNameString HostConfig")
-    FireSimGeneratorArgs(a(0), a(1), a(2), a(3), a(4), a(5), a(6), a(7))
-  }
-
-  // Shortform useful when all classes are local to the firesim.firesim package
-  def apply(targetName: String, targetConfig: String, platformConfig: String): FireSimGeneratorArgs =
-  FireSimGeneratorArgs(
-    targetDir = "generated-src/",
-    topModuleClass = targetName,
-    targetConfigs = targetConfig,
-    platformConfigs = platformConfig
-  )
-}
-
-trait HasFireSimGeneratorUtilities extends HasGeneratorUtilities with HasTestSuites {
-  // We reuse this trait in the scala tests and in a top-level App, where this
-  // this structure will be populated with CML arguments
-  def generatorArgs: FireSimGeneratorArgs
-
-  def getGenerator(targetNames: ParsedInputNames, params: Parameters): RawModule = {
-    implicit val valName = ValName(targetNames.topModuleClass)
-    targetNames.topModuleClass match {
-      case "FireSim"  => LazyModule(new FireSim()(params)).module
-      case "FireBoom" => LazyModule(new FireBoom()(params)).module
-      case "FireSimNoNIC"  => LazyModule(new FireSimNoNIC()(params)).module
-      case "FireBoomNoNIC" => LazyModule(new FireBoomNoNIC()(params)).module
-      case "FireSimSupernode" => new FireSimSupernode()(params)
-    }
-  }
-
+trait HasFireSimGeneratorUtilities extends HasTargetAgnosticUtilites with HasTestSuites {
   lazy val names = generatorArgs.targetNames
   lazy val longName = names.topModuleClass
   // Use a second parsedInputNames to reuse RC's handy config lookup functions
   lazy val hostNames = generatorArgs.platformNames
   lazy val targetParams = getParameters(names.fullConfigClasses)
   lazy val target = getGenerator(names, targetParams)
-  lazy val testDir = new File(names.targetDir)
+  // For HasTestSuites
+  lazy val testDir = genDir
   val targetTransforms = Seq(
     firesim.passes.AsyncResetRegPass,
     firesim.passes.PlusArgReaderPass
   )
   lazy val hostTransforms = Seq(
-    new firesim.passes.ILATopWiringTransform(testDir)
+    new firesim.passes.ILATopWiringTransform(genDir)
   )
 
-  // While this is called the HostConfig, it does also include configurations
-  // that control what models are instantiated
-  lazy val hostParams = getParameters(
-    hostNames.fullConfigClasses ++
-    names.fullConfigClasses
-  ).alterPartial({ case midas.OutputDir => testDir })
+  lazy val hostParams = getHostParameters(names, hostNames)
 
   def elaborateAndCompileWithMidas() {
     val c3circuit = chisel3.Driver.elaborate(() => target)
@@ -104,7 +51,7 @@ trait HasFireSimGeneratorUtilities extends HasGeneratorUtilities with HasTestSui
     generatorArgs.midasFlowKind match {
       case "midas" | "strober" =>
         midas.MidasCompiler(
-          chirrtl, annos, portList, testDir, None, targetTransforms, hostTransforms
+          chirrtl, annos, portList, genDir, None, targetTransforms, hostTransforms
         )(hostParams alterPartial {case midas.EnableSnapshot => generatorArgs.midasFlowKind == "strober" })
     // Need replay
     }
@@ -114,25 +61,6 @@ trait HasFireSimGeneratorUtilities extends HasGeneratorUtilities with HasTestSui
   def generateTestSuiteMakefrags {
     addTestSuites(names.topModuleClass, targetParams)
     writeOutputFile(s"$longName.d", TestGeneration.generateMakefrag) // Subsystem-specific test suites
-  }
-
-  def writeOutputFile(fname: String, contents: String): File = {
-    val f = new File(testDir, fname)
-    val fw = new FileWriter(f)
-    fw.write(contents)
-    fw.close
-    f
-  }
-
-  // Capture FPGA-toolflow related verilog defines
-  def generateHostVerilogHeader() {
-    val headerName = "cl_firesim_generated_defines.vh"
-    val requestedFrequency = hostParams(DesiredHostFrequency)
-    val availableFrequenciesMhz = Seq(190, 175, 160, 90, 85, 75)
-    if (!availableFrequenciesMhz.contains(requestedFrequency)) {
-      throw new RuntimeException(s"Requested frequency (${requestedFrequency} MHz) is not available.\nAllowed options: ${availableFrequenciesMhz} MHz")
-    }
-    writeOutputFile(headerName, s"`define SELECTED_FIRESIM_CLOCK ${requestedFrequency}\n")
   }
 
   // Output miscellaneous files produced as a side-effect of elaboration
@@ -221,8 +149,8 @@ trait HasTestSuites {
 }
 
 object FireSimGenerator extends App with HasFireSimGeneratorUtilities {
-  lazy val generatorArgs = FireSimGeneratorArgs(args)
-
+  lazy val generatorArgs = GeneratorArgs(args)
+  lazy val genDir = new File(names.targetDir)
   elaborateAndCompileWithMidas
   generateTestSuiteMakefrags
   generateHostVerilogHeader
@@ -235,7 +163,8 @@ object FireSimGenerator extends App with HasFireSimGeneratorUtilities {
 //   1: Output directory (same as above)
 //   Remaining argments are the same as above
 object FireSimRuntimeConfGenerator extends App with HasFireSimGeneratorUtilities {
-  lazy val generatorArgs = FireSimGeneratorArgs(args)
+  lazy val generatorArgs = GeneratorArgs(args)
+  lazy val genDir = new File(names.targetDir)
   // We need the scala instance of an elaborated memory-model, so that settings
   // may be legalized against the generated hardware. TODO: Currently these
   // settings aren't dependent on the target-AXI4 widths (~bug); this will need

--- a/sim/src/main/scala/midasexamples/Config.scala
+++ b/sim/src/main/scala/midasexamples/Config.scala
@@ -10,6 +10,7 @@ import junctions._
 class NoConfig extends Config(Parameters.empty)
 // This is incomplete and must be mixed into a complete platform config
 class DefaultF1Config extends Config(new Config((site, here, up) => {
+    case firesim.firesim.DesiredHostFrequency => 75
     case SynthAsserts => true
     case SynthPrints => true
 }) ++ new Config(new firesim.firesim.WithDefaultMemModel ++ new midas.F1Config))

--- a/sim/src/main/scala/midasexamples/Config.scala
+++ b/sim/src/main/scala/midasexamples/Config.scala
@@ -7,11 +7,12 @@ import midas.widgets._
 import freechips.rocketchip.config._
 import junctions._
 
+class NoConfig extends Config(Parameters.empty)
 // This is incomplete and must be mixed into a complete platform config
-class DefaultMIDASConfig extends Config(new Config((site, here, up) => {
+class DefaultF1Config extends Config(new Config((site, here, up) => {
     case SynthAsserts => true
     case SynthPrints => true
-}) ++ new Config(new firesim.firesim.WithDefaultMemModel))
+}) ++ new Config(new firesim.firesim.WithDefaultMemModel ++ new midas.F1Config))
 
 class PointerChaserConfig extends Config((site, here, up) => {
   case MemSize => BigInt(1 << 30) // 1 GB
@@ -19,4 +20,5 @@ class PointerChaserConfig extends Config((site, here, up) => {
   case CacheBlockBytes => 64
   case CacheBlockOffsetBits => chisel3.util.log2Up(here(CacheBlockBytes))
   case NastiKey => NastiParameters(dataBits = 64, addrBits = 32, idBits = 3)
+  case Seed => System.currentTimeMillis
 })

--- a/sim/src/main/scala/midasexamples/Generator.scala
+++ b/sim/src/main/scala/midasexamples/Generator.scala
@@ -6,44 +6,36 @@ import midas._
 import freechips.rocketchip.config.Config
 import java.io.File
 
-trait GeneratorUtils {
-  def targetName: String
-  def genDir: File
-  def platform: midas.PlatformType
+import firesim.util.{GeneratorArgs, HasTargetAgnosticUtilites}
 
-  def dut = targetName match {
-    case "PointerChaser" =>
-      new PointerChaser()((new PointerChaserConfig).toInstance)
-    case _ =>
-      Class.forName(s"firesim.midasexamples.${targetName}")
-           .getConstructors.head
-           .newInstance()
-           .asInstanceOf[chisel3.experimental.RawModule]
-  }
-  def midasParams = (platform match {
-    case midas.F1       => new Config(new DefaultMIDASConfig ++ new midas.F1Config)
-  }).toInstance
+trait GeneratorUtils extends HasTargetAgnosticUtilites {
+  lazy val names = generatorArgs.targetNames
+  lazy val targetParams = getParameters(names.fullConfigClasses)
+  lazy val target = getGenerator(names, targetParams)
+  lazy val hostNames = generatorArgs.platformNames
+  lazy val hostParams = getHostParameters(names, hostNames)
 
- lazy val hostTransforms = Seq(
+  lazy val hostTransforms = Seq(
     new firesim.passes.ILATopWiringTransform(genDir)
   )
 
-  def compile() { MidasCompiler(dut, genDir, hostTransforms = hostTransforms)(midasParams) }
+  def compile() { MidasCompiler(target, genDir, hostTransforms = hostTransforms)(hostParams) }
   def compileWithSnaptshotting() {
-    MidasCompiler(dut, genDir, hostTransforms = hostTransforms)(
-      midasParams alterPartial { case midas.EnableSnapshot => true })
-  }
-  def compileWithReplay() {
-    strober.replay.Compiler(dut, genDir)
+    MidasCompiler(target, genDir, hostTransforms = hostTransforms)(
+      hostParams alterPartial { case midas.EnableSnapshot => true })
   }
 }
 
 object Generator extends App with GeneratorUtils {
-  lazy val targetName = args(1)
-  lazy val genDir = new File(args(2))
-  lazy val platform = args(3) match {
-    case "f1" => midas.F1
-    case x => throw new RuntimeException(s"${x} platform is not supported in FireSim")
-  }
+  lazy val generatorArgs = GeneratorArgs(args)
+  lazy val genDir = new File(names.targetDir)
+
+  //lazy val targetName = args(1)
+  //lazy val genDir = new File(args(2))
+  //lazy val platform = args(3) match {
+  //  case "f1" => midas.F1
+  //  case x => throw new RuntimeException(s"${x} platform is not supported in FireSim")
+  //}
   compile
+  generateHostVerilogHeader
 }

--- a/sim/src/main/scala/midasexamples/Generator.scala
+++ b/sim/src/main/scala/midasexamples/Generator.scala
@@ -29,13 +29,6 @@ trait GeneratorUtils extends HasTargetAgnosticUtilites {
 object Generator extends App with GeneratorUtils {
   lazy val generatorArgs = GeneratorArgs(args)
   lazy val genDir = new File(names.targetDir)
-
-  //lazy val targetName = args(1)
-  //lazy val genDir = new File(args(2))
-  //lazy val platform = args(3) match {
-  //  case "f1" => midas.F1
-  //  case x => throw new RuntimeException(s"${x} platform is not supported in FireSim")
-  //}
   compile
   generateHostVerilogHeader
 }

--- a/sim/src/main/scala/midasexamples/PointerChaser.scala
+++ b/sim/src/main/scala/midasexamples/PointerChaser.scala
@@ -11,13 +11,13 @@ case object MemSize extends Field[Int]
 case object NMemoryChannels extends Field[Int]
 case object CacheBlockBytes extends Field[Int]
 case object CacheBlockOffsetBits extends Field[Int]
+case object Seed extends Field[Long]
 
 // This module computes the sum of a simple singly linked-list, where each
 // node consists of a pointer to the next node and a 64 bit SInt
 // Inputs: (Decoupled) start address: the location of the first node in memory
 // Outputs: (Decoupled) result: The sum of the list
-class PointerChaser(seed: Long = System.currentTimeMillis)
-                   (implicit val p: Parameters) extends Module with HasNastiParameters {
+class PointerChaser(implicit val p: Parameters) extends Module with HasNastiParameters {
   val io = IO(new Bundle {
     val nasti = new NastiIO
     val result = Decoupled(SInt(nastiXDataBits.W))
@@ -83,7 +83,7 @@ class PointerChaser(seed: Long = System.currentTimeMillis)
   memoryIF.ar.valid := arValid
   memoryIF.r.ready := true.B
 
-  val rnd = new scala.util.Random(seed)
+  val rnd = new scala.util.Random(p(Seed))
   memoryIF.aw.bits := NastiWriteAddressChannel(
     id = rnd.nextInt(1 << nastiWIdBits).U,
     len = rnd.nextInt(1 << nastiXLenBits).U,

--- a/sim/src/main/scala/util/GeneratorUtils.scala
+++ b/sim/src/main/scala/util/GeneratorUtils.scala
@@ -1,0 +1,92 @@
+//See LICENSE for license details.
+
+package firesim.util
+
+import java.io.{File, FileWriter}
+
+import chisel3.experimental.RawModule
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy.{ValName, LazyModule}
+import freechips.rocketchip.util.{HasGeneratorUtilities, ParsedInputNames}
+
+import firesim.firesim.DesiredHostFrequency
+
+// Contains FireSim generator utilities that can be reused in MIDAS examples
+trait HasTargetAgnosticUtilites extends HasGeneratorUtilities {
+  def generatorArgs: firesim.util.GeneratorArgs
+  def hostParams: Parameters
+  def genDir: File
+
+  def writeOutputFile(fname: String, contents: String): File = {
+    val f = new File(genDir, fname)
+    val fw = new FileWriter(f)
+    fw.write(contents)
+    fw.close
+    f
+  }
+
+  // Capture FPGA-toolflow related verilog defines
+  def generateHostVerilogHeader() {
+    val headerName = "cl_firesim_generated_defines.vh"
+    val requestedFrequency = hostParams(DesiredHostFrequency)
+    val availableFrequenciesMhz = Seq(190, 175, 160, 90, 85, 75)
+    if (!availableFrequenciesMhz.contains(requestedFrequency)) {
+      throw new RuntimeException(s"Requested frequency (${requestedFrequency} MHz) is not available.\nAllowed options: ${availableFrequenciesMhz} MHz")
+    }
+    writeOutputFile(headerName, s"`define SELECTED_FIRESIM_CLOCK ${requestedFrequency}\n")
+  }
+
+  def getGenerator(targetNames: ParsedInputNames, params: Parameters): RawModule = {
+    implicit val valName = ValName(targetNames.topModuleClass)
+    implicit val p: Parameters = params
+    val cls = Class.forName(targetNames.fullTopModuleClass)
+    val inst = try {
+      // Check if theres a constructor that accepts a Parameters object
+      cls.getConstructor(classOf[Parameters]).newInstance(params)
+    } catch {
+      // Otherwise try to fallback on an argument-less constructor
+      case e: java.lang.NoSuchMethodException => cls.getConstructor().newInstance()
+    }
+    inst match {
+      case m: RawModule => m
+      case l: LazyModule => LazyModule(l).module
+    }
+  }
+
+  // While this is called the HostConfig, it does also include configurations
+  // that control what models are instantiated
+  def getHostParameters(targetNames: ParsedInputNames, hostNames: ParsedInputNames): Parameters =
+    getParameters(
+      hostNames.fullConfigClasses ++
+      targetNames.fullConfigClasses
+    ).alterPartial({ case midas.OutputDir => genDir })
+}
+
+case class GeneratorArgs(
+  midasFlowKind: String, // "midas", "strober", "replay"
+  targetDir: String, // Where generated files should be emitted
+  topModuleProject: String,
+  topModuleClass: String,
+  targetConfigProject: String,
+  targetConfigs: String,
+  platformConfigProject: String,
+  platformConfigs: String) {
+
+  def targetNames(): ParsedInputNames =
+    ParsedInputNames(targetDir, topModuleProject, topModuleClass, targetConfigProject, targetConfigs)
+
+  def platformNames(): ParsedInputNames =
+    ParsedInputNames(targetDir, "Unused", "Unused", platformConfigProject, platformConfigs)
+
+  def tupleName(): String = s"$topModuleClass-$targetConfigs-$platformConfigs"
+}
+
+// Companion object to build the GeneratorArgs from the args passed to App
+object GeneratorArgs {
+  def apply(a: Seq[String]): GeneratorArgs = {
+    require(a.size == 8, "Usage: sbt> run [midas | strober | replay] " +
+      "TargetDir TopModuleProjectName TopModuleName ConfigProjectName ConfigNameString HostConfig")
+    GeneratorArgs(a(0), a(1), a(2), a(3), a(4), a(5), a(6), a(7))
+  }
+}

--- a/sim/src/test/scala/firesim/ScalaTestSuite.scala
+++ b/sim/src/test/scala/firesim/ScalaTestSuite.scala
@@ -11,12 +11,26 @@ import freechips.rocketchip.system.{RocketTestSuite, BenchmarkTestSuite}
 import freechips.rocketchip.system.TestGeneration._
 import freechips.rocketchip.system.DefaultTestSuites._
 
+import firesim.util.GeneratorArgs
+
 abstract class FireSimTestSuite(
-    val generatorArgs: FireSimGeneratorArgs,
+    topModuleClass: String,
+    targetConfigs: String,
+    platformConfigs: String,
     N: Int = 8
   ) extends firesim.midasexamples.TestSuiteCommon with HasFireSimGeneratorUtilities {
   import scala.concurrent.duration._
   import ExecutionContext.Implicits.global
+
+  lazy val generatorArgs = GeneratorArgs(
+    midasFlowKind = "midas",
+    targetDir = "generated-src",
+    topModuleProject = "firesim.firesim",
+    topModuleClass = topModuleClass,
+    targetConfigProject = "firesim.firesim",
+    targetConfigs = targetConfigs,
+    platformConfigProject = "firesim.firesim",
+    platformConfigs = platformConfigs)
 
   // From HasFireSimGeneratorUtilities
   // For the firesim utilities to use the same directory as the test suite
@@ -95,16 +109,9 @@ abstract class FireSimTestSuite(
   runSuite("verilator")(FastBlockdevTests)
 }
 
-class RocketF1Tests extends FireSimTestSuite(
-  FireSimGeneratorArgs("FireSimNoNIC", "FireSimRocketChipConfig", "FireSimConfig"))
-
-class RocketF1ClockDivTests extends FireSimTestSuite(
-  FireSimGeneratorArgs("FireSimNoNIC", "FireSimRocketChipConfig", "FireSimClockDivConfig"))
-
-class BoomF1Tests extends FireSimTestSuite(
-  FireSimGeneratorArgs("FireBoomNoNIC", "FireSimBoomConfig", "FireSimConfig"))
-
-class RocketNICF1Tests extends FireSimTestSuite(
-  FireSimGeneratorArgs("FireSim", "FireSimRocketChipConfig", "FireSimConfig")) {
+class RocketF1Tests extends FireSimTestSuite("FireSimNoNIC", "FireSimRocketChipConfig", "FireSimConfig")
+class RocketF1ClockDivTests extends FireSimTestSuite("FireSimNoNIC", "FireSimRocketChipConfig", "FireSimClockDivConfig")
+class BoomF1Tests extends FireSimTestSuite("FireBoomNoNIC", "FireSimBoomConfig", "FireSimConfig")
+class RocketNICF1Tests extends FireSimTestSuite("FireSim", "FireSimRocketChipConfig", "FireSimConfig") {
   runSuite("verilator")(NICLoopbackTests)
 }

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -5,16 +5,31 @@ import java.io.File
 import scala.sys.process.{stringSeqToProcess, ProcessLogger}
 import scala.io.Source
 
+import firesim.util.GeneratorArgs
+
 abstract class TutorialSuite(
     val targetName: String, // See GeneratorUtils
-    val platform: midas.PlatformType, // See TestSuiteCommon
+    targetConfigs: String = "NoConfig",
     tracelen: Int = 8,
     simulationArgs: Seq[String] = Seq()
   ) extends TestSuiteCommon with GeneratorUtils {
 
+  lazy val generatorArgs = GeneratorArgs(
+    midasFlowKind = "midas",
+    targetDir = "generated-src",
+    topModuleProject = "firesim.midasexamples",
+    topModuleClass = targetName,
+    targetConfigProject = "firesim.midasexamples",
+    targetConfigs = targetConfigs,
+    platformConfigProject = "firesim.midasexamples",
+    platformConfigs = "DefaultF1Config")
+
   val args = Seq(s"+tracelen=$tracelen") ++ simulationArgs
-  val commonMakeArgs = Seq(s"TARGET_PROJECT=midasexamples", s"DESIGN=$targetName")
-  val targetTuple = targetName
+  val commonMakeArgs = Seq(s"TARGET_PROJECT=midasexamples",
+                           s"DESIGN=$targetName",
+                           s"TARGET_CONFIG=${generatorArgs.targetConfigs}")
+  val targetTuple = generatorArgs.tupleName
+  override lazy val platform = hostParams(midas.Platform)
 
   //implicit val p = (platform match {
   //  case midas.F1 => new midas.F1Config
@@ -97,25 +112,26 @@ abstract class TutorialSuite(
   runTest("vcs", true)
 }
 
-class PointerChaserF1Test extends TutorialSuite("PointerChaser", midas.F1, 8, Seq("`cat runtime.conf`"))
-class GCDF1Test extends TutorialSuite("GCD", midas.F1, 3)
+class PointerChaserF1Test extends TutorialSuite(
+  "PointerChaser", "PointerChaserConfig", simulationArgs = Seq("`cat runtime.conf`"))
+class GCDF1Test extends TutorialSuite("GCD")
 // Hijack Parity to test all of the Midas-level backends
-class ParityF1Test extends TutorialSuite("Parity", midas.F1) {
+class ParityF1Test extends TutorialSuite("Parity") {
   runTest("verilator", true)
   runTest("vcs")
 }
-class ShiftRegisterF1Test extends TutorialSuite("ShiftRegister", midas.F1)
-class ResetShiftRegisterF1Test extends TutorialSuite("ResetShiftRegister", midas.F1)
-class EnableShiftRegisterF1Test extends TutorialSuite("EnableShiftRegister", midas.F1)
-class StackF1Test extends TutorialSuite("Stack", midas.F1, 8)
-class RiscF1Test extends TutorialSuite("Risc", midas.F1, 64)
-class RiscSRAMF1Test extends TutorialSuite("RiscSRAM", midas.F1, 64)
-class AssertModuleF1Test extends TutorialSuite("AssertModule", midas.F1)
-class PrintfModuleF1Test extends TutorialSuite("PrintfModule", midas.F1,
+class ShiftRegisterF1Test extends TutorialSuite("ShiftRegister")
+class ResetShiftRegisterF1Test extends TutorialSuite("ResetShiftRegister")
+class EnableShiftRegisterF1Test extends TutorialSuite("EnableShiftRegister")
+class StackF1Test extends TutorialSuite("Stack")
+class RiscF1Test extends TutorialSuite("Risc")
+class RiscSRAMF1Test extends TutorialSuite("RiscSRAM")
+class AssertModuleF1Test extends TutorialSuite("AssertModule")
+class PrintfModuleF1Test extends TutorialSuite("PrintfModule",
   simulationArgs = Seq("+print-human-readable", "+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }
-class NarrowPrintfModuleF1Test extends TutorialSuite("NarrowPrintfModule", midas.F1,
+class NarrowPrintfModuleF1Test extends TutorialSuite("NarrowPrintfModule",
   simulationArgs = Seq("+print-human-readable", "+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }


### PR DESCRIPTION
This PR updates the midas examples generator and scalatests to more closely resemble Firesim. This makes it easier to extend the manager to deploy midas examples, and DRYs out a bunch of generator stuff. 

I put target-agnostic utilities in the package `firesim.util`. 

This change is smaller than it appears as it is mostly shuffling scala around to reuse utilities in FireSim's generator in the midas examples.