### PR TITLE
CXXOPTS & Updates synthesized printf driver plusargs and defaults

### DIFF
--- a/docs/Advanced-Usage/Debugging/RTL-Simulation.rst
+++ b/docs/Advanced-Usage/Debugging/RTL-Simulation.rst
@@ -22,26 +22,37 @@ the design/abstraction hierarchy. Ordered from least to most detailed, they are:
   simulation flow provided by AWS. Supported simulators: VCS, Vivado XSIM.
 
 
-Generally, MIDAS-level simulations are only slightly slower than simulating at
-target-RTL. Moving to FPGA-Level is very expensive. This illustrated in the
-chart below.
+Generally, MIDAS-level simulations are only slightly slower than target-level
+ones. Moving to FPGA-Level is very expensive. This illustrated in the chart
+below.
 
-====== ===== =======  ========= =======
-Level  Waves VCS      Verilator XSIM
-====== ===== =======  ========= =======
-Target Off   4.8 kHz  6.2 kHz   N/A
-Target On    0.8 kHz  4.8 kHz   N/A
-MIDAS  Off   3.8 kHz  2.0 kHz   N/A
-MIDAS  On    2.9 kHz  1.0 kHz   N/A
-FPGA   On    2.3  Hz  N/A       0.56 Hz
-====== ===== =======  ========= =======
+====== ===== =======  ========= ============= ============= =======
+Level  Waves VCS      Verilator Verilator -O1 Verilator -O2 XSIM
+====== ===== =======  ========= ============= ============= =======
+Target Off   4.8 kHz  3.9 kHz   6.6 kHz       N/A           N/A
+Target On    0.8 kHz  3.0 kHz   5.1 kHz       N/A           N/A
+MIDAS  Off   3.8 kHz  2.4 kHz   4.5 kHz       5.3 KHz       N/A
+MIDAS  On    2.9 kHz  1.5 kHz   2.7 kHz       3.4 KHz       N/A
+FPGA   On    2.3  Hz  N/A       N/A           N/A           0.56 Hz
+====== ===== =======  ========= ============= ============= =======
 
-Notes: Default configurations of a single-core Rocket Chip instance running
-rv64ui-v-add.  Frequencies are given in target-Hz. Presently, the default
+Note that using more agressive optimization levels when compiling the
+Verilated-design dramatically lengths compile time:
+
+====== ===== =======  ========= ============= =============
+Level  Waves VCS      Verilator Verilator -O1 Verilator -O2
+====== ===== =======  ========= ============= =============
+MIDAS  Off   35s      48s       3m32s         4m35s
+MIDAS  On    35s      49s       5m27s         6m33s
+====== ===== =======  ========= ============= =============
+
+Notes: Default configurations of a single-core, Rocket-based instance running
+rv64ui-v-add. Frequencies are given in target-Hz. Presently, the default
 compiler flags passed to Verilator and VCS differ from level to level. Hence,
-these numbers are only intended to ball park simulation speeds with FireSim's
-out-of-the-box settings, not provide a scientific comparison between
-simulators.
+these numbers are only intended to ball park simulation speeds, not provide a
+scientific comparison between simulators. VCS numbers collected on Millenium,
+Verilator numbers collected on a c4.4xlarge. (ML verilator version: 4.002, TL
+verilator version: 3.904)
 
 Target-Level Simulation
 --------------------------

--- a/docs/Advanced-Usage/Debugging/printf-synthesis.rst
+++ b/docs/Advanced-Usage/Debugging/printf-synthesis.rst
@@ -53,11 +53,16 @@ Runtime Arguments
     Specifies the target cycle at which to stop pulling the synthesized print
     trace from the simulator.
 
-**+print-human-readable**
-    By default, a captured printf trace will be written to file as a raw,
-    unformatted binary, as properly formatting the printf further slows the
-    simulator.  Setting this will properly format the print data before writing
-    it to file.
+**+print-binary**
+    By default, a captured printf trace will be written to file formatted
+    as it would be emitted by a software RTL simulator. Setting this dumps the
+    raw binary coming off the FPGA instead, improving simulation rate.
+
+**+print-no-cycle-prefix**
+    (Formatted output only) This removes the cycle prefix from each printf to
+    save bandwidth in cases where the printf already includes a cycle field. In
+    binary-output mode, since the target cycle is implicit in the token stream,
+    this flag has no effect.
 
 Related Publications
 --------------------

--- a/scripts/profile-simulation-rate.sh
+++ b/scripts/profile-simulation-rate.sh
@@ -45,34 +45,34 @@ do
     sim=simulator-example-DefaultExampleConfig
 
     # Hack...
-    sed -i "'s/-O[0-3]/-O${optlevel}/'" Makefile
-    make -j$MAKE_THREADS
-    make -j$MAKE_THREADS debug
+    sed -i "s/-O[0-3]/-O${optlevel}/" Makefile
+    make clean
+    /usr/bin/time -a -o $REPORT_FILE make
+    /usr/bin/time -a -o $REPORT_FILE make debug
 
-    /usr/bin/time -a -o nowaves.log ./$sim $SIM_ARGS $test_path &> nowaves.log
-    /usr/bin/time -a -o waves.log ./$sim-debug $SIM_ARGS -vtest.vcd $test_path &> waves.log
 
     echo -e "\nNo Waves\n" >> $REPORT_FILE
+    /usr/bin/time -a -o $REPORT_FILE ./$sim $SIM_ARGS $test_path &> nowaves.log
     tail nowaves.log >> $REPORT_FILE
+    /usr/bin/time -a -o $REPORT_FILE ./$sim-debug $SIM_ARGS -vtest.vcd $test_path &> waves.log
     echo -e "\nWaves Enabled\n" >> $REPORT_FILE
     tail waves.log >> $REPORT_FILE
 done
 
-## VCS
+echo -e "\nTarget-level VCS\n" >> $REPORT_FILE
 cd $firesim_root/target-design/firechip/vsim/
 sim=simv-example-DefaultExampleConfig
-make -j$MAKE_THREADS
-make -j$MAKE_THREADS debug
+/usr/bin/time -a -o $REPORT_FILE make -j$MAKE_THREADS
+/usr/bin/time -a -o $REPORT_FILE make -j$MAKE_THREADS debug
 
-./$sim $SIM_ARGS $test_path &> nowaves.log
-./$sim-debug $SIM_ARGS $test_path &> waves.log
-
-echo -e "\nTarget-level VCS\n" >> $REPORT_FILE
+echo -e "\nNo Waves\n" >> $REPORT_FILE
+/usr/bin/time -a -o $REPORT_FILE ./$sim $SIM_ARGS $test_path &> nowaves.log
 tail nowaves.log >> $REPORT_FILE
-echo -e "\nTarget-level VCS -- Waves Enabled\n" >> $REPORT_FILE
+echo -e "\nWaves Enabled\n" >> $REPORT_FILE
+/usr/bin/time -a -o $REPORT_FILE ./$sim-debug $SIM_ARGS $test_path &> waves.log
 tail waves.log >> $REPORT_FILE
 
-#################################################################################
+################################################################################
 ## MIDAS level
 ################################################################################
 ml_output_dir=$firesim_root/sim/output/f1/$DESIGN-$TARGET_CONFIG-$PLATFORM_CONFIG

--- a/sim/Makefrag
+++ b/sim/Makefrag
@@ -39,10 +39,12 @@ CONF_NAME ?= runtime.conf
 # Verilator MIDAS-Level Simulators #
 ####################################
 
+VERILATOR_CXXOPTS ?= -O0
+
 verilator = $(GENERATED_DIR)/V$(DESIGN)
 verilator_debug = $(GENERATED_DIR)/V$(DESIGN)-debug
 
-$(verilator) $(verilator_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) -D RTLSIM
+$(verilator) $(verilator_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VERILATOR_CXXOPTS) -D RTLSIM
 $(verilator) $(verilator_debug): export LDFLAGS := $(LDFLAGS) $(common_ld_flags)
 
 $(verilator): $(HEADER) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -59,10 +61,13 @@ verilator-debug: $(verilator_debug)
 ##############################
 # VCS MIDAS-Level Simulators #
 ##############################
+
+VCS_CXXOPTS ?= -O2
+
 vcs = $(GENERATED_DIR)/$(DESIGN)
 vcs_debug = $(GENERATED_DIR)/$(DESIGN)-debug
 
-$(vcs) $(vcs_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) -I$(VCS_HOME)/include -D RTLSIM
+$(vcs) $(vcs_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VCS_CXXOPTS) -I$(VCS_HOME)/include -D RTLSIM
 $(vcs) $(vcs_debug): export LDFLAGS := $(LDFLAGS) $(common_ld_flags)
 
 $(vcs): $(HEADER) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -79,6 +84,8 @@ vcs-debug: $(vcs_debug)
 ############################
 # Master Simulation Driver #
 ############################
+DRIVER_CXXOPTS ?= -O2
+
 $(OUTPUT_DIR)/$(DESIGN).chain: $(VERILOG)
 	mkdir -p $(OUTPUT_DIR)
 	$(if $(wildcard $(GENERATED_DIR)/$(DESIGN).chain),cp $(GENERATED_DIR)/$(DESIGN).chain $@,)
@@ -88,7 +95,7 @@ $(PLATFORM): $($(PLATFORM)) $(OUTPUT_DIR)/$(DESIGN).chain
 
 fpga_dir = $(firesim_base_dir)/../platforms/$(PLATFORM)/aws-fpga
 
-$(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) -I$(fpga_dir)/sdk/userspace/include
+$(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) -I$(fpga_dir)/sdk/userspace/include
 # Statically link libfesvr to make it easier to distribute drivers to f1 instances
 $(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -lfpga_mgmt
 

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -128,10 +128,10 @@ class RiscF1Test extends TutorialSuite("Risc")
 class RiscSRAMF1Test extends TutorialSuite("RiscSRAM")
 class AssertModuleF1Test extends TutorialSuite("AssertModule")
 class PrintfModuleF1Test extends TutorialSuite("PrintfModule",
-  simulationArgs = Seq("+print-human-readable", "+print-file=synthprinttest.out")) {
+  simulationArgs = Seq("+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }
 class NarrowPrintfModuleF1Test extends TutorialSuite("NarrowPrintfModule",
-  simulationArgs = Seq("+print-human-readable", "+print-file=synthprinttest.out")) {
+  simulationArgs = Seq("+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -128,10 +128,10 @@ class RiscF1Test extends TutorialSuite("Risc")
 class RiscSRAMF1Test extends TutorialSuite("RiscSRAM")
 class AssertModuleF1Test extends TutorialSuite("AssertModule")
 class PrintfModuleF1Test extends TutorialSuite("PrintfModule",
-  simulationArgs = Seq("+print-file=synthprinttest.out")) {
+  simulationArgs = Seq("+print-no-cycle-prefix", "+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }
 class NarrowPrintfModuleF1Test extends TutorialSuite("NarrowPrintfModule",
-  simulationArgs = Seq("+print-file=synthprinttest.out")) {
+  simulationArgs = Seq("+print-no-cycle-prefix", "+print-file=synthprinttest.out")) {
   diffSynthesizedPrints("synthprinttest.out")
 }


### PR DESCRIPTION
See ucb-bar/midas#115
- Based off feedback from Jerry and Albert, changes +args to synthesized-prints to be more sensible
  - Makes human-readable and cycle-prefix on by default
  - +print-human-readable -> +print-binary
  - +print-cycle-prefix -> +print-no-cycle-prefix

- Adds separate CXX optimization flags for driver (-O2), verilator(-O0), VCS(-O2)
  - updates runtime charts in docs, adds compile time table
