### PR TITLE
Add support for using f1.4xlarge instances

### DIFF
--- a/deploy/firesim
+++ b/deploy/firesim
@@ -139,7 +139,7 @@ def launchrunfarm(runtime_conf):
     runtime_conf.runfarm.launch_run_farm()
 
 
-def terminaterunfarm(runtime_conf, terminatesomef1_16, terminatesomef1_2,
+def terminaterunfarm(runtime_conf, terminatesomef1_16, terminatesomef1_4, terminatesomef1_2,
                      terminatesomem4_16, forceterminate):
     """ Terminate instances in the runfarm.
 
@@ -152,7 +152,7 @@ def terminaterunfarm(runtime_conf, terminatesomef1_16, terminatesomef1_2,
        that many instances of the specified types and leave all others
        untouched.
     """
-    runtime_conf.terminate_run_farm(terminatesomef1_16, terminatesomef1_2,
+    runtime_conf.terminate_run_farm(terminatesomef1_16, terminatesomef1_4, terminatesomef1_2,
                                     terminatesomem4_16, forceterminate)
 
 def shareagfi(buildconf):
@@ -205,6 +205,9 @@ def construct_firesim_argparser():
     parser.add_argument('-g', '--terminatesomef12', type=int,
                         help='Only used by terminatesome. Terminates this many of the previously launched f1.2xlarges.',
                         default=-1)
+    parser.add_argument('-i', '--terminatesomef14', type=int,
+                        help='Only used by terminatesome. Terminates this many of the previously launched f1.4xlarges.',
+                        default=-1)
     parser.add_argument('-m', '--terminatesomem416', type=int,
                         help='Only used by terminatesome. Terminates this many of the previously launched m4.16xlarges.',
                         default=-1)
@@ -241,6 +244,7 @@ def main(args):
     if args.task == 'terminaterunfarm':
         runtime_conf = RuntimeConfig(args)
         terminaterunfarm(runtime_conf, args.terminatesomef116,
+                         args.terminatesomef14,
                          args.terminatesomef12, args.terminatesomem416,
                          args.forceterminate)
 

--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -166,6 +166,7 @@ class FireSimTopologyWithPasses:
         """ A very simple host mapping strategy.  """
         switches = self.firesimtopol.get_dfs_order_switches()
         f1_2s_used = 0
+        f1_4s_used = 0
         f1_16s_used = 0
         m4_16s_used = 0
 
@@ -184,6 +185,11 @@ class FireSimTopologyWithPasses:
                     self.run_farm.f1_2s[f1_2s_used].add_switch(switch)
                     self.run_farm.f1_2s[f1_2s_used].add_simulation(downlinknodes[0])
                     f1_2s_used += 1
+                elif (len(downlinknodes) == 2) and (f1_4s_used < len(self.run_farm.f1_4s)):
+                    self.run_farm.f1_4s[f1_4s_used].add_switch(switch)
+                    for server in downlinknodes:
+                        self.run_farm.f1_4s[f1_4s_used].add_simulation(server)
+                    f1_4s_used += 1
                 else:
                     self.run_farm.f1_16s[f1_16s_used].add_switch(switch)
                     for server in downlinknodes:

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -243,9 +243,10 @@ class InnerRuntimeConfiguration:
             runtime_dict[overridesection][overridefield] = overridevalue
 
         self.runfarmtag = runtime_dict['runfarm']['runfarmtag']
-        self.f1_16xlarges_requested = int(runtime_dict['runfarm']['f1_16xlarges'])
-        self.m4_16xlarges_requested = int(runtime_dict['runfarm']['m4_16xlarges'])
-        self.f1_2xlarges_requested = int(runtime_dict['runfarm']['f1_2xlarges'])
+        self.f1_16xlarges_requested = int(runtime_dict['runfarm']['f1_16xlarges']) if 'f1_16xlarges' in runtime_dict['runfarm'] else 0
+        self.f1_4xlarges_requested = int(runtime_dict['runfarm']['f1_4xlarges']) if 'f1_4xlarges' in runtime_dict['runfarm'] else 0
+        self.m4_16xlarges_requested = int(runtime_dict['runfarm']['m4_16xlarges']) if 'm4_16xlarges' in runtime_dict['runfarm'] else 0
+        self.f1_2xlarges_requested = int(runtime_dict['runfarm']['f1_2xlarges']) if 'f1_2xlarges' in runtime_dict['runfarm'] else 0
 
         self.run_instance_market = runtime_dict['runfarm']['runinstancemarket']
         self.spot_interruption_behavior = runtime_dict['runfarm']['spotinterruptionbehavior']
@@ -300,6 +301,7 @@ class RuntimeConfig:
         self.workload = WorkloadConfig(self.innerconf.workload_name, self.launch_time)
 
         self.runfarm = RunFarm(self.innerconf.f1_16xlarges_requested,
+                               self.innerconf.f1_4xlarges_requested,
                                self.innerconf.f1_2xlarges_requested,
                                self.innerconf.m4_16xlarges_requested,
                                self.innerconf.runfarmtag,
@@ -321,10 +323,10 @@ class RuntimeConfig:
         """ directly called by top-level launchrunfarm command. """
         self.runfarm.launch_run_farm()
 
-    def terminate_run_farm(self, terminatesomef1_16, terminatesomef1_2,
+    def terminate_run_farm(self, terminatesomef1_16, terminatesomef1_4, terminatesomef1_2,
                            terminatesomem4_16, forceterminate):
         """ directly called by top-level terminaterunfarm command. """
-        self.runfarm.terminate_run_farm(terminatesomef1_16, terminatesomef1_2,
+        self.runfarm.terminate_run_farm(terminatesomef1_16, terminatesomef1_4, terminatesomef1_2,
                                         terminatesomem4_16, forceterminate)
 
     def infrasetup(self):

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -6,6 +6,7 @@ runfarmtag=mainrunfarm
 
 f1_16xlarges=1
 m4_16xlarges=0
+f1_4xlarges=0
 f1_2xlarges=0
 
 runinstancemarket=ondemand

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -1,7 +1,8 @@
 usage: firesim [-h] [-c RUNTIMECONFIGFILE] [-b BUILDCONFIGFILE]
                [-r BUILDRECIPESCONFIGFILE] [-a HWDBCONFIGFILE]
                [-x OVERRIDECONFIGDATA] [-f TERMINATESOMEF116]
-               [-g TERMINATESOMEF12] [-m TERMINATESOMEM416] [-q]
+               [-g TERMINATESOMEF12] [-i TERMINATESOMEF14]
+               [-m TERMINATESOMEM416] [-q]
                
                {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
 
@@ -35,6 +36,9 @@ optional arguments:
   -g TERMINATESOMEF12, --terminatesomef12 TERMINATESOMEF12
                         Only used by terminatesome. Terminates this many of
                         the previously launched f1.2xlarges.
+  -i TERMINATESOMEF14, --terminatesomef14 TERMINATESOMEF14
+                        Only used by terminatesome. Terminates this many of
+                        the previously launched f1.4xlarges.
   -m TERMINATESOMEM416, --terminatesomem416 TERMINATESOMEM416
                         Only used by terminatesome. Terminates this many of
                         the previously launched m4.16xlarges.

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -40,8 +40,8 @@ you should not change it unless you are done with your current Run Farm.
 
 Per AWS restrictions, this tag can be no longer than 255 characters.
 
-``f1_16xlarges``, ``m4_16xlarges``, ``f1_2xlarges``
-""""""""""""""""""""""""""""""""""""""""""""""""""""
+``f1_16xlarges``, ``m4_16xlarges``, ``f1_4xlarges``, ``f1_2xlarges``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Set these three values respectively based on the number and types of instances
 you need. While we could automate this setting, we choose not to, so that

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -96,7 +96,7 @@ that someone else owns and gave you access to.
 ---------------------------
 
 This command launches a Run Farm on which you run simulations. Run Farms
-consist of ``f1.16xlarge``, ``f1.2xlarge``, and ``m4.16xlarge`` instances.
+consist of ``f1.16xlarge``, ``f1.4xlarge``, ``f1.2xlarge``, and ``m4.16xlarge`` instances.
 Before you run the command, you define the number of each that you want in
 ``config_runtime.ini``.
 
@@ -155,8 +155,9 @@ RUN FARM WITHOUT PROMPTING FOR CONFIRMATION:
 
 There a few additional commandline arguments that let you terminate only
 some of the instances in a particular Run Farm: ``--terminatesomef116 INT``,
-``--terminatesomef12 INT``, and ``--terminatesomem416 INT``, which will terminate
-ONLY as many of each type of instance as you specify.
+``--terminatesomef14 INT``, ``--terminatesomef12 INT``, and
+``--terminatesomem416 INT``, which will terminate ONLY as many of each type of
+instance as you specify.
 
 Here are some examples:
 

--- a/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
+++ b/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
@@ -36,7 +36,7 @@ Check your EC2 Instance Limits
 
 AWS limits access to particular instance types for new/infrequently used
 accounts to protect their infrastructure. You should make sure that your
-account has access to ``f1.2xlarge``, ``f1.16xlarge``,
+account has access to ``f1.2xlarge``, ``f1.4xlarge``, ``f1.16xlarge``,
 ``m4.16xlarge``, and ``c4.4xlarge`` instances by looking at the "Limits" page
 in the EC2 panel, which you can access
 `here <https://console.aws.amazon.com/ec2/v2/home#Limits:>`__. The

--- a/docs/Running-Simulations-Tutorial/Running-a-Cluster-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Cluster-Simulation.rst
@@ -127,6 +127,7 @@ You should expect output like the following:
 
     Waiting for instance boots: f1.16xlarges
     i-09e5491cce4d5f92d booted!
+    Waiting for instance boots: f1.4xlarges
     Waiting for instance boots: m4.16xlarges
     Waiting for instance boots: f1.2xlarges
     The full log of this run is:
@@ -516,6 +517,8 @@ Which should present you with the following:
 	IMPORTANT!: This will terminate the following instances:
 	f1.16xlarges
 	['i-09e5491cce4d5f92d']
+	f1.4xlarges
+	[]
 	m4.16xlarges
 	[]
 	f1.2xlarges

--- a/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
@@ -55,7 +55,7 @@ We'll need to modify a couple of these lines.
 First, let's tell the manager to use the correct numbers and types of instances.
 You'll notice that in the ``[runfarm]`` section, the manager is configured to
 launch a Run Farm named ``mainrunfarm``, consisting of one ``f1.16xlarge`` and
-no ``m4.16xlarge``\ s or ``f1.2xlarge``\ s. The tag specified here allows the
+no ``m4.16xlarge``\ s, ``f1.4xlarge``\ s, or ``f1.2xlarge``\ s. The tag specified here allows the
 manager to differentiate amongst many parallel run farms (each running
 a workload) that you may be operating -- but more on that later.
 
@@ -68,6 +68,7 @@ Since we only want to simulate a single node, let's switch to using one
     # per aws restrictions, this tag cannot be longer than 255 chars
     runfarmtag=mainrunfarm
     f1_16xlarges=0
+    f1_4xlarges=0
     m4_16xlarges=0
     f1_2xlarges=1
 
@@ -122,6 +123,7 @@ As a final sanity check, your ``config_runtime.ini`` file should now look like t
 	runfarmtag=mainrunfarm
 
 	f1_16xlarges=0
+	f1_4xlarges=1
 	m4_16xlarges=0
 	f1_2xlarges=1
 
@@ -181,6 +183,7 @@ You should expect output like the following:
 	Running: launchrunfarm
 
 	Waiting for instance boots: f1.16xlarges
+	Waiting for instance boots: f1.4xlarges
 	Waiting for instance boots: m4.16xlarges
 	Waiting for instance boots: f1.2xlarges
 	i-0d6c29ac507139163 booted!
@@ -466,6 +469,8 @@ Which should present you with the following:
 
 	IMPORTANT!: This will terminate the following instances:
 	f1.16xlarges
+	[]
+	f1.4xlarges
 	[]
 	m4.16xlarges
 	[]


### PR DESCRIPTION
This is ready for review/merge.

I purposefully tried to avoid reflowing lines to make reviewing easy, this can be fixed in a future PR.

I tested running an example_2config on a 4xlarge.