### PR TITLE
Fix a determinism hole in ready-valid channels

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,32 +10,32 @@
 # own images.
 
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-05d5661be7ff56e56
+agfi=agfi-0af9beadf70b9e023
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-0e7fddaf325d9bb87
+agfi=agfi-0236643bf3aef471c
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-053a9d22cc843be57
+agfi=agfi-0858a54927060295b
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-0ddaac70e1a26a407
+agfi=agfi-027902f66591054f2
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-09f2f5e9103b92124
+agfi=agfi-03d4f0fc23f6ac667
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-singlecore-nic-lbp]
-agfi=agfi-0f393219d7aed52f1
+agfi=agfi-0846fde20af4f4792
 deploytripletoverride=None
 customruntimeconfig=None
 


### PR DESCRIPTION
See midas ucb-bar/midas#116 

Ready-valid channels were not irrevocably asserting ready-tokens. This would make the channel appear like a pipe-queue if the deq-side token handshake occurred early enough and a non-pipe-queue otherwise (the desired behavior). 

I booted 8 instances of boom and checked they terminated on same cycle. 