### PR TITLE
Fix GAPBS submodule initialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,9 @@
 [submodule "deploy/workloads/Speckle"]
 	path = deploy/workloads/Speckle
 	url = https://github.com/ccelio/Speckle.git
-[submodule "deploy/workloads/gapbs"]
-	path = deploy/workloads/runscripts/gapbs-scripts/gapbs
-	url = https://github.com/sbeamer/gapbs.git
 [submodule "deploy/workloads/ccbench-cache-sweep/ccbench"]
 	path = deploy/workloads/ccbench-cache-sweep/ccbench
 	url = https://github.com/ucb-bar/ccbench
+[submodule "deploy/workloads/runscripts/gapbs-scripts/gapbs"]
+	path = deploy/workloads/runscripts/gapbs-scripts/gapbs
+	url = https://github.com/sbeamer/gapbs.git

--- a/deploy/workloads/.gitignore
+++ b/deploy/workloads/.gitignore
@@ -1,6 +1,5 @@
 spec17-intrate
 spec17-intspeed
-/gapbs
 build
 fedora-uniform/stage4-disk.img
 fedora-uniform/QEMU-ONLY-bbl
@@ -9,3 +8,4 @@ check-rtc-linux
 bw-test-one-instance/*.riscv
 bw-test-two-instances/*.riscv
 unittest/STRESSRUNS
+/gapbs

--- a/deploy/workloads/Makefile
+++ b/deploy/workloads/Makefile
@@ -36,7 +36,7 @@ spec17-%: spec17-%.json $(SPECKLE_DIR)/build/overlay/%/$(input)
 		-s $(SPECKLE_DIR)/build/overlay/$*/$(input)
 
 #Default to test input size for GAPBS
-gapbs: input = test
+gapbs: input = graph500
 
 $(GAP_DIR)/overlay/$(input):
 	cd $(GAP_DIR) && ./gen_run_scripts.sh --binaries --input $(input)

--- a/deploy/workloads/gapbs.json
+++ b/deploy/workloads/gapbs.json
@@ -4,7 +4,7 @@
   "deliver_dir" : "gapbs",
   "common_args" : [],
   "common_files" : ["gapbs.sh"],
-  "common_simulation_outputs": ["uartlog"],
+  "common_simulation_outputs": ["uartlog", "memory_stats.csv"],
   "common_outputs" : ["/output"],
   "workloads" : [
     {

--- a/deploy/workloads/run-simple-workload.sh
+++ b/deploy/workloads/run-simple-workload.sh
@@ -12,14 +12,15 @@ terminate=1
 
 function usage
 {
-    echo "usage: run-simple-workload.sh <workload.ini> [-H | -h | --help] [--noterminate]"
-    echo "   workload.ini: the workload you'd like to run."
-    echo "   withlaunch: will spin up a runfarm based on the ini"
-    echo "   noterminate: will not forcibly terminate runfarm instances after runworkload"
+    echo "usage: run-simple-workload.sh <workload.ini> [-H | -h | --help] [--noterminate] [--withlaunch]"
+    echo "   workload.ini:  the workload you'd like to run."
+    echo "   --withlaunch:  (Optional) will spin up a runfarm based on the ini"
+    echo "   --noterminate: (Optional) will not forcibly terminate runfarm instances after runworkload"
 }
 
 if [ $# -eq 0 -o "$1" == "--help" -o "$1" == "-h" -o "$1" == "-H" ]; then
-    usage exit 3
+    usage
+    exit 3
 fi
 
 ini=$1

--- a/deploy/workloads/run-simple-workload.sh
+++ b/deploy/workloads/run-simple-workload.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This is some sugar around:
+# ./firesim -c <ini> {launchrunfarm && infrasetup && runworkload && terminaterunfarm}
+
+# "Simple" workloads are simply those that don't need to make any other calls beyond 
+# the four above.
+
+# Defaults
+withlaunch=0
+terminate=1
+
+function usage
+{
+    echo "usage: run-simple-workload.sh <workload.ini> [-H | -h | --help] [--noterminate]"
+    echo "   workload.ini: the workload you'd like to run."
+    echo "   withlaunch: will spin up a runfarm based on the ini"
+    echo "   noterminate: will not forcibly terminate runfarm instances after runworkload"
+}
+
+if [ $# -eq 0 -o "$1" == "--help" -o "$1" == "-h" -o "$1" == "-H" ]; then
+    usage exit 3
+fi
+
+ini=$1
+shift
+
+while test $# -gt 0
+do
+   case "$1" in
+        --withlaunch)
+            withlaunch=1
+            ;;
+        --noterminate)
+            terminate=0;
+            ;;
+        -h | -H | -help)
+            usage
+            exit
+            ;;
+        --*) echo "ERROR: bad option $1"
+            usage
+            exit 1
+            ;;
+        *) echo "ERROR: bad argument $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+trap "exit" INT
+set -e
+set -o pipefail
+
+if [ "$withlaunch" -ne "0" ]; then
+    firesim -c $ini launchrunfarm
+fi
+
+firesim -c $ini infrasetup
+firesim -c $ini runworkload
+
+if [ "$terminate" -eq "1" ]; then
+    firesim -c $ini terminaterunfarm --forceterminate
+fi

--- a/deploy/workloads/run-workload.sh
+++ b/deploy/workloads/run-workload.sh
@@ -12,7 +12,8 @@ terminate=1
 function usage
 {
     echo "usage: run-workload.sh <workload.ini> [-H | -h | --help] [--noterminate] [--withlaunch]"
-    echo "   workload.ini:  the workload you'd like to run."
+    echo "   workload.ini:  the firesim-relative path to the workload you'd like to run"
+    echo "                  e.g. workloads/gapbs.ini"
     echo "   --withlaunch:  (Optional) will spin up a runfarm based on the ini"
     echo "   --noterminate: (Optional) will not forcibly terminate runfarm instances after runworkload"
 }

--- a/deploy/workloads/run-workload.sh
+++ b/deploy/workloads/run-workload.sh
@@ -2,9 +2,8 @@
 
 # This is some sugar around:
 # ./firesim -c <ini> {launchrunfarm && infrasetup && runworkload && terminaterunfarm}
-
-# "Simple" workloads are simply those that don't need to make any other calls beyond 
-# the four above.
+# And thus will only work for workloads that do not need run other applications
+# between firesim calls
 
 # Defaults
 withlaunch=0
@@ -12,7 +11,7 @@ terminate=1
 
 function usage
 {
-    echo "usage: run-simple-workload.sh <workload.ini> [-H | -h | --help] [--noterminate] [--withlaunch]"
+    echo "usage: run-workload.sh <workload.ini> [-H | -h | --help] [--noterminate] [--withlaunch]"
     echo "   workload.ini:  the workload you'd like to run."
     echo "   --withlaunch:  (Optional) will spin up a runfarm based on the ini"
     echo "   --noterminate: (Optional) will not forcibly terminate runfarm instances after runworkload"

--- a/docs/Advanced-Usage/Workloads/GAP-Benchmark-Suite.rst
+++ b/docs/Advanced-Usage/Workloads/GAP-Benchmark-Suite.rst
@@ -5,13 +5,13 @@ GAP Benchmark Suite
 You can run the reference implementation of the GAP (Graph Algorithm Performance)
 Benchmark Suite. We provide scripts that cross-compile the graph kernels for RISCV.
 
-For more information about the benchmark itself, please refer to the site: 
+For more information about the benchmark itself, please refer to the site:
 http://gap.cs.berkeley.edu/benchmark.html
 
 Some notes:
 
 -  Only the Kron input graph is currently supported.
--  Benchmark uses ``test`` input graph size of 2^10 vertices by default. ``graph500`` input size has 2^20 vertices and can be used by specifying an argument into make: ``make gapbs input=graph500``
+-  Benchmark uses ``graph500`` input graph size of 2^20 vertices by default. ``test`` input size has 2^10 vertices and can be used by specifying an argument into make: ``make gapbs input=test``
 -  The reference input size with 2^27 verticies is not currently supported.
 
 By default, the gapbs workload definition runs the benchmark multithreaded with number of threads equal to the number of cores. To change the number of threads, you need to edit ``firesim/deploy/workloads/runscripts/gapbs-scripts/gapbs.sh``. Additionally, the workload does not verify the output of the benchmark by default. To change this, add a ``--verify`` parameter to the json.

--- a/docs/Advanced-Usage/Workloads/GAP-Benchmark-Suite.rst
+++ b/docs/Advanced-Usage/Workloads/GAP-Benchmark-Suite.rst
@@ -35,7 +35,7 @@ To Run:
 
 .. code-block:: bash
 
-    workloads/run-workload.sh workloads/gapbs.ini --withlaunch
+    ./run-workload.sh workloads/gapbs.ini --withlaunch
 
 Simulation times are host and target dependent. For reference, on a
 four-core rocket-based SoC with a DDR3 + 1 MiB LLC model, with a 90

--- a/docs/Advanced-Usage/Workloads/GAP-Benchmark-Suite.rst
+++ b/docs/Advanced-Usage/Workloads/GAP-Benchmark-Suite.rst
@@ -35,11 +35,7 @@ To Run:
 
 .. code-block:: bash
 
-    firesim launchrunfarm    -c workloads/gapbs.ini
-    firesim infrasetup       -c workloads/gapbs.ini
-    firesim runworkload      -c workloads/gapbs.ini
-    firesim terminaterunfarm -c workloads/gapbs.ini
-
+    workloads/run-workload.sh workloads/gapbs.ini --withlaunch
 
 Simulation times are host and target dependent. For reference, on a
 four-core rocket-based SoC with a DDR3 + 1 MiB LLC model, with a 90

--- a/docs/Advanced-Usage/Workloads/SPEC-2017.rst
+++ b/docs/Advanced-Usage/Workloads/SPEC-2017.rst
@@ -50,10 +50,7 @@ To Run:
 
 .. code-block:: bash
 
-    firesim launchrunfarm    -c workloads/spec17-intspeed.ini
-    firesim infrasetup       -c workloads/spec17-intspeed.ini
-    firesim runworkload      -c workloads/spec17-intspeed.ini
-    firesim terminaterunfarm -c workloads/spec17-intspeed.ini
+    workloads/run-workload.sh workloads/spec17-intspeed.ini --withlaunch
 
 On a single-core rocket-based SoC with a DDR3 + 256 KiB LLC model, with a 160
 MHz host clock, the longest benchmarks (xz, mcf) complete in about 1
@@ -86,10 +83,7 @@ To Run:
 
 .. code-block:: bash
 
-    firesim launchrunfarm    -c workloads/spec17-intrate.ini
-    firesim infrasetup       -c workloads/spec17-intrate.ini
-    firesim runworkload      -c workloads/spec17-intrate.ini
-    firesim terminaterunfarm -c workloads/spec17-intrate.ini
+    workloads/run-workload.sh workloads/spec17-intrate.ini --withlaunch
 
 
 Simulation times are host and target dependent. For reference, on a

--- a/docs/Advanced-Usage/Workloads/SPEC-2017.rst
+++ b/docs/Advanced-Usage/Workloads/SPEC-2017.rst
@@ -50,7 +50,7 @@ To Run:
 
 .. code-block:: bash
 
-    workloads/run-workload.sh workloads/spec17-intspeed.ini --withlaunch
+    ./run-workload.sh workloads/spec17-intspeed.ini --withlaunch
 
 On a single-core rocket-based SoC with a DDR3 + 256 KiB LLC model, with a 160
 MHz host clock, the longest benchmarks (xz, mcf) complete in about 1
@@ -83,7 +83,7 @@ To Run:
 
 .. code-block:: bash
 
-    workloads/run-workload.sh workloads/spec17-intrate.ini --withlaunch
+    ./run-workload.sh workloads/spec17-intrate.ini --withlaunch
 
 
 Simulation times are host and target dependent. For reference, on a


### PR DESCRIPTION
The path in .gitmodules was malformed. 

Other changes:
- Change the default from test to graph500, which completes in < 1hr on a single-core rocket-based instance.
- Add a script that copies the common pattern of `firesim -c <ini> {launchrunfarm, infrasetup, runworkload, terminaterunfarm}`
