### PR TITLE
Adds quad-core BOOM target config

### DIFF
--- a/sim/src/main/scala/firesim/TargetConfigs.scala
+++ b/sim/src/main/scala/firesim/TargetConfigs.scala
@@ -1,5 +1,6 @@
 package firesim.firesim
 
+import chisel3.util.{log2Ceil}
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
@@ -154,10 +155,15 @@ class FireSimBoomConfig extends Config(
 // tile in the "up" view
 class WithNDuplicatedBoomCores(n: Int) extends Config((site, here, up) => {
   case BoomTilesKey => List.tabulate(n)(i => up(BoomTilesKey).head.copy(hartId = i))
+  case MaxHartIdBits => log2Ceil(site(BoomTilesKey).size)
 })
 
 class FireSimBoomDualCoreConfig extends Config(
   new WithNDuplicatedBoomCores(2) ++
+  new FireSimBoomConfig)
+
+class FireSimBoomQuadCoreConfig extends Config(
+  new WithNDuplicatedBoomCores(4) ++
   new FireSimBoomConfig)
 
 class FireSimBoomTracedConfig extends Config(

--- a/sim/src/main/scala/firesim/TargetConfigs.scala
+++ b/sim/src/main/scala/firesim/TargetConfigs.scala
@@ -1,6 +1,6 @@
 package firesim.firesim
 
-import chisel3.util.{log2Ceil}
+import chisel3.util.{log2Up}
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
@@ -155,7 +155,7 @@ class FireSimBoomConfig extends Config(
 // tile in the "up" view
 class WithNDuplicatedBoomCores(n: Int) extends Config((site, here, up) => {
   case BoomTilesKey => List.tabulate(n)(i => up(BoomTilesKey).head.copy(hartId = i))
-  case MaxHartIdBits => log2Ceil(site(BoomTilesKey).size)
+  case MaxHartIdBits => log2Up(site(BoomTilesKey).size)
 })
 
 class FireSimBoomDualCoreConfig extends Config(


### PR DESCRIPTION
This PR adds a quad-core BOOM config. I've built the AGFI and booted Linux.
The maximum number of hart ID bits must be set according to the number of BOOM tiles, otherwise, we get an error at elaboration phase.