### PR TITLE
Fix python3 install, centos bumped to 3.6, installing 3.4 no longer creates python3/pip3 links

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -7,11 +7,11 @@ curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm
 sudo yum install -y sbt texinfo gengetopt
 sudo yum install -y expat-devel libusb1-devel ncurses-devel cmake "perl(ExtUtils::MakeMaker)"
 # deps for poky
-sudo yum install -y python34 patch diffstat texi2html texinfo subversion chrpath git wget
+sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath git wget
 # deps for qemu
 sudo yum install -y gtk3-devel
 # deps for firesim-software (note that rsync is installed but too old)
-sudo yum install -y python34-pip python34-devel rsync
+sudo yum install -y python36-pip python36-devel rsync
 # install DTC. it's not available in repos in FPGA AMI
 DTCversion=dtc-1.4.4
 wget https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/$DTCversion.tar.gz


### PR DESCRIPTION
This fixes currently broken master build-setup process.