### PR TITLE
Add coremark workload

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "deploy/workloads/runscripts/gapbs-scripts/gapbs"]
 	path = deploy/workloads/runscripts/gapbs-scripts/gapbs
 	url = https://github.com/sbeamer/gapbs.git
+[submodule "deploy/workloads/coremark/riscv-coremark"]
+	path = deploy/workloads/coremark/riscv-coremark
+	url = https://github.com/riscv-boom/riscv-coremark

--- a/deploy/workloads/Makefile
+++ b/deploy/workloads/Makefile
@@ -106,8 +106,13 @@ fc-test:
 	ln -sf ../../../sw/network-benchmarks/fc-test/fc-client.riscv $@/fc-client.riscv
 	ln -sf ../../../sw/network-benchmarks/fc-test/fc-server.riscv $@/fc-server.riscv
 
+coremark:
+	cd coremark/riscv-coremark/coremark && make CC=riscv64-unknown-linux-gnu-gcc compile
+	mv coremark/riscv-coremark/coremark/coremark.exe coremark/overlay/coremark.riscv
+	python gen-benchmark-rootfs.py -w $@.json -r -b $(BASE_IMAGE) -s $@/overlay
+
 .PHONY: $(spec17_overlays) $(spec17_rootfs_dirs) gapbs fedora-uniform \
 	memcached-thread-imbalance bw-test-one-instance bw-test-two-instances \
 	ping-latency simperf-test simperf-test-latency simperf-test-scale \
 	iperf3 check-rtc check-rtc-linux allpaper checksum-test \
-	ccbench-cache-sweep flash-stress fc-test
+	ccbench-cache-sweep flash-stress fc-test coremark

--- a/deploy/workloads/coremark.json
+++ b/deploy/workloads/coremark.json
@@ -1,0 +1,19 @@
+{
+  "common_bootbinary" : "bbl-vmlinux",
+  "benchmark_name" : "coremark",
+  "deliver_dir" : "/",
+  "common_args" : [],
+  "common_files" : ["coremark.riscv"],
+  "common_outputs" : [],
+  "common_simulation_outputs" : ["uartlog"],
+  "NOpost_run_hook": "python process-data.py",
+  "workloads" : [
+    {
+      "name": "coremark",
+      "files": [],
+      "command": "/coremark.riscv",
+      "simulation_outputs": [],
+      "outputs": []
+    }
+  ]
+}

--- a/deploy/workloads/coremark/.gitignore
+++ b/deploy/workloads/coremark/.gitignore
@@ -1,0 +1,2 @@
+coremark.ext2
+overlay

--- a/deploy/workloads/coremark/bbl-vmlinux
+++ b/deploy/workloads/coremark/bbl-vmlinux
@@ -1,0 +1,1 @@
+../linux-uniform/br-base-bin


### PR DESCRIPTION
I got this result, running on the included (very small) BOOM config:

```
[    0.012000] VFS: Mounted root (ext2 filesystem) on device 253:0.
[    0.012000] devtmpfs: mounted
[    0.012000] Freeing unused kernel memory: 148K
[    0.012000] This architecture does not have kernel memory protection.
mount: mounting sysfs on /sys failed: No such device
Starting logging: OK
Starting mdev...
mdev: /sys/dev: No such file or directory
modprobe: can't change directory to '/lib/modules': No such file or directory
Initializing random number generator... done.
Starting network: ip: SIOCGIFFLAGS: No such device
ip: can't find device 'eth0'
FAIL
Starting dropbear sshd: OK
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 12838
Total time (secs): 12.838000
Iterations/Sec   : 4673.625175
Iterations       : 60000
Compiler version : GCC7.2.0
Compiler flags   : -O2   -lrt
Memory location  : Please put data memory location here
                        (e.g. code in flash, data on heap etc)
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0xbd59
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 4673.625175 / GCC7.2.0 -O2   -lrt / Heap
[   15.432000] reboot: Power down
Power off

*** PASSED *** after 50770673641 cycles
time elapsed: 565.9 s, simulation speed = 89.72 MHz
FPGA-Cycles-to-Model-Cycles Ratio (FMR): 1.03
Runs 50770673641 cycles
```
