### PR TITLE
Revert "downgrade package to remove deprecation warnings"

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -52,8 +52,6 @@ sudo pip2 install graphviz==0.8.3
 sudo pip2 install --upgrade --ignore-installed pyparsing
 sudo pip2 install matplotlib==2.2.2
 sudo pip2 install pandas==0.22.0
-# this is explicitly installed to downgrade it to a version without deprec warnings
-sudo pip2 install cryptography==2.2.2
 
 sudo activate-global-python-argcomplete
 


### PR DESCRIPTION
Resolves #298.

This breaks `buildafi`. We can deal with paramiko spewing garbage during `runworkload` for now. 