### PR TITLE
Revert FireSim AMI related commits

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -13,22 +13,19 @@ rootLogger = logging.getLogger()
 # users are instructed to create a key named `firesim` in the wiki
 keyname = 'firesim'
 
-# this needs to be updated whenever the FireSim Base AMI or FPGA Dev AMI changes.
-# Run AMI and build AMI are separated since a build currently fails in the FireSim Base AMI 
-# (likely due to tools licensing issues) 
-f1_ami_name_run = "FireSim Base AMI 1.6.0-1febcaa0-2602-4690-99b9-62bfd3998066-ami-043bd8d76d14e6b3d.4"
-f1_ami_name_build = "FPGA Developer AMI - 1.6.0-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-0b1edf08d56c2da5c.4"
+# this needs to be updated whenever the FPGA Dev AMI changes
+f1_ami_name = "FPGA Developer AMI - 1.6.0-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-0b1edf08d56c2da5c.4"
 
 # users are instructed to create these in the setup instructions
 securitygroupname = 'firesim'
 vpcname = 'firesim'
 
 # AMIs are region specific
-def get_f1_ami_id(ami_name_to_get = f1_ami_name_build):
+def get_f1_ami_id():
     """ Get the AWS F1 Developer AMI by looking up the image name -- should be region independent.
     """
     client = boto3.client('ec2')
-    response = client.describe_images(Filters=[{'Name': 'name', 'Values': [ami_name_to_get]}])
+    response = client.describe_images(Filters=[{'Name': 'name', 'Values': [f1_ami_name]}])
     assert len(response['Images']) == 1
     return response['Images'][0]['ImageId']
 
@@ -71,7 +68,7 @@ def construct_instance_market_options(instancemarket, spotinterruptionbehavior, 
     else:
         assert False, "INVALID INSTANCE MARKET TYPE."
 
-def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavior, spotmaxprice, blockdevices=None, tags=None, randomsubnet=False, ami_name_to_get=f1_ami_name_build):
+def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavior, spotmaxprice, blockdevices=None, tags=None, randomsubnet=False):
     """ Launch count instances of type instancetype, optionally with additional
     block devices mappings and instance tags
 
@@ -89,7 +86,7 @@ def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavi
         Filters=[{'Name':'group-name', 'Values': [securitygroupname]}])['SecurityGroups'][0]['GroupId']
 
     marketconfig = construct_instance_market_options(instancemarket, spotinterruptionbehavior, spotmaxprice)
-    f1_image_id = get_f1_ami_id(ami_name_to_get)
+    f1_image_id = get_f1_ami_id()
 
     if blockdevices is None:
         blockdevices = []
@@ -149,7 +146,7 @@ def launch_run_instances(instancetype, count, fsimclustertag, instancemarket, sp
                 },
             },
         ],
-        tags={ 'fsimcluster': fsimclustertag }, ami_name_to_get=f1_ami_name_run)
+        tags={ 'fsimcluster': fsimclustertag })
 
 def get_instances_by_tag_type(fsimclustertag, instancetype):
     """ return list of instances that match a tag and instance type """

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -43,7 +43,7 @@ For each config, the build process entails:
 
 4. [Locally] Emit Verilog to run through the AWS FPGA Flow
 
-5. Launch an FireSim Base AMI build instance for each configuration you want built.
+5. Launch an FPGA Dev AMI build instance for each configuration you want built.
 
 6. [Local/Remote] Prep build instances, copy generated verilog for hardware configuration to build instance.
 

--- a/docs/Advanced-Usage/Miscellaneous-Tips.rst
+++ b/docs/Advanced-Usage/Miscellaneous-Tips.rst
@@ -13,7 +13,7 @@ which FireSim run farm an instance belongs to.
 To do so, click the gear in the top right of the AWS management console. From
 there, you should see a checkbox for ``fsimcluster``. Enable it to see the column.
 
-FPGA Dev AMI / FireSim Base AMI Remote Desktop Setup
+FPGA Dev AMI Remote Desktop Setup
 -----------------------------------
 
 To Remote Desktop into your manager instance, you must do the following:

--- a/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
+++ b/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
@@ -139,12 +139,4 @@ AMI <https://aws.amazon.com/marketplace/pp/B06VVYBLZZ>`__. Click the
 button to subscribe to the FPGA Dev AMI (it should be free) and follow
 the prompts to accept the EULA (but do not launch any instances).
 
-Subscribe to FireSim Base AMI
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Go to the `AWS Marketplace page for the FireSim Base
-AMI <https://aws.amazon.com/marketplace/pp/B07RP9L1R5>`__. Click the
-button to subscribe to the FireSim Base AMI (it should be free) and follow
-the prompts to accept the EULA (but do not launch any instances).
-
-
 Now, hit next to continue on to setting up our Manager Instance.

--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -22,7 +22,7 @@ To launch a manager instance, follow these steps:
    data is preserved when you stop/start the instance, and your data is
    not lost when pricing spikes on the spot market.
 2. When prompted to select an AMI, search in the ``Community AMIs`` tab for
-   "FireSim Base" and select the option that starts with ``FireSim Base AMI 1.6.0``.
+   "FPGA" and select the option that starts with ``FPGA Developer AMI - 1.6.0``.
    **DO NOT USE ANY OTHER VERSION.**
 3. When prompted to choose an instance type, select the instance type of
    your choosing. A good choice is a ``c4.4xlarge``.
@@ -36,14 +36,23 @@ To launch a manager instance, follow these steps:
       manager instance from being terminated by accident. You will need
       to disable this setting before being able to terminate the
       instance using usual methods.
-4. On the next page ("Add Storage"), increase the size of the root EBS
+   3. Also on this page, expand "Advanced Details" and in the resulting
+      text box, paste the following:
+
+      .. include:: /../scripts/machine-launch-script.sh
+         :code: bash
+
+      This will pre-install all of the dependencies needed to run FireSim on your instance.
+
+5. On the next page ("Add Storage"), increase the size of the root EBS
    volume to ~300GB. The default of 150GB can quickly become tight as
    you accumulate large Vivado reports/outputs, large waveforms, XSim outputs,
-   and large root filesystems for simulations.
-5. You can skip the "Add Tags" page, unless you want tags.
-6. On the "Configure Security Group" page, select the ``firesim``
+   and large root filesystems for simulations. You can get rid of the
+   small (5GB) secondary volume that is added by default.
+6. You can skip the "Add Tags" page, unless you want tags.
+7. On the "Configure Security Group" page, select the ``firesim``
    security group that was automatically created for you earlier.
-7. On the review page, click the button to launch your instance.
+8. On the review page, click the button to launch your instance.
 
 Make sure you select the ``firesim`` key pair that we setup earlier.
 
@@ -53,8 +62,22 @@ Access your instance
 We **HIGHLY** recommend using `mosh <https://mosh.org/>`__ instead
 of ``ssh`` or using ``ssh`` with a screen/tmux session running on your
 manager instance to ensure that long-running jobs are not killed by a
-bad network connection to your manager instance. 
-Now, ``ssh`` or ``mosh`` into your instance (e.g. ``ssh -i firesim.pem centos@YOUR_INSTANCE_IP``).
+bad network connection to your manager instance. On this instance, the
+``mosh`` server is installed as part of the setup script we pasted
+before, so we need to first ssh into the instance and make sure the
+setup is complete.
+
+In either case, ``ssh`` into your instance (e.g. ``ssh -i firesim.pem centos@YOUR_INSTANCE_IP``) and wait until the
+``~/machine-launchstatus`` file contains all the following text:
+
+::
+
+    centos@ip-172-30-2-140.us-west-2.compute.internal:~$ cat machine-launchstatus
+    machine launch script started
+    machine launch script completed!
+
+Once this line appears, exit and re-``ssh`` into the system. If you want
+to use ``mosh``, ``mosh`` back into the system.
 
 Key Setup, Part 2
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This reverts to using the FPGA developer AMI for everything, pending some FireSim AMI publishing fixes.