### PR TITLE
Printf Cycle Count and FASED Functional Model Bugfixes

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,32 +10,32 @@
 # own images.
 
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-04fbd4e1e16e9cc06
+agfi=agfi-03e6e564659bd0aed
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-067142e76de97dcb4
+agfi=agfi-0459cfa6dad378686
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-0ee9ea5b27c928b58
+agfi=agfi-0c745f8af725cf074
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-0612f9e6c22bc6448
+agfi=agfi-00cedc0b7d4ccc9a6
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-0beded186d46e6c90
+agfi=agfi-0dd065a67365f8a56
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-singlecore-nic-lbp]
-agfi=agfi-0efd582a3bfcf11b4
+agfi=agfi-0b168a3effc91fc4a
 deploytripletoverride=None
 customruntimeconfig=None
 


### PR DESCRIPTION
This bumps MIDAS to fix the following:
- a bug where the printf driver was not properly counting null-token cycles, producing an incorrect cycle prefix
- a limitation imposed by FASED functional models that required ID Reuse * # IDs be a power of 2.