### PR TITLE
Fix redundant SBT_FLAGS adding

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -29,11 +29,12 @@ PLATFORM ?= f1
 ifdef FIRESIM_STANDALONE
 
 base_dir := $(firesim_base_dir)
+rocketchip_dir := $(firesim_base_dir)/target-rtl/chipyard/generators/rocket-chip
 
 JVM_MEMORY ?= 16G
 SCALA_VERSION ?= 2.12.4
-SBT_FLAGS ?= -J-Xmx$(JVM_MEMORY) ++$(SCALA_VERSION)
-SBT ?= sbt $(SBT_FLAGS)
+SBT_FLAGS ?= -J-Xmx$(JVM_MEMORY)
+SBT ?= java $(SBT_FLAGS) -jar $(rocketchip_dir)/sbt-launch.jar ++$(SCALA_VERSION)
 
 # Manage the FIRRTL dependency manually
 FIRRTL_SUBMODULE_DIR ?= $(firesim_base_dir)/target-rtl/chipyard/tools/firrtl

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -33,8 +33,8 @@ rocketchip_dir := $(firesim_base_dir)/target-rtl/chipyard/generators/rocket-chip
 
 JVM_MEMORY ?= 16G
 SCALA_VERSION ?= 2.12.4
-SBT_FLAGS ?= -J-Xmx$(JVM_MEMORY)
-SBT ?= java $(SBT_FLAGS) -jar $(rocketchip_dir)/sbt-launch.jar ++$(SCALA_VERSION)
+JAVA_ARGS ?= -J-Xmx$(JVM_MEMORY)
+SBT ?= java $(JAVA_ARGS) -jar $(rocketchip_dir)/sbt-launch.jar ++$(SCALA_VERSION)
 
 # Manage the FIRRTL dependency manually
 FIRRTL_SUBMODULE_DIR ?= $(firesim_base_dir)/target-rtl/chipyard/tools/firrtl

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -30,15 +30,16 @@ ifdef FIRESIM_STANDALONE
 
 base_dir := $(firesim_base_dir)
 
-SBT ?= sbt
 JVM_MEMORY ?= 16G
-SBT_FLAGS ?= -J-Xmx$(JVM_MEMORY) ++2.12.4
+SCALA_VERSION ?= 2.12.4
+SBT_FLAGS ?= -J-Xmx$(JVM_MEMORY) ++$(SCALA_VERSION)
+SBT ?= sbt $(SBT_FLAGS)
 
 # Manage the FIRRTL dependency manually
 FIRRTL_SUBMODULE_DIR ?= $(firesim_base_dir)/target-rtl/chipyard/tools/firrtl
 FIRRTL_JAR ?= $(firesim_base_dir)/target-rtl/chipyard/lib/firrtl.jar
 $(FIRRTL_JAR): $(shell find $(FIRRTL_SUBMODULE_DIR)/src/main/scala -iname "*.scala")
-	$(MAKE) -C $(FIRRTL_SUBMODULE_DIR) SBT="$(SBT) $(SBT_FLAGS)" root_dir=$(FIRRTL_SUBMODULE_DIR) build-scala
+	$(MAKE) -C $(FIRRTL_SUBMODULE_DIR) SBT="$(SBT)" root_dir=$(FIRRTL_SUBMODULE_DIR) build-scala
 	touch $(FIRRTL_SUBMODULE_DIR)/utils/bin/firrtl.jar
 	mkdir -p $(@D)
 	cp -p $(FIRRTL_SUBMODULE_DIR)/utils/bin/firrtl.jar $@
@@ -62,9 +63,9 @@ compile: $(VERILOG)
 
 # Phony targets for launching the sbt shell and running scalatests
 sbt: $(FIRRTL_JAR)
-	cd $(base_dir) && $(SBT) $(SBT_FLAGS) shell
+	cd $(base_dir) && $(SBT) shell
 test: $(FIRRTL_JAR)
-	cd $(base_dir) && $(SBT) $(SBT_FLAGS) test
+	cd $(base_dir) && $(SBT) test
 
 
 # All target-agnostic firesim recipes are defined here

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -36,8 +36,7 @@ common_chisel_args = $(patsubst $(base_dir)/%,%,$(GENERATED_DIR)) $(DESIGN_PACKA
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)
-	$(SBT) $(SBT_FLAGS) \
-	"runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
+	$(SBT) "runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
 
 ##########################
 # Driver Sources & Flags #

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -34,8 +34,8 @@ endif
 
 $(VERILOG) $(HEADER): $(SCALA_SOURCES) $(FIRRTL_JAR)
 	mkdir -p $(@D)
-	cd $(base_dir) && $(SBT) $(SBT_FLAGS) \
-	"project $(firesim_sbt_project)" "runMain firesim.firesim.FireSimGenerator $(if $(STROBER),strober,midas) $(common_chisel_args)"
+	cd $(base_dir) && \
+	$(SBT) "project $(firesim_sbt_project)" "runMain firesim.firesim.FireSimGenerator $(if $(STROBER),strober,midas) $(common_chisel_args)"
 
 ##########################
 # Driver Sources & Flags #
@@ -56,8 +56,8 @@ CONF_NAME ?= runtime.conf
 .PHONY: conf
 conf:
 	mkdir -p $(GENERATED_DIR)
-	cd $(base_dir) && $(SBT) $(SBT_FLAGS) \
-	"project $(firesim_sbt_project)" "runMain firesim.firesim.FireSimRuntimeConfGenerator $(CONF_NAME) $(common_chisel_args)"
+	cd $(base_dir) && \
+	$(SBT) "project $(firesim_sbt_project)" "runMain firesim.firesim.FireSimRuntimeConfGenerator $(CONF_NAME) $(common_chisel_args)"
 
 ################################################################
 # SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -32,8 +32,7 @@ CONF_NAME ?= runtime.conf
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)
-	$(SBT) $(SBT_FLAGS) \
-	"runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
+	$(SBT) "runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
 	# Remove once runtime conf generation is generalized, and something is always emitted
 	touch $(GENERATED_DIR)/$(CONF_NAME)
 

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -190,7 +190,7 @@ unittest_args = \
 		EMUL=$(EMUL) \
 		ROCKETCHIP_DIR=$(rocketchip_dir) \
 		GEN_DIR=$(unittest_generated_dir) \
-		SBT="$(SBT) $(SBT_FLAGS)" \
+		SBT="$(SBT)" \
 		CONFIG=$(UNITTEST_CONFIG)
 
 run-midas-unittests: $(chisel_srcs)


### PR DESCRIPTION
When firesim is being used as a library by chipyard, the SBT variable gets set to include the Java/SBT flags. The current make rules will thus redundantly add the flags, since they always call "$(SBT) $(SBT_FLAGS)". This changes the default SBT variable to include the flags and avoids adding SBT_FLAGS again when invoking sbt.