### PR TITLE
Add a .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+formats: all
+sphinx:
+  configuration: docs/conf.py
+submodules:
+   exclude: all
+python:
+   install:
+      - requirements: docs/requirements.txt


### PR DESCRIPTION
We were using a deprecated flag to skip submodule initialization --> switch to using the config which now natively supports this feature.