### PR TITLE
Fix `make {sbt, test}` and initialize memories to 0 in ML simulation

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -66,10 +66,9 @@ compile: $(VERILOG)
 
 # Phony targets for launching the sbt shell and running scalatests
 sbt: $(FIRRTL_JAR)
-	cd $(base_dir) && $(SBT) shell
+	cd $(base_dir) && $(SBT) "project $(firesim_sbt_project)" "shell"
 test: $(FIRRTL_JAR)
-	cd $(base_dir) && $(SBT) test
-
+	cd $(base_dir) && $(SBT) "project $(firesim_sbt_project)" "test"
 
 # All target-agnostic firesim recipes are defined here
 include target-agnostic.mk

--- a/sim/build.sbt
+++ b/sim/build.sbt
@@ -54,4 +54,3 @@ lazy val firesimLib = (project in file("firesim-lib"))
 // Contains example targets, like the MIDAS examples, and FASED tests
 lazy val firesim    = (project in file("."))
   .settings(commonSettings).dependsOn(chisel, rocketchip, midas, firesimLib % "test->test;compile->compile")
-  .aggregate(firechip)

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -67,7 +67,7 @@ TIMEOUT_CYCLES = 1000000000
 SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
 mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
 COMMON_SIM_ARGS ?= $(mem_model_args)
-vcs_args = +vcs+initreg+0
+vcs_args = +vcs+initreg+0 +vcs+initmem+0
 
 # Arguments used only at a particular simulation abstraction
 MIDAS_LEVEL_SIM_ARGS ?= +dramsim +max-cycles=$(TIMEOUT_CYCLES)

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -23,6 +23,12 @@ OUTPUT_DIR    := $(firesim_base_dir)/output/$(PLATFORM)/$(name_tuple)
 VERILOG := $(GENERATED_DIR)/FPGATop.v
 HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 
+ifdef FIRESIM_STANDALONE
+	firesim_sbt_project := firesim
+else
+	firesim_sbt_project := {file:${firesim_base_dir}/sim/}firesim
+endif
+
 submodules = \
     $(addprefix $(firesim_base_dir)/,. midas midas/targetutils firesim-lib) \
     $(addprefix $(chipyard_dir)/, \
@@ -36,7 +42,7 @@ common_chisel_args = $(patsubst $(firesim_base_dir)/%,%,$(GENERATED_DIR)) $(DESI
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)
-	$(SBT) "runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
+	$(SBT) "project $(firesim_sbt_project)" "runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
 
 ##########################
 # Driver Sources & Flags #

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -26,7 +26,7 @@ HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := firesim
 else
-	firesim_sbt_project := {file:${firesim_base_dir}/sim/}firesim
+	firesim_sbt_project := {file:${firesim_base_dir}/}firesim
 endif
 
 submodules = \

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -89,20 +89,21 @@ FPGA_LEVEL_SIM_ARGS ?=
 
 verilator = $(GENERATED_DIR)/V$(DESIGN)
 verilator_debug = $(GENERATED_DIR)/V$(DESIGN)-debug
+verilator_args =
 vcs = $(GENERATED_DIR)/$(DESIGN)
 vcs_debug = $(GENERATED_DIR)/$(DESIGN)-debug
-vcs_args = +vcs+initreg+0
+vcs_args = +vcs+initreg+0 +vcs+initmem+0
 xsim = $(GENERATED_DIR)/$(DESIGN)-$(PLATFORM)
 sim_binary_basename := $(basename $(notdir $(SIM_BINARY)))
 
 run-verilator: $(verilator)
 	cd $(dir $<) && \
-	$(verilator) +permissive $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY)) \
+	$(verilator) +permissive $(verilator_args) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY)) \
 	$(disasm) $(sim_binary_basename).out
 
 run-verilator-debug: $(verilator_debug)
 	cd $(dir $<) && \
-	$(verilator_debug) +permissive +waveform=$(sim_binary_basename).vpd $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY)) \
+	$(verilator_debug) +permissive $(verilator_args) +waveform=$(sim_binary_basename).vpd $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) +permissive-off $(abspath $(SIM_BINARY)) \
 	$(disasm) $(sim_binary_basename).out
 
 run-vcs: $(vcs)
@@ -149,16 +150,16 @@ endif
 # the binary name. These are captured with $($*_ARGS)
 $(OUTPUT_DIR)/%.run: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $($(EMUL)_args) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/% $(EMUL)
 	cd $(dir $($(EMUL))) && \
-	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
+	./$(notdir $($(EMUL))) $< +sample=$<.sample $($*_ARGS) $($(EMUL)_args) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	$(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(OUTPUT_DIR)/%.vpd: $(OUTPUT_DIR)/% $(EMUL)-debug
 	cd $(dir $($(EMUL)_debug)) && \
-	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
+	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) $($(EMUL)_args) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	$(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -33,7 +33,7 @@ CONF_NAME ?= runtime.conf
 SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
 mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
 COMMON_SIM_ARGS ?= $(mem_model_args)
-vcs_args = +vcs+initreg+0
+vcs_args = +vcs+initreg+0 +vcs+initmem+0
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -18,6 +18,12 @@ OUTPUT_DIR    := $(firesim_base_dir)/output/$(PLATFORM)/$(name_tuple)
 VERILOG := $(GENERATED_DIR)/FPGATop.v
 HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 
+ifdef FIRESIM_STANDALONE
+	firesim_sbt_project := firesim
+else
+	firesim_sbt_project := {file:${firesim_base_dir}/sim/}firesim
+endif
+
 submodules = \
     $(addprefix $(firesim_base_dir)/,. midas midas/targetutils firesim-lib) \
     $(addprefix $(chipyard_dir)/, \
@@ -37,7 +43,7 @@ vcs_args = +vcs+initreg+0 +vcs+initmem+0
 
 $(VERILOG) $(HEADER): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)
-	$(SBT) "runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
+	$(SBT) "project $(firesim_sbt_project)" "runMain $(DESIGN_PACKAGE).Generator $(if $(STROBER),strober,midas) $(common_chisel_args)"
 	# Remove once runtime conf generation is generalized, and something is always emitted
 	touch $(GENERATED_DIR)/$(CONF_NAME)
 

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -21,7 +21,7 @@ HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := firesim
 else
-	firesim_sbt_project := {file:${firesim_base_dir}/sim/}firesim
+	firesim_sbt_project := {file:${firesim_base_dir}/}firesim
 endif
 
 submodules = \

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -183,14 +183,20 @@ xsim: $(xsim)
 #########################
 UNITTEST_CONFIG ?= AllUnitTests
 
-rocketchip_dir := $(base_dir)/target-rtl/chipyard/generators/rocket-chip
+ifdef FIRESIM_STANDALONE
+	firesimLib_sbt_project := firesim
+else
+	firesimLib_sbt_project := {file:${firesim_base_dir}/}firesimLib
+endif
+
+rocketchip_dir := $(chipyard_dir)/generators/rocket-chip
 unittest_generated_dir := $(base_dir)/generated-src/unittests/$(UNITTEST_CONFIG)
 unittest_args = \
 		BASE_DIR=$(base_dir) \
 		EMUL=$(EMUL) \
 		ROCKETCHIP_DIR=$(rocketchip_dir) \
 		GEN_DIR=$(unittest_generated_dir) \
-		SBT="$(SBT)" \
+		SBT="$(SBT) \"project $(firesimLib_sbt_project)\" " \
 		CONFIG=$(UNITTEST_CONFIG)
 
 run-midas-unittests: $(chisel_srcs)


### PR DESCRIPTION
This PR fixes a number of chipyard-integration related breakages.
1. Fixes NIC and BlockDev tests which were failing on being unable to build target binaries under chipyard
2. Passes `vcs_args` to ML simulation execution targets that are driven by the generated *.d
2. Fixes `make test` and `make sbt` to set the right SBT project. Fixes #314  
3. [SBT] Stops aggregating firechip into firesim to make test behavior more sensible 

Finally, it also initializes memories to 0 under VCS (as Howie did with registers) to make MIDAS-level simulation behave more like an FPGA. 