### PR TITLE
Two Block Device Widget Fixes

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,32 +10,32 @@
 # own images.
 
 [fireboom-singlecore-nic-ddr3-llc4mb]
-agfi=agfi-00136b261a940f143
+agfi=agfi-025ab63ac6a29a904
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-ddr3-llc4mb]
-agfi=agfi-01e3f8263d0c3359f
+agfi=agfi-07fe490937fda5a9a
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-ddr3-llc4mb]
-agfi=agfi-064faf3698c685714
+agfi=agfi-09bf9c1b6a927e7a5
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-ddr3-llc4mb]
-agfi=agfi-0fdce5fc3f3b8092d
+agfi=agfi-0cd8e4590e15feafa
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-singlecore-no-nic-lbp]
-agfi=agfi-013a3fd09bb12de2d
+agfi=agfi-05a1f6d8a6c0b3cf6
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-singlecore-nic-lbp]
-agfi=agfi-0602572a8790c2ab8
+agfi=agfi-0fa472d20fe22b030
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/deploy/workloads/.gitignore
+++ b/deploy/workloads/.gitignore
@@ -7,5 +7,6 @@ iperf3
 check-rtc-linux
 bw-test-one-instance/*.riscv
 bw-test-two-instances/*.riscv
+linux-immediate-poweroff
 unittest/STRESSRUNS
 /gapbs

--- a/deploy/workloads/Makefile
+++ b/deploy/workloads/Makefile
@@ -119,4 +119,5 @@ coremark:
 	memcached-thread-imbalance bw-test-one-instance bw-test-two-instances \
 	ping-latency simperf-test simperf-test-latency simperf-test-scale \
 	iperf3 check-rtc check-rtc-linux allpaper checksum-test \
-	ccbench-cache-sweep flash-stress fc-test coremark
+	ccbench-cache-sweep flash-stress fc-test coremark \
+	linux-immediate-poweroff

--- a/sim/firesim-lib/src/main/scala/endpoints/BlockDevWidget.scala
+++ b/sim/firesim-lib/src/main/scala/endpoints/BlockDevWidget.scala
@@ -164,6 +164,9 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
 
     when (tFire) {
       when (done || idle) {
+        readRespBeatsLeft := 0.U
+        returnWrite := false.B
+
         // If a write-response is waiting, return it first
         when(writeLatencyPipe.io.deq.valid) {
           returnWrite := true.B
@@ -171,9 +174,6 @@ class BlockDevWidget(implicit p: Parameters) extends EndpointWidget()(p) {
         }.elsewhen(readLatencyPipe.io.deq.valid) {
           readRespBeatsLeft := readLatencyPipe.io.deq.bits * dataBeats.U
           readLatencyPipe.io.deq.ready := true.B
-        }.otherwise {
-          readRespBeatsLeft := 0.U
-          returnWrite := false.B
         }
       }.elsewhen(readRespBusy && target.resp.fire) {
         readRespBeatsLeft := readRespBeatsLeft - 1.U


### PR DESCRIPTION
This PR fixes two bugs in the block device widget on dev. See ucb-bar/midas#137
1) Pulls @armiasalib fix from master into dev (see #305)
2) Fixes a determinism bug whereby block device read requests would be served early under different host stalling behavior. Ideally the timing model in the block-device widget would be FAME1 transformed -- this would trivially gate state updates to the timing model under stall. I figured it was easier to instead change the DynamicLatencyPipe in MIDAS to simply drive valid high combinationally on cycle match.