### PR TITLE
Make sure serial_t destructor cleans up fesvr properly

### DIFF
--- a/sim/src/main/cc/endpoints/serial.cc
+++ b/sim/src/main/cc/endpoints/serial.cc
@@ -65,7 +65,7 @@ serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args, SERIALWID
 
 serial_t::~serial_t() {
     free(this->mmio_addrs);
-    free(fesvr);
+    delete fesvr;
 }
 
 void serial_t::init() {


### PR DESCRIPTION
I've long had a problem on the millennium machines in which terminating a firesim VCS simulation will cause a weird HTIF error to be printed out. I think I finally found the cause of it.

Since the `fesvr` object is created using `new`, it must be cleaned up using `delete`, not `free`.