### PR TITLE
Linux5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/firesim/network-benchmarks.git
 [submodule "sw/qemu"]
 	path = sw/qemu
-	url = git@github.com:qemu/qemu.git 
+	url = https://github.com/qemu/qemu.git 
 [submodule "deploy/workloads/memcached-thread-imbalance/mutilate-loadgen-riscv-release"]
 	path = deploy/workloads/memcached-thread-imbalance/mutilate-loadgen-riscv-release
 	url = https://github.com/firesim/mutilate-loadgen-riscv-release

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/firesim/network-benchmarks.git
 [submodule "sw/qemu"]
 	path = sw/qemu
-	url = https://github.com/riscv/riscv-qemu.git
+	url = git@github.com:qemu/qemu.git 
 [submodule "deploy/workloads/memcached-thread-imbalance/mutilate-loadgen-riscv-release"]
 	path = deploy/workloads/memcached-thread-imbalance/mutilate-loadgen-riscv-release
 	url = https://github.com/firesim/mutilate-loadgen-riscv-release

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -141,6 +141,9 @@ if wget -T 1 -t 3 -O /dev/null http://169.254.169.254/; then
     cd $RDIR
     sudo pip3 install -r sw/firesim-software/python-requirements.txt
     cat sw/firesim-software/centos-requirements.txt | sudo xargs yum install -y
+    pushd sw/firesim-software
+    ./marshal init
+    popd
 
     # run sourceme-f1-full.sh once on this machine to build aws libraries and
     # pull down some IP, so we don't have to waste time doing it each time on

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -141,9 +141,6 @@ if wget -T 1 -t 3 -O /dev/null http://169.254.169.254/; then
     cd $RDIR
     sudo pip3 install -r sw/firesim-software/python-requirements.txt
     cat sw/firesim-software/centos-requirements.txt | sudo xargs yum install -y
-    pushd sw/firesim-software
-    ./marshal init
-    popd
 
     # run sourceme-f1-full.sh once on this machine to build aws libraries and
     # pull down some IP, so we don't have to waste time doing it each time on

--- a/docs/Advanced-Usage/FireMarshal/FireMarshal-Commands.rst
+++ b/docs/Advanced-Usage/FireMarshal/FireMarshal-Commands.rst
@@ -36,6 +36,20 @@ FireMarshal will redirect much of it's output to a log file in order to keep
 standard out clean. This option instructs FireMarshal to print much more output to
 standard out (in addition to logging it).
 
+
+init
+--------------------------------------
+The init command is used to initialize a fresh clone of FireMarshal. It sets up
+the default linux kernel and initramfs source files along with any other
+one-time initialization tasks needed by FireMarshal. It is safe to run the init
+command multiple times, although you may see warnings about linux source
+patches being skipped. If you have no local changes to the default linux
+source, these should be safe to ignore.
+
+::
+
+   ./marshal init
+
 build
 --------------------------------------
 The build command is used to generate the rootfs's and boot-binaries from the

--- a/docs/Advanced-Usage/FireMarshal/FireMarshal-Commands.rst
+++ b/docs/Advanced-Usage/FireMarshal/FireMarshal-Commands.rst
@@ -22,13 +22,15 @@ By default, FireMarshal will search the same directory as the provided
 configuration file for ``base`` references and the workload source directory.
 This option instructs FireMarshal to look elsewhere for these references.
 
-``-i --initramfs``
+``-d --no-disk``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Alias: ``-i --initramfs``
+
 By default, FireMarshal assumes that your workload includes both a rootfs and a
 boot-binary. However, it may be necessary (e.g. when using spike) to build the
 rootfs into the boot-binary and load it into RAM during boot. This is only
 supported on linux-based workloads. This option instructs FireMarshal too use
-the \*-initramfs boot-binary instead of the disk-based outputs.
+the \*-nodisk boot-binary instead of the disk-based outputs.
 
 ``-v --verbose``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,26 +38,12 @@ FireMarshal will redirect much of it's output to a log file in order to keep
 standard out clean. This option instructs FireMarshal to print much more output to
 standard out (in addition to logging it).
 
-
-init
---------------------------------------
-The init command is used to initialize a fresh clone of FireMarshal. It sets up
-the default linux kernel and initramfs source files along with any other
-one-time initialization tasks needed by FireMarshal. It is safe to run the init
-command multiple times, although you may see warnings about linux source
-patches being skipped. If you have no local changes to the default linux
-source, these should be safe to ignore.
-
-::
-
-   ./marshal init
-
 build
 --------------------------------------
 The build command is used to generate the rootfs's and boot-binaries from the
 workload configuration file. The output will be ``images/NAME-JOBNAME-bin`` and
 ``images/NAME-JOBNAME.img`` files for each job in the workload. If you passed
-the --initramfs option to FireMarshal, a ``images/NAME-JOBNAME-bin-initramfs``
+the --nodisk option to FireMarshal, a ``images/NAME-JOBNAME-bin-nodisk``
 file will also be created.
 
 ::
@@ -91,7 +79,7 @@ to run using the --job option.
 In some cases, you may need to boot your workload in spike (typically due to a
 custom ISA extension or hardware model). In that case, you may use the -s
 option. Note that spike currently does not support network or block devices.
-You must pass the --initramfs option to FireMarshal when using spike.
+You must pass the --nodisk option to FireMarshal when using spike.
 
 clean
 --------------------------------------
@@ -111,7 +99,7 @@ included in the output directory.
 
 ``-s --spike``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Test using spike instead of qemu (requires the --initramfs option to the
+Test using spike instead of qemu (requires the --nodisk option to the
 ``marshal`` command).
 
 ``-m testDir --manual testDir``

--- a/docs/Advanced-Usage/FireMarshal/FireMarshal-Config.rst
+++ b/docs/Advanced-Usage/FireMarshal/FireMarshal-Config.rst
@@ -152,9 +152,10 @@ this workload. Defaults to the riscv-linux source submoduled at
 
 linux-config
 ^^^^^^^^^^^^^^^^
-Linux configuration file to use when building linux. Take care when using a
-custom configuration, FireSim may require certain boot arguments and device
-drivers to work properly.
+Linux configuration fragment(s) to use when building linux. A kernel
+configuration fragment contains one or more linux configuration options (in the
+same format as a standard linux configuration file). These options will
+override the default values for riscv-linux.
 
 host-init
 ^^^^^^^^^^^^^^

--- a/docs/Advanced-Usage/FireMarshal/FireMarshal-QuickStart.rst
+++ b/docs/Advanced-Usage/FireMarshal/FireMarshal-QuickStart.rst
@@ -12,8 +12,20 @@ All workload-generation related commands and code are in ``firesim/sw/firesim-so
 
 FireMarshal comes with a few basic workloads that you can build right out of
 the box (in ``workloads/``). In this example, we will build and test the
-buildroot-based linux distribution (called *br-base*). We begin by building the
-workload:
+buildroot-based linux distribution (called *br-base*).
+
+The first time you clone FireMarshal, you will need to initialize it. If you
+are using FireSim, the build-setup script will have already done this. It is
+safe to re-run the ``init`` command multiple times, although you may see
+warnings about skipping patches.
+
+::
+
+   ./marshal init
+
+
+Next, we build the workload. This will build the linux binary, the platform
+specific drivers (and initramfs), and the root filesystem:
 
 ::
 
@@ -23,7 +35,7 @@ The first time you build a workload may take a long time (buildroot must
 download and cross-compile a large number of packages), but subsequent builds
 of the same base will use cached results. Once the command completes, you
 should see two new files in ``images/``: ``br-base-bin`` and ``br-base.img``.
-These are the boot-binary (linux + boot loader) and root filesystem
+These are the boot-binary (linux, initramfs, and boot loader) and root filesystem
 (respectively). We can now launch this workload in qemu:
 
 ::

--- a/docs/Advanced-Usage/FireMarshal/FireMarshal-QuickStart.rst
+++ b/docs/Advanced-Usage/FireMarshal/FireMarshal-QuickStart.rst
@@ -14,17 +14,7 @@ FireMarshal comes with a few basic workloads that you can build right out of
 the box (in ``workloads/``). In this example, we will build and test the
 buildroot-based linux distribution (called *br-base*).
 
-The first time you clone FireMarshal, you will need to initialize it. If you
-are using FireSim, the build-setup script will have already done this. It is
-safe to re-run the ``init`` command multiple times, although you may see
-warnings about skipping patches.
-
-::
-
-   ./marshal init
-
-
-Next, we build the workload. This will build the linux binary, the platform
+We begin by building the workload. This will build the linux binary, the platform
 specific drivers (and initramfs), and the root filesystem:
 
 ::

--- a/docs/Advanced-Usage/FireMarshal/index.rst
+++ b/docs/Advanced-Usage/FireMarshal/index.rst
@@ -32,3 +32,4 @@ installed to firesim for running on real RTL.
    FireMarshal-QuickStart
    FireMarshal-Commands
    FireMarshal-Config
+   internal/index

--- a/docs/Advanced-Usage/FireMarshal/internal/Build.rst
+++ b/docs/Advanced-Usage/FireMarshal/internal/Build.rst
@@ -1,0 +1,117 @@
+Build Process
+=====================
+``wlutil/build.py``
+
+The goal of building a workload is to produce a working boot binary and
+(optionally) a root filesystem to boot from. The same outputs are used for
+Spike, Qemu, and FireSim. The one exception is that Spike does not support a
+disk, so users may choose to create an initramfs-only version of their workload
+for Spike (that binary will boot on Qemu and FireSim as well). The build process
+proceeds as follows:
+
+Build Parents
+--------------------
+The first step is to make sure the workload's base workload is ready. Marshal
+will first follow the dependency chain of bases and ensure that all
+dependencies are built before starting on the requested workload. Once the
+immediate parent is completed, Marshal begins the build process by create a
+copy of the parent's root filesystem to use as the basis for the requested
+workload (the distros hard-code their rootfs's to end the recursion).
+
+Host Init
+-------------------
+Before doing anything else, Marshal runs the workload's ``host-init`` script
+(if any) to prepare the workload. This script is allowed to do anything it
+wants, so we must run it early in the process in case it changes anything from
+the linux kernel source to the root filesystem overlay.
+
+Build Binary
+--------------------------------------
+``wlutil/build.py:makeBin()``
+
+We build the boot binary before finishing the rootfs because we may need to
+boot the workload in Qemu in order to build it. This step is skipped if the
+user provided a hard-coded boot binary.
+
+Create Final Linux Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Users provide only kernel configuration fragments that must be processed to
+create the real linux configuration. We first run 'make ARCH=riscv defconfig'
+in the linux source directory (either default or user-provided). We then append
+configuration options to include an initramfs (CONFIG_BLK_DEV_INITRD and
+CONFIG_INITRAMFS_SOURCE), more on that below. We then call a script provided by
+linux to combine the kernel fragments
+(``riscv-linux/scripts/kconfig/merge_config.sh``). The default configuration
+(including initramfs options) is only created once per source. If you change
+the default configuration in a custom kernel, you should manually delete the
+generated ``defconfig`` file.
+
+Generate Initramfs
+^^^^^^^^^^^^^^^^^^^^^^^^^
+FireSim provides a number of non-standard devices that require custom linux
+drivers. In particular, the block device driver is needed in order to boot a
+working system. Instead of maintaining a custom fork of the linux kernel (and
+requiring users to keep in sync with it), we provide a custom initramfs that
+boots before your main system and loads the drivers.
+
+The drivers for firesim are provided under ``boards/firechip/drivers``. Marshal
+first runs ``make modules_prepare`` in the linux source tree, and then compiles
+each driver against the provided source. This happens on each new build to
+ensure they receive the latest kernel source and configuration (especially
+important if the workload provides a custom kernel). We currently do not
+support alternative drivers, so any custom linux kernel must be compatible with
+the default kernel with regard to these drivers.
+
+Finally, we generate the initramfs cpio. ``marshal init`` prepared most of this
+for us by building busybox and creating the filesystem skeleton at
+``wlutil/initramfsRoot``. At build time, we additionally copy in the
+newly-built drivers and generate a script (``loadDrivers.sh``) that loads them
+at boot-time. Finally, we call ``makeInitramfs.sh`` to create the cpio. This
+script must be separate because it runs in a fakeroot environment to create the
+needed device nodes (e.g. ``/dev/console``).
+
+Note that for full-initramfs workloads (those constructed with the ``-i``
+flag), we cannot use our custom initramfs or drivers. Those workloads instead
+convert the target rootfs into an initramfs and use that. Users will need to
+manually build and load any drivers that they need.
+
+Linux Kernel Generation and Linking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+With all of the dependencies finished, we can finally compile the Linux kernel
+and link it with the bootloader. While each workload can use a custom kernel
+source, all workloads use the same bootloader (for now), located at
+``riscv-pk/``. The final linked bbl+linux+initramfs is coppied into
+``images/workloadName-bin``.
+
+Build Rootfs
+-------------------
+``wlutil/build.py:makeImage()``
+
+Add Files
+^^^^^^^^^^^^^^^^^
+Marshal internally converts both the ``files`` and ``overlay`` options into a
+list of ``FileSpec`` objects that describe the source and destination paths. We
+then mount the guest rootfs on ``disk-mount/`` using guestmount (see
+``applyOverlay()`` and ``copyImageFiles()`` in ``wlutil/wlutil.py``).
+
+.. Note:: Guestmount was used to remove the need for root permissions, but it
+  is somewhat slower and doesn't play nice with Ubuntu. The mounting method can
+  be changed via the ``mountImg()`` decorator in ``wlutil/wlutil.py``.
+
+Guest Init
+^^^^^^^^^^^^^^^
+Now that we have a working binary and root filesystem, we can run the user's
+``guest-init`` script (if provided). We configure the image to run this script
+on boot (see below for how), and boot exacly once in Qemu.
+
+Run Script or Command
+^^^^^^^^^^^^^^^^^^^^^^^^
+The final step is to apply the users ``run`` script or ``command`` options (if
+any). For simplicity, commands are converted into a run script (stored in
+``wlutil/_command.sh``) before proceeding.
+
+Run scripts are handled in a per-distro fashion (since distros acheive it in
+different ways). Marshal abstracts this by requesting that the distribution
+generate a "bootScriptOverlay" that we apply to the image. In Buildroot, this
+places the script in a known location and uses a hard-coded init script that
+runs it. Fedora has a systemd service that runs the script.

--- a/docs/Advanced-Usage/FireMarshal/internal/index.rst
+++ b/docs/Advanced-Usage/FireMarshal/internal/index.rst
@@ -1,0 +1,11 @@
+.. _firemarshal-internal:
+
+Implementation Details
+=============================
+
+.. toctree::
+   :maxdepth: 1
+
+   Build
+
+


### PR DESCRIPTION
This PR updates the firesim-software submodule to include the linux 5.3 bump and also includes some documentation updates to go along with it. FireMarshal also includes updated buildroot and fedora base images.

In this PR, I only added enough documentation to explain the changes introduced for the linux 5 bump. I will submit a future PR with more documentation, I just didn't want to clutter the already complicated process of updating firesim-software

see:
- firesim/FireMarshal#46
- firesim/FireMarshal#41
- firesim/FireMarshal#50