### PR TITLE
Add a .readthedocs.yml to appease the RTD deprecation gods

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+formats: all
+sphinx:
+  configuration: docs/conf.py
+submodules:
+   exclude: all
+python:
+   install:
+      - requirements: docs/requirements.txt


### PR DESCRIPTION
Cherry-picked from dev. This should fix failing doc builds on master (i hope).
