### PR TITLE
[config] Prepend FASEDEndpoints to EndpointMap in configs

### DIFF
--- a/sim/src/main/scala/firesim/SimConfigs.scala
+++ b/sim/src/main/scala/firesim/SimConfigs.scala
@@ -56,8 +56,7 @@ class WithTracerVWidget extends Config((site, here, up) => {
 // Instantiates an AXI4 memory model that executes (1 / clockDivision) of the frequency
 // of the RTL transformed model (Rocket Chip)
 class WithDefaultMemModel(clockDivision: Int = 1) extends Config((site, here, up) => {
-  case EndpointKey => up(EndpointKey) ++ EndpointMap(Seq(
-    new FASEDAXI4Endpoint(midas.core.ReciprocalClockRatio(clockDivision))))
+  case EndpointKey => EndpointMap(Seq(new FASEDAXI4Endpoint(midas.core.ReciprocalClockRatio(clockDivision)))) ++ up(EndpointKey, site)
   case LlcKey => None
   // Only used if a DRAM model is requested
   case DramOrganizationKey => DramOrganizationParams(maxBanks = 8, maxRanks = 4, dramSize = BigInt(1) << 34)


### PR DESCRIPTION
Since the updated Endpoint matcher class was appended instead of prepended to the EndpointMap, channel generation would see the older Endpoint definition first, and use the old frequency division.

This only affects configs that include at least _two_ instances of DefaultMemModel, with at least two different requested frequency divisions. Additionally, this only affects channel generation, the memory model constructor still gets the expected parameterization.

None of the default AGFIs use this feature. 