### PR TITLE
Use GNU make 4.x for toolchain build

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -61,20 +61,9 @@ do
     shift
 done
 
-# We're a submodule of rebar, so don't initalize the submodule
-# ignore riscv-tools for submodule init recursive
-# you must do this globally (otherwise riscv-tools deep
-# in the submodule tree will get pulled anyway
-git config submodule.toolchains/riscv-tools.update none
-git config --global submodule.experimental-blocks.update none
-git config --global submodule.sims/firesim.update none
 # Disable the REBAR submodule initially, and enable if we're not in library mode
 git config submodule.target-design/chipyard.update none
 git submodule update --init --recursive #--jobs 8
-# unignore riscv-tools,catapult-shell2 globally
-git config --global --unset submodule.sims/firesim.update
-git config --unset submodule.toolchains/riscv-tools.update
-git config --global --unset submodule.experimental-blocks.update
 
 if [ "$IS_LIBRARY" = false ]; then
     git config --unset submodule.target-design/chipyard.update

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -102,6 +102,16 @@ else
     target_chipyard_dir=$RDIR/target-design/chipyard
 fi
 
+# Enable latest Developer Toolset for GNU make 4.x
+devtoolset=''
+for dir in /opt/rh/devtoolset-* ; do
+    ! [ -x "${dir}/root/usr/bin/make" ] || devtoolset="${dir}"
+done
+if [ -n "${devtoolset}" ] ; then
+    echo "Enabling ${devtoolset##*/}"
+    . "${devtoolset}/enable"
+fi
+
 #build the toolchain through chipyard (whether as top or as library)
 cd $target_chipyard_dir
 if [ "$FASTINSTALL" = "true" ]; then

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -12,6 +12,10 @@ sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath
 sudo yum install -y gtk3-devel
 # deps for firesim-software (note that rsync is installed but too old)
 sudo yum install -y python36-pip python36-devel rsync
+# Install GNU make 4.x (needed to cross-compile glibc 2.28+)
+sudo yum install -y centos-release-scl
+sudo yum install -y devtoolset-8-make
+
 # install DTC. it's not available in repos in FPGA AMI
 DTCversion=dtc-1.4.4
 wget https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/$DTCversion.tar.gz


### PR DESCRIPTION
This is needed for `scripts/firesim-setup.sh` with ucb-bar/chipyard#261.

make 3.82 is still the default for CentOS release 7.6 (FPGA Developer AMI 1.6.0), which is too old for cross-compiling glibc 2.28 and newer.

The second commit includes minor cleanup to avoid unnecessary pollution of the global `.gitconfig`.