### PR TITLE
Manager changes for isolation for tutorials/courses

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -67,7 +67,8 @@ def iam_tutorial_mode():
         'securitygroupname': resptags['firesim-tutorial-securitygroupname'],
         'keyname':           resptags['firesim-tutorial-keyname'],
         's3bucketname' :     resptags['firesim-tutorial-s3bucketname'],
-        'snsname'      :     resptags['firesim-tutorial-snsname']
+        'snsname'      :     resptags['firesim-tutorial-snsname'],
+        'runfarmprefix':     resptags['firesim-tutorial-runfarmprefix'],
     }
 
     return returntags

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -10,15 +10,8 @@ from fabric.api import local
 
 rootLogger = logging.getLogger()
 
-# users are instructed to create a key named `firesim` in the wiki
-keyname = 'firesim'
-
 # this needs to be updated whenever the FPGA Dev AMI changes
 f1_ami_name = "FPGA Developer AMI - 1.6.0-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-0b1edf08d56c2da5c.4"
-
-# users are instructed to create these in the setup instructions
-securitygroupname = 'firesim'
-vpcname = 'firesim'
 
 # AMIs are region specific
 def get_f1_ami_id():
@@ -74,6 +67,12 @@ def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavi
 
          This will launch instances in avail zone 0, then once capacity runs out, zone 1, then zone 2, etc.
     """
+    # users are instructed to create a key named `firesim` in the wiki
+    keyname = 'firesim'
+    # users are instructed to create these in the setup instructions
+    securitygroupname = 'firesim'
+    vpcname = 'firesim'
+
     ec2 = boto3.resource('ec2')
     client = boto3.client('ec2')
 

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -43,9 +43,11 @@ def aws_resource_names():
     }
 
     # first get this instance's ID
-    res = local("""curl -s http://169.254.169.254/latest/meta-data/instance-id""", capture=True)
+    res = None
+    with hide('everything'):
+        res = local("""curl -s http://169.254.169.254/latest/meta-data/instance-id""", capture=True)
     instanceid = res.stdout
-    print(instanceid)
+    rootLogger.debug(instanceid)
 
     # try to get tags. if we don't have permission for this. return False
     client = boto3.client('ec2')
@@ -68,7 +70,7 @@ def aws_resource_names():
     resptags = {}
     for pair in resp['Tags']:
         resptags[pair['Key']] = pair['Value']
-    print(resptags)
+    rootLogger.debug(resptags)
 
     in_tutorial_mode = 'firesim-tutorial-username' in resptags.keys()
     if not in_tutorial_mode:

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -6,7 +6,7 @@ import logging
 import boto3
 import botocore
 from botocore import exceptions
-from fabric.api import local
+from fabric.api import local, hide
 
 rootLogger = logging.getLogger()
 

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -143,7 +143,6 @@ def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavi
          This will launch instances in avail zone 0, then once capacity runs out, zone 1, then zone 2, etc.
     """
 
-    # now, check if we're in tutorial mode and override if necessary
     aws_resource_names_dict = aws_resource_names()
     keyname = aws_resource_names_dict['keyname']
     securitygroupname = aws_resource_names_dict['securitygroupname']

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -19,8 +19,8 @@ def iam_tutorial_mode():
 
     Returns dict with at least:
         'firesim-tutorial-mode' set to True or False
-        if true, then also:
-            'vpcname', 'securitygroupname', 'keyname', 's3bucketname'.
+        if True, then also:
+            'vpcname', 'securitygroupname', 'keyname', 's3bucketname', 'snsname'.
 
     Note that these tags are NOT used to enforce the usage of these resources,
     rather just to configure the manager. Enforcement is done in IAM
@@ -66,7 +66,8 @@ def iam_tutorial_mode():
         'vpcname':           resptags['firesim-tutorial-vpcname'],
         'securitygroupname': resptags['firesim-tutorial-securitygroupname'],
         'keyname':           resptags['firesim-tutorial-keyname'],
-        's3bucketname' :     resptags['firesim-tutorial-s3bucketname']
+        's3bucketname' :     resptags['firesim-tutorial-s3bucketname'],
+        'snsname'      :     resptags['firesim-tutorial-snsname']
     }
 
     return returntags
@@ -340,9 +341,16 @@ def subscribe_to_firesim_topic(email):
     """ Subscribe a user to their FireSim SNS topic for notifications. """
     client = boto3.client('sns')
 
+    snsname = 'FireSim'
+
+    tutorial_mode_dict = iam_tutorial_mode()
+    if tutorial_mode_dict['firesim-tutorial-mode']:
+        # in tutorial mode, these are not just 'firesim'
+        snsname = tutorial_mode_dict['snsname']
+
     # this will either create the topic, if it doesn't exist, or just get the arn
     response = client.create_topic(
-        Name='FireSim'
+        Name=snsname
     )
     arn = response['TopicArn']
 
@@ -363,9 +371,16 @@ def send_firesim_notification(subject, body):
     """ Send a FireSim SNS Email notification. """
     client = boto3.client('sns')
 
+    snsname = 'FireSim'
+
+    tutorial_mode_dict = iam_tutorial_mode()
+    if tutorial_mode_dict['firesim-tutorial-mode']:
+        # in tutorial mode, these are not just 'firesim'
+        snsname = tutorial_mode_dict['snsname']
+
     # this will either create the topic, if it doesn't exist, or just get the arn
     response = client.create_topic(
-        Name='FireSim'
+        Name=snsname
     )
 
     arn = response['TopicArn']

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -75,12 +75,12 @@ def aws_resource_names():
         return base_dict
 
     # at this point, assume we are in tutorial mode and get all tags we need
-    base_dict['vpcname']           = resptags['firesim-tutorial-username'],
-    base_dict['securitygroupname'] = resptags['firesim-tutorial-username'],
-    base_dict['keyname']           = resptags['firesim-tutorial-username'],
-    base_dict['s3bucketname']      = resptags['firesim-tutorial-username'],
-    base_dict['snsname']           = resptags['firesim-tutorial-username'],
-    base_dict['runfarmprefix']     = resptags['firesim-tutorial-username'],
+    base_dict['vpcname']           = resptags['firesim-tutorial-username']
+    base_dict['securitygroupname'] = resptags['firesim-tutorial-username']
+    base_dict['keyname']           = resptags['firesim-tutorial-username']
+    base_dict['s3bucketname']      = resptags['firesim-tutorial-username']
+    base_dict['snsname']           = resptags['firesim-tutorial-username']
+    base_dict['runfarmprefix']     = resptags['firesim-tutorial-username']
 
     return base_dict
 

--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -89,10 +89,10 @@ class GlobalBuildConfig:
         self.s3_bucketname = \
             global_build_configfile.get('afibuild', 's3bucketname')
 
-        tutorial_mode_dict = iam_tutorial_mode()
-        if tutorial_mode_dict['firesim-tutorial-mode']:
+        aws_resource_names_dict = aws_resource_names()
+        if aws_resource_names_dict['s3bucketname'] is not None:
             # in tutorial mode, special s3 bucket name
-            self.s3_bucketname = tutorial_mode_dict['s3bucketname']
+            self.s3_bucketname = aws_resource_names_dict['s3bucketname']
 
         self.build_instance_market = \
                 global_build_configfile.get('afibuild', 'buildinstancemarket')

--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -88,6 +88,12 @@ class GlobalBuildConfig:
 
         self.s3_bucketname = \
             global_build_configfile.get('afibuild', 's3bucketname')
+
+        tutorial_mode_dict = iam_tutorial_mode()
+        if tutorial_mode_dict['firesim-tutorial-mode']:
+            # in tutorial mode, special s3 bucket name
+            self.s3_bucketname = tutorial_mode_dict['s3bucketname']
+
         self.build_instance_market = \
                 global_build_configfile.get('afibuild', 'buildinstancemarket')
         self.spot_interruption_behavior = \

--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -28,8 +28,12 @@ class BuildConfig:
         return """{}-{}-{}""".format(self.DESIGN, self.TARGET_CONFIG, self.PLATFORM_CONFIG)
 
     def launch_build_instance(self, build_instance_market,
-                          spot_interruption_behavior, spot_max_price):
-        """ Launch an instance to run this build. """
+                          spot_interruption_behavior, spot_max_price,
+                              buildfarmprefix):
+        """ Launch an instance to run this build.
+        buildfarmprefix can be None.
+        """
+        buildfarmprefix = '' if buildfarmprefix is None else buildfarmprefix
         num_instances = 1
         self.launched_instance_object = launch_instances(self.instancetype,
                           num_instances, build_instance_market,
@@ -44,6 +48,7 @@ class BuildConfig:
                                   },
                               },
                           ],
+                          tags={ 'fsimbuildcluster': buildfarmprefix },
                           randomsubnet=True)[0]
 
     def get_launched_instance_object(self):
@@ -125,10 +130,19 @@ class GlobalBuildConfig:
 
     def launch_build_instances(self):
         """ Launch an instance for the builds we want to do """
+
+        # get access to the runfarmprefix, which we will apply to build
+        # instances too now.
+        aws_resource_names_dict = aws_resource_names()
+        # just duplicate the runfarmprefix for now. This can be None,
+        # in which case we give an empty build farm prefix
+        build_farm_prefix = aws_resource_names_dict['runfarmprefix']
+
         for build in self.builds_list:
             build.launch_build_instance(self.build_instance_market,
                                         self.spot_interruption_behavior,
-                                        self.spot_max_price)
+                                        self.spot_max_price,
+                                        build_farm_prefix)
 
     def wait_build_instances(self):
         """ block until all build instances are launched """

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -251,10 +251,10 @@ class InnerRuntimeConfiguration:
         self.runfarmtag = runfarmtagprefix + runtime_dict['runfarm']['runfarmtag']
 
         # now, check if we're in tutorial mode and set extra prefix if so
-        tutorial_mode_dict = iam_tutorial_mode()
-        if tutorial_mode_dict['firesim-tutorial-mode']:
-            # in tutorial mode, further prefix runfarmtag
-            self.runfarmtag = tutorial_mode_dict['runfarmprefix'] + "-" + self.runfarmtag
+        aws_resource_names_dict = aws_resource_names()
+        if aws_resource_names_dict['runfarmprefix'] is not None:
+            # if specified, further prefix runfarmtag
+            self.runfarmtag = aws_resource_names_dict['runfarmprefix'] + "-" + self.runfarmtag
 
         self.f1_16xlarges_requested = int(runtime_dict['runfarm']['f1_16xlarges']) if 'f1_16xlarges' in runtime_dict['runfarm'] else 0
         self.f1_4xlarges_requested = int(runtime_dict['runfarm']['f1_4xlarges']) if 'f1_4xlarges' in runtime_dict['runfarm'] else 0

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -250,7 +250,6 @@ class InnerRuntimeConfiguration:
 
         self.runfarmtag = runfarmtagprefix + runtime_dict['runfarm']['runfarmtag']
 
-        # now, check if we're in tutorial mode and set extra prefix if so
         aws_resource_names_dict = aws_resource_names()
         if aws_resource_names_dict['runfarmprefix'] is not None:
             # if specified, further prefix runfarmtag

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -244,8 +244,18 @@ class InnerRuntimeConfiguration:
             rootLogger.warning(overridefield + "=" + overridevalue)
             runtime_dict[overridesection][overridefield] = overridevalue
 
-        runfarmtagprefix = "" if 'FIRESIM_RUNFARM_PREFIX' not in os.environ else os.environ['FIRESIM_RUNFARM_PREFIX'] + "-"
+        runfarmtagprefix = "" if 'FIRESIM_RUNFARM_PREFIX' not in os.environ else os.environ['FIRESIM_RUNFARM_PREFIX']
+        if runfarmtagprefix != "":
+            runfarmtagprefix += "-"
+
         self.runfarmtag = runfarmtagprefix + runtime_dict['runfarm']['runfarmtag']
+
+        # now, check if we're in tutorial mode and set extra prefix if so
+        tutorial_mode_dict = iam_tutorial_mode()
+        if tutorial_mode_dict['firesim-tutorial-mode']:
+            # in tutorial mode, further prefix runfarmtag
+            self.runfarmtag = tutorial_mode_dict['runfarmprefix'] + "-" + self.runfarmtag
+
         self.f1_16xlarges_requested = int(runtime_dict['runfarm']['f1_16xlarges']) if 'f1_16xlarges' in runtime_dict['runfarm'] else 0
         self.f1_4xlarges_requested = int(runtime_dict['runfarm']['f1_4xlarges']) if 'f1_4xlarges' in runtime_dict['runfarm'] else 0
         self.m4_16xlarges_requested = int(runtime_dict['runfarm']['m4_16xlarges']) if 'm4_16xlarges' in runtime_dict['runfarm'] else 0


### PR DESCRIPTION
This adds a tutorial mode for the manager (will also be useful for classes) that externally sets a bunch of parameters based on tags applied to the manager instance. This is merely for configuration of the manager -- enforcement of these things happens in IAM policies.

This sets a per-user:
vpcname
securitygroup
keyname
snsname
s3bucketname

I have not tested this heavily, this PR is just for early feedback right now.