### PR TITLE
Add support for a firesim-software symlink in chipyard.

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -69,7 +69,7 @@ if [ "$IS_LIBRARY" = false ]; then
     git config --unset submodule.target-design/chipyard.update
     git submodule update --init target-design/chipyard
     cd $RDIR/target-design/chipyard
-    ./scripts/init-submodules-no-riscv-tools.sh
+    ./scripts/init-submodules-no-riscv-tools.sh --no-firesim
     cd $RDIR
 fi
 


### PR DESCRIPTION
Add support for having a FireMarshal submodule in chipyard. This should be safe to merge before the chipyard update (the '--no-firesim' option won't do anything on the old script).

Note the FireMarshal submodule update, it points to:
See: firesim/firemarshal#52