### PR TITLE
Add SHA-3 demo recipe

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build.ini
+++ b/deploy/sample-backup-configs/sample_config_build.ini
@@ -26,6 +26,8 @@ fireboom-singlecore-nic-ddr3-llc4mb
 #firesim-supernode-quadcore-nic-ddr3-llc4mb
 firesim-supernode-singlecore-nic-lbp
 fireboom-singlecore-no-nic-ddr3-llc4mb-gg
+# for MICRO 2019 tutorial. May be removed in the future.
+firesim-singlecore-sha3-l2-nic-ddr3-llc4mb
 
 
 [agfistoshare]
@@ -43,6 +45,8 @@ fireboom-singlecore-nic-ddr3-llc4mb
 #firesim-supernode-quadcore-nic-ddr3-llc4mb
 firesim-supernode-singlecore-nic-lbp
 fireboom-singlecore-no-nic-ddr3-llc4mb-gg
+# for MICRO 2019 tutorial. May be removed in the future.
+firesim-singlecore-sha3-l2-nic-ddr3-llc4mb
 
 [sharewithaccounts]
 somebodysname=123456789012

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -136,3 +136,11 @@ PLATFORM_CONFIG=FireSimDDR3FRFCFSLLC4MBConfig_MCRams_F90MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
+# SHA-3 Demo Recipes
+
+[firesim-singlecore-sha3-l2-nic-ddr3-llc4mb]
+DESIGN=FireSim
+TARGET_CONFIG=FireSimRocketChipSha3L2Config
+PLATFORM_CONFIG=FireSimDDR3FRFCFSLLC4MBConfig_F90MHz
+instancetype=c5.4xlarge
+deploytriplet=None


### PR DESCRIPTION
This adds a `firesim-singlecore-sha3-l2-nic-ddr3-llc4mb` recipe for the tutorial.  The LLC model might not be necessary with the L2 present, but it's used here to be consistent with other recipes.

The chipyard submodule points to ucb-bar/chipyard#265.