### PR TITLE
Enable devtoolset for only the toolchain build

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -91,24 +91,32 @@ else
     target_chipyard_dir=$RDIR/target-design/chipyard
 fi
 
-# Enable latest Developer Toolset for GNU make 4.x
-devtoolset=''
-for dir in /opt/rh/devtoolset-* ; do
-    ! [ -x "${dir}/root/usr/bin/make" ] || devtoolset="${dir}"
-done
-if [ -n "${devtoolset}" ] ; then
-    echo "Enabling ${devtoolset##*/}"
-    . "${devtoolset}/enable"
-fi
 
-#build the toolchain through chipyard (whether as top or as library)
-cd $target_chipyard_dir
-if [ "$FASTINSTALL" = "true" ]; then
-  $target_chipyard_dir/scripts/build-toolchains.sh --ec2fast
-else
-  $target_chipyard_dir/scripts/build-toolchains.sh
-fi
-cd $RDIR
+# Restrict the devtoolset environment to a subshell
+#
+# The devtoolset wrapper around sudo does not correctly pass options
+# through, which causes an aws-fpga SDK setup script to fail:
+# platforms/f1/aws-fpga/sdk/userspace/install_fpga_mgmt_tools.sh
+(
+    # Enable latest Developer Toolset for GNU make 4.x
+    devtoolset=''
+    for dir in /opt/rh/devtoolset-* ; do
+        ! [ -x "${dir}/root/usr/bin/make" ] || devtoolset="${dir}"
+    done
+    if [ -n "${devtoolset}" ] ; then
+        echo "Enabling ${devtoolset##*/}"
+        . "${devtoolset}/enable"
+    fi
+
+    # Build the toolchain through chipyard (whether as top or as library)
+    cd "$target_chipyard_dir"
+    if [ "$FASTINSTALL" = "true" ] ; then
+        ./scripts/build-toolchains.sh --ec2fast
+    else
+        ./scripts/build-toolchains.sh
+    fi
+)
+
 #generate env.sh file which sources the chipyard env.sh file
 echo "if [ -f \"$target_chipyard_dir/env.sh\" ]; then" > env.sh
 echo "  source $target_chipyard_dir/env.sh" >> env.sh


### PR DESCRIPTION
This restricts the devtoolset environment to a subshell to avoid breaking the aws-fpga SDK setup.

The devtoolset wrapper around `sudo` does not correctly pass options through.

```
Root privileges are required to install. You may be asked for your password...
+ sudo -E /mnt/firesim/src/chipyard/sims/firesim/platforms/f1/aws-fpga/sdk/userspace/install_fpga_mgmt_tools.sh
/var/tmp/scleJG4F6: line 8: -E: command not found
+ exit 127
Error: install_fpga_mgmt_tools.sh returned 127
Error: AWS SDK install was unsuccessful, sdk_install.sh returned 0
```