### PR TITLE
Remove FireBoom DUT, Add AFI for Hetero-Boom+Rocket

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build.ini
+++ b/deploy/sample-backup-configs/sample_config_build.ini
@@ -33,6 +33,7 @@ firesim-singlecore-sha3-nic-l2-llc4mb-ddr3
 firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3
 fireboom-dualcore-no-nic-l2-llc4mb-ddr3
 fireboom-dualcore-nic-l2-llc4mb-ddr3
+firerocketboom-1x1core-no-nic-ddr3-llc4mb
 
 [agfistoshare]
 # Legacy recipe without an L2
@@ -57,6 +58,7 @@ firesim-singlecore-sha3-nic-l2-llc4mb-ddr3
 firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3
 fireboom-dualcore-no-nic-l2-llc4mb-ddr3
 fireboom-dualcore-nic-l2-llc4mb-ddr3
+firerocketboom-1x1core-no-nic-ddr3-llc4mb
 
 [sharewithaccounts]
 somebodysname=123456789012

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -88,42 +88,42 @@ deploytriplet=None
 
 # Single-core, BOOM-based targets
 [fireboom-singlecore-no-nic-l2-lbp]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-l2-llc4mb-ddr3]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-singlecore-nic-l2-llc4mb-ddr3]
-DESIGN=FireBoom
+DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-lbp]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-llc4mb-ddr3]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-singlecore-nic-llc4mb-ddr3]
-DESIGN=FireBoom
+DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
 instancetype=c5.4xlarge
@@ -131,42 +131,42 @@ deploytriplet=None
 
 # Dual-core, BOOM-based targets
 [fireboom-dualcore-no-nic-l2-lbp]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-dualcore-no-nic-l2-llc4mb-ddr3]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-dualcore-nic-l2-llc4mb-ddr3]
-DESIGN=FireBoom
+DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-dualcore-no-nic-lbp]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-dualcore-no-nic-llc4mb-ddr3]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-dualcore-nic-llc4mb-ddr3]
-DESIGN=FireBoom
+DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
 instancetype=c5.4xlarge
@@ -174,7 +174,7 @@ deploytriplet=None
 
 # Quad-core, BOOM-based targets
 [fireboom-quadcore-nic-l2-llc4mb-ddr3]
-DESIGN=FireBoom
+DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F50MHz
 instancetype=c5.4xlarge
@@ -182,7 +182,7 @@ deploytriplet=None
 
 # As above, with Golden Gate multi-ported RAM optimizations
 [fireboom-quadcore-nic-l2-llc4mb-ddr3-ramopt]
-DESIGN=FireBoom
+DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F50MHz_MCRams
 instancetype=c5.4xlarge
@@ -236,7 +236,7 @@ instancetype=c5.4xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
-DESIGN=FireBoomNoNIC
+DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_MCRams_F90MHz
 instancetype=c5.4xlarge

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -258,3 +258,10 @@ TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipSha3L2Config
 PLATFORM_CONFIG=BaseF1Config_F120MHz
 instancetype=c5.4xlarge
 deploytriplet=None
+
+[firerocketboom-1x1core-no-nic-ddr3-llc4mb]
+DESIGN=FireSimNoNIC
+TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimRocketBoomConfig
+PLATFORM_CONFIG=BaseF1Config_F75MHz
+instancetype=c5.4xlarge
+deploytriplet=None

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -8,6 +8,11 @@
 # Only AGFIs for the latest release of FireSim are guaranteed to be available.
 # If you are using an older version of FireSim, you will need to generate your
 # own images.
+[firerocketboom-1x1core-no-nic-ddr3-llc4mb]
+agfi=agfi-00304223095b134f4
+deploytripletoverride=None
+customruntimeconfig=None
+
 [fireboom-dualcore-nic-l2-llc4mb-ddr3]
 agfi=agfi-00b93ed6068dfe13d
 deploytripletoverride=None

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -8,11 +8,6 @@
 # Only AGFIs for the latest release of FireSim are guaranteed to be available.
 # If you are using an older version of FireSim, you will need to generate your
 # own images.
-[firerocketboom-1x1core-no-nic-ddr3-llc4mb]
-agfi=agfi-00304223095b134f4
-deploytripletoverride=None
-customruntimeconfig=None
-
 [fireboom-dualcore-nic-l2-llc4mb-ddr3]
 agfi=agfi-00b93ed6068dfe13d
 deploytripletoverride=None
@@ -62,6 +57,11 @@ customruntimeconfig=None
 
 [firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3]
 agfi=agfi-0679d5d17ba885886
+deploytripletoverride=None
+customruntimeconfig=None
+
+[firerocketboom-1x1core-no-nic-ddr3-llc4mb]
+agfi=agfi-00304223095b134f4
 deploytripletoverride=None
 customruntimeconfig=None
 


### PR DESCRIPTION
This PR is to be used in conjunction with the following Chipyard PR: https://github.com/ucb-bar/chipyard/pull/277

This removes the use of FireBoom as a DUT since BOOM uses a new DCache that doesn't use the `ExcludeInvalidBoomAssertions`. This also makes it so that there is less duplication around DUT's.