### PR TITLE
[Configs] Change FASED default line lengths to 64B

### DIFF
--- a/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
@@ -87,7 +87,7 @@ class LBP32R32W extends Config(
   new WithFuncModelLimits(32,32) ++
   new WithDefaultMemModel)
 
-class LBP32R32WLLC4MB extends Config(
+class LBP32R32WLLC2MB extends Config(
   new WithLLCModel(4096, 8) ++
   new WithFuncModelLimits(32,32) ++
   new WithDefaultMemModel)
@@ -100,7 +100,7 @@ class LBP32R32W3Div extends Config(
 
 // DDR3 - FCFS models.
 class FCFS16GBQuadRank extends Config(new WithDDR3FIFOMAS(8) ++ new WithDefaultMemModel)
-class FCFS16GBQuadRankLLC4MB extends Config(
+class FCFS16GBQuadRankLLC2MB extends Config(
   new WithLLCModel(4096, 8) ++
   new FCFS16GBQuadRank)
 
@@ -110,12 +110,12 @@ class FRFCFS16GBQuadRank(clockDiv: Int = 1) extends Config(
   new WithDDR3FRFCFS(8, 8) ++
   new WithDefaultMemModel(clockDiv)
 )
-class FRFCFS16GBQuadRankLLC4MB extends Config(
+class FRFCFS16GBQuadRankLLC2MB extends Config(
   new WithLLCModel(4096, 8) ++
   new FRFCFS16GBQuadRank
 )
 
-class FRFCFS16GBQuadRankLLC4MB3Div extends Config(
+class FRFCFS16GBQuadRankLLC2MB3Div extends Config(
   new WithLLCModel(4096, 8) ++
   new FRFCFS16GBQuadRank(3)
 )

--- a/sim/src/main/scala/fasedtests/Config.scala
+++ b/sim/src/main/scala/fasedtests/Config.scala
@@ -53,7 +53,7 @@ class FRFCFSConfig extends Config(
   new DefaultConfig)
 
 class LLCDRAMConfig extends Config(
-  new FRFCFS16GBQuadRankLLC4MB ++
+  new FRFCFS16GBQuadRankLLC2MB ++
   new DefaultConfig)
 
 


### PR DESCRIPTION
[This is not RTL changing]

With the current parameterization (generation-time configuration) of FASED, to get the full 4MB capacity you need to use 128B lines at runtime. I'm seeing anomalous behavior in some benchmarks at this length, and so i'm reducing this to 64B which not only matches the line size of our target machines, but was more heavily validated and also matches the default size we used until recently.

I will generate a plot with CCBench and drop it in here.

To port existing HWDB entries, we just need to search-replace 4MB -> 2MB and everything will just work without needing to rebuild AGFIs.