### PR TITLE
Re-add FASED runtime config generation support 

### DIFF
--- a/sim/firesim-lib/src/main/scala/util/GeneratorUtils.scala
+++ b/sim/firesim-lib/src/main/scala/util/GeneratorUtils.scala
@@ -92,24 +92,3 @@ trait HasFireSimGeneratorUtilities extends HasTargetAgnosticUtilites {
     af.close()
   }
 }
-
- // A runtime-configuration generation for memory models
-// Args
-//   0: filename (basename)
-//   1: Output directory (same as above)
-//   Remaining argments are the same as above
-object FireSimRuntimeConfGenerator extends App with HasFireSimGeneratorUtilities {
-  val longName = "confGenerator"
-  require(1==0, "See Midas #132")
-  lazy val generatorArgs = GeneratorArgs(args)
-  lazy val genDir = new File(names.targetDir)
-  // We need the scala instance of an elaborated memory-model, so that settings
-  // may be legalized against the generated hardware. TODO: Currently these
-  // settings aren't dependent on the target-AXI4 widths (~bug); this will need
-  // to be an optional post-generation step in MIDAS
-  //lazy val memModel = (hostParams(midas.models.MemModelKey))(hostParams alterPartial {
-  //    case junctions.NastiKey => junctions.NastiParameters(64, 32, 4)})// Related note ^
-  //chisel3.Driver.elaborate(() => memModel)
-  //val confFileName = args(0)
-  //memModel.getSettings(confFileName)(hostParams)
-}

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -29,6 +29,8 @@ ANNO_FILE := $(GENERATED_DIR)/$(long_name).anno.json
 VERILOG := $(GENERATED_DIR)/FPGATop.v
 HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 
+CONF_NAME ?= runtime.conf
+
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := firesim
 else
@@ -60,16 +62,6 @@ DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, fasedtests/*
 
 TARGET_CXX_FLAGS := -g -O2 -I$(driver_dir) -I$(driver_dir)/fasedtests -I$(RISCV)/include
 TARGET_LD_FLAGS :=
-
-####################################
-# Runtime-Configuraiton Generation #
-####################################
-CONF_NAME ?= runtime.conf
-#.PHONY: conf
-#conf:
-#	mkdir -p $(GENERATED_DIR)
-#	$(SBT) $(SBT_FLAGS) \
-#	"runMain $(DESIGN_PACKAGE).FireSimRuntimeConfGenerator $(CONF_NAME) $(common_chisel_args)"
 
 ################################################################
 # SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -60,16 +60,6 @@ $(info $(DRIVER_CC))
 TARGET_CXX_FLAGS := -g -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include
 TARGET_LD_FLAGS :=
 
-####################################
-# Runtime-Configuraiton Generation #
-####################################
-CONF_NAME ?= runtime.conf
-.PHONY: conf
-conf:
-	mkdir -p $(GENERATED_DIR)
-	cd $(base_dir) && \
-	$(SBT) "project $(firesim_sbt_project)" "runMain firesim.firesim.FireSimRuntimeConfGenerator $(CONF_NAME) $(common_chisel_args)"
-
 ################################################################
 # SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #
 ################################################################

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -26,6 +26,9 @@ ANNO_FILE ?=
 PLATFORM_CONFIG_PACKAGE ?= firesim.midasexamples
 PLATFORM_CONFIG ?= DefaultF1Config
 
+# The name of the generated runtime configuration file
+CONF_NAME ?= runtime.conf
+
 # The host platform type
 PLATFORM ?= f1
 
@@ -54,9 +57,23 @@ $(VERILOG) $(HEADER): $(FIRRTL_FILE) $(ANNO_FILE)
 		-E verilog"
 
 ####################################
-# Runtime-Configuraiton Generation #
+# Runtime-Configuration Generation #
 ####################################
-CONF_NAME ?= runtime.conf
+
+# This reads in the annotations from a generated target, elaborates a
+# FASEDTimingModel if a BridgeAnnoation for one exists, and asks for user input
+# to generate a runtime configuration that is compatible with the generated
+# hardware (BridgeModule). Useful for modelling a memory system that differs from the default.
+.PHONY: conf
+conf: $(ANNO_FILE)
+	mkdir -p $(GENERATED_DIR)
+	cd $(base_dir) && \
+	$(SBT) "project $(midas_sbt_project)" "runMain midas.stage.RuntimeConfigGeneratorMain \
+		-td $(GENERATED_DIR) \
+		-ggaf $(ANNO_FILE) \
+		-ggcp $(PLATFORM_CONFIG_PACKAGE) \
+		-ggcs $(PLATFORM_CONFIG) \
+		-ggrc $(CONF_NAME)"
 
 ####################################
 # Verilator MIDAS-Level Simulators #


### PR DESCRIPTION
[Not RTL changing; not a depedency for the MICRO tutorial; must go into 1.7 release]

Resolves #315. See ucb-bar/midas#148. 

This fixes and improves a feature I broke during the port to chipyard.