### PR TITLE
Add ground test bridge and bridge driver

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/groundtest.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/groundtest.cc
@@ -1,0 +1,28 @@
+//See LICENSE for license details
+#ifdef GROUNDTESTBRIDGEMODULE_struct_guard
+
+#include "groundtest.h"
+
+groundtest_t::groundtest_t(
+        simif_t *sim, const std::vector<std::string> &args,
+        GROUNDTESTBRIDGEMODULE_struct *mmio_addrs) :
+    bridge_driver_t(sim), sim(sim), mmio_addrs(mmio_addrs)
+{
+
+}
+
+groundtest_t::~groundtest_t()
+{
+    free(this->mmio_addrs);
+}
+
+void groundtest_t::init()
+{
+}
+
+void groundtest_t::tick()
+{
+    _success = read(this->mmio_addrs->success);
+}
+
+#endif

--- a/sim/firesim-lib/src/main/cc/bridges/groundtest.h
+++ b/sim/firesim-lib/src/main/cc/bridges/groundtest.h
@@ -1,0 +1,29 @@
+//See LICENSE for license details
+#ifndef __GROUNDTEST_H
+#define __GROUNDTEST_H
+
+#include "bridges/bridge_driver.h"
+
+#ifdef GROUNDTESTBRIDGEMODULE_struct_guard
+class groundtest_t: public bridge_driver_t
+{
+  public:
+    groundtest_t(
+        simif_t *sim, const std::vector<std::string> &args,
+        GROUNDTESTBRIDGEMODULE_struct *mmio_addrs);
+    ~groundtest_t();
+
+    virtual void init();
+    virtual void tick();
+    virtual bool terminate() { return _success; }
+    virtual int  exit_code() { return 0; }
+    virtual void finish() {};
+
+  private:
+    bool _success = false;
+    simif_t* sim;
+    GROUNDTESTBRIDGEMODULE_struct *mmio_addrs;
+};
+#endif
+
+#endif

--- a/sim/firesim-lib/src/main/scala/bridges/GroundTestBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/GroundTestBridge.scala
@@ -1,0 +1,44 @@
+//See LICENSE for license details
+package firesim.bridges
+
+import midas.widgets._
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.config.Parameters
+
+class GroundTestBridge extends BlackBox
+    with Bridge[HostPortIO[GroundTestBridgeTargetIO], GroundTestBridgeModule] {
+  val io = IO(new GroundTestBridgeTargetIO)
+  val bridgeIO = HostPort(io)
+  val constructorArg = None
+  generateAnnotations()
+}
+
+object GroundTestBridge {
+  def apply(success: Bool)(implicit p: Parameters): GroundTestBridge = {
+    val bridge = Module(new GroundTestBridge)
+    bridge.io.success := success
+    bridge
+  }
+}
+
+class GroundTestBridgeTargetIO extends Bundle {
+  val success = Input(Bool())
+}
+
+class GroundTestBridgeModule(implicit p: Parameters)
+    extends BridgeModule[HostPortIO[GroundTestBridgeTargetIO]] {
+  val io = IO(new WidgetIO)
+  val hPort = IO(HostPort(new GroundTestBridgeTargetIO))
+
+  hPort.toHost.hReady := true.B
+  hPort.fromHost.hValid := true.B
+
+  val success = RegInit(false.B)
+
+  when (hPort.hBits.success && !success) { success := true.B }
+
+  genROReg(success, "success")
+  genCRFile()
+}

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -8,6 +8,7 @@
 #include "bridges/simplenic.h"
 #include "bridges/blockdev.h"
 #include "bridges/tracerv.h"
+#include "bridges/groundtest.h"
 
 // Golden Gate provided bridge drivers
 #include "bridges/fpga_model.h"
@@ -328,6 +329,49 @@ uint64_t host_mem_offset = -0x80000000LL;
     #ifdef TRACERVBRIDGEMODULE_7_PRESENT
     TRACERVBRIDGEMODULE_7_substruct_create;
     add_bridge_driver(new tracerv_t(this, args, TRACERVBRIDGEMODULE_7_substruct, 7, TRACERVBRIDGEMODULE_7_DMA_ADDR));
+    #endif
+#endif
+
+#ifdef GROUNDTESTBRIDGEMODULE_struct_guard
+    #ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
+    GROUNDTESTBRIDGEMODULE_0_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_0_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_1_PRESENT
+    GROUNDTESTBRIDGEMODULE_1_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_1_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_2_PRESENT
+    GROUNDTESTBRIDGEMODULE_2_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_2_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_3_PRESENT
+    GROUNDTESTBRIDGEMODULE_3_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_3_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_4_PRESENT
+    GROUNDTESTBRIDGEMODULE_4_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_4_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_5_PRESENT
+    GROUNDTESTBRIDGEMODULE_5_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_5_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_6_PRESENT
+    GROUNDTESTBRIDGEMODULE_6_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_6_substruct));
+    #endif
+    #ifdef GROUNDTESTBRIDGEMODULE_7_PRESENT
+    GROUNDTESTBRIDGEMODULE_7_substruct_create;
+    add_bridge_driver(new groundtest_t(
+            this, args, GROUNDTESTBRIDGEMODULE_7_substruct));
     #endif
 #endif
 

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -164,3 +164,20 @@ $(OUTPUT_DIR)/%.vpd: $(OUTPUT_DIR)/% $(EMUL)-debug
 	./$(notdir $($(EMUL)_debug)) $< +sample=$<.sample +waveform=$@ $($*_ARGS) $($(EMUL)_args) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
 	$(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
+# TraceGen rules
+
+AXE_DIR=$(chipyard_dir)/tools/axe/src
+AXE=$(AXE_DIR)/axe
+
+$(OUTPUT_DIR)/tracegen.out: $($(EMUL))
+	mkdir -p $(OUTPUT_DIR) && \
+	cd $(dir $($(EMUL))) && \
+	./$(notdir $($(EMUL))) +sample=$<.sample $($(EMUL)_args) $(COMMON_SIM_ARGS) $(MIDAS_LEVEL_SIM_ARGS) $(EXTRA_SIM_ARGS) \
+	2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
+
+$(OUTPUT_DIR)/tracegen.result: $(OUTPUT_DIR)/tracegen.out $(AXE)
+	$(chipyard_dir)/scripts/check-tracegen.sh $< > $@
+
+fsim-tracegen: $(OUTPUT_DIR)/tracegen.result
+
+.PHONY: fsim-tracegen


### PR DESCRIPTION
This bridge is needed to allow FireSimTraceGen to exit cleanly.