### PR TITLE
Remove FASED configs that model clock division in channels

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -79,13 +79,6 @@ PLATFORM_CONFIG=BaseF1Config_F90MHz
 instancetype=c5.4xlarge
 deploytriplet=None
 
-[firesim-quadcore-no-nic-llc4mb-ddr3-3div]
-DESIGN=FireSimNoNIC
-TARGET_CONFIG=DDR3FRFCFSLLC4MB3Div_FireSimRocketChipQuadCoreConfig
-PLATFORM_CONFIG=BaseF1Config
-instancetype=c5.4xlarge
-deploytriplet=None
-
 # Single-core, BOOM-based targets
 [fireboom-singlecore-no-nic-l2-lbp]
 DESIGN=FireSimNoNIC

--- a/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
@@ -26,7 +26,9 @@ class WithDefaultMemModel(clockDivision: Int = 1) extends Config((site, here, up
     llcKey = site(LlcKey))
 
   case MemModelKey => new LatencyPipeConfig(site(BaseParamsKey))
-})
+}) {
+  require(clockDivision == 1, "Endpoint clock-division temporarily removed until FireSim 1.8.0")
+}
 
 
 /*******************************************************************************


### PR DESCRIPTION
This feature was removed in Golden Gate as the CDC channels require a ground-up rewrite to interface compatibly with the new LI-BDN-complaint FAME1 transform. 

More general support for modeling this will be re-provided in the next FireSim release (1.8.0) before ICCAD this November.