### PR TITLE
Add optional, host-stateful assertions for checking token irrevocability

### DIFF
--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -83,3 +83,8 @@ class F1ConfigWithSnapshot extends Config(new Config((site, here, up) => {
   case EnableSnapshot => true
 }) ++ new F1Config)
 
+// Turns on all additional synthesizable debug features for checking the
+// implementation of the simulator.
+class HostDebugFeatures extends Config((site, here, up) => {
+  case GenerateTokenIrrevocabilityAssertions => true
+})

--- a/sim/midas/src/main/scala/midas/core/SimWrapper.scala
+++ b/sim/midas/src/main/scala/midas/core/SimWrapper.scala
@@ -273,9 +273,6 @@ class SimWrapper(chAnnos: Seq[FAMEChannelConnectionAnnotation],
       case None => channelPorts.elements(s"${chAnno.globalName}_source") <> channel.io.out
     }
 
-    AssertTokenIrrevocable(channel.io.in, Some(s"${chAnno.globalName}_in"))
-    AssertTokenIrrevocable(channel.io.out, Some(s"${chAnno.globalName}_out"))
-
     channel.io.trace.ready := DontCare
     channel.io.traceLen := DontCare
     channel
@@ -338,11 +335,6 @@ class SimWrapper(chAnnos: Seq[FAMEChannelConnectionAnnotation],
         case None => channelPorts.rvOutputPortMap(chName)
       })
       bindRVChannelDeq(channel.io.deq, deqPortPair)
-
-      channel.io.enq.fwdIrrevocabilityAssertions(Some(strippedName))
-      channel.io.enq.revIrrevocabilityAssertions(Some(strippedName))
-      channel.io.deq.fwdIrrevocabilityAssertions(Some(strippedName))
-      channel.io.deq.revIrrevocabilityAssertions(Some(strippedName))
 
       channel.io.trace := DontCare
       channel.io.traceLen := DontCare

--- a/sim/midas/src/main/scala/midas/core/SimWrapper.scala
+++ b/sim/midas/src/main/scala/midas/core/SimWrapper.scala
@@ -273,6 +273,9 @@ class SimWrapper(chAnnos: Seq[FAMEChannelConnectionAnnotation],
       case None => channelPorts.elements(s"${chAnno.globalName}_source") <> channel.io.out
     }
 
+    AssertTokenIrrevocable(channel.io.in, Some(s"${chAnno.globalName}_in"))
+    AssertTokenIrrevocable(channel.io.out, Some(s"${chAnno.globalName}_out"))
+
     channel.io.trace.ready := DontCare
     channel.io.traceLen := DontCare
     channel
@@ -335,6 +338,11 @@ class SimWrapper(chAnnos: Seq[FAMEChannelConnectionAnnotation],
         case None => channelPorts.rvOutputPortMap(chName)
       })
       bindRVChannelDeq(channel.io.deq, deqPortPair)
+
+      channel.io.enq.fwdIrrevocabilityAssertions(Some(strippedName))
+      channel.io.enq.revIrrevocabilityAssertions(Some(strippedName))
+      channel.io.deq.fwdIrrevocabilityAssertions(Some(strippedName))
+      channel.io.deq.revIrrevocabilityAssertions(Some(strippedName))
 
       channel.io.trace := DontCare
       channel.io.traceLen := DontCare

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -24,12 +24,13 @@ abstract class TutorialSuite(
     targetConfigProject = "firesim.midasexamples",
     targetConfigs = targetConfigs,
     platformConfigProject = "firesim.midasexamples",
-    platformConfigs = "DefaultF1Config")
+    platformConfigs = "HostDebugFeatures_DefaultF1Config")
 
   val args = Seq(s"+tracelen=$tracelen") ++ simulationArgs
   val commonMakeArgs = Seq(s"TARGET_PROJECT=midasexamples",
                            s"DESIGN=$targetName",
-                           s"TARGET_CONFIG=${generatorArgs.targetConfigs}")
+                           s"TARGET_CONFIG=${generatorArgs.targetConfigs}",
+                           s"PLATFORM_CONFIG=${generatorArgs.platformConfigs}")
   val targetTuple = generatorArgs.tupleName
 
   def run(backend: String,


### PR DESCRIPTION
This enables generation of stateful assertions to check that bridges and models are generating tokens irrevocably. Failure to do so is one common source of non-determinism in FireSim simulations. Setting `GeneratingTokenIrrevocabilityAssertions=true` in your `PLATFORM_CONFIG` will generate these assertions; these can be used to check for violations in MIDAS-level simulations. 

I will enable these by default in chipyard's CI once when we bump FireSim there. 