### PR TITLE
Fix Target-Level Simulation When FireSim is Top

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -31,7 +31,7 @@ PLATFORM ?= f1
 ifdef FIRESIM_STANDALONE
 
 base_dir := $(firesim_base_dir)
-chipyard_dir := $(firesim_base_dir)/target-rtl/chipyard
+chipyard_dir := $(abspath ..)/target-design/chipyard
 rocketchip_dir := $(chipyard_dir)/generators/rocket-chip
 
 JVM_MEMORY ?= 16G
@@ -40,8 +40,8 @@ JAVA_ARGS ?= -Xmx$(JVM_MEMORY)
 SBT ?= java $(JAVA_ARGS) -jar $(rocketchip_dir)/sbt-launch.jar ++$(SCALA_VERSION)
 
 # Manage the FIRRTL dependency manually
-FIRRTL_SUBMODULE_DIR ?= $(firesim_base_dir)/target-rtl/chipyard/tools/firrtl
-FIRRTL_JAR ?= $(firesim_base_dir)/target-rtl/chipyard/lib/firrtl.jar
+FIRRTL_SUBMODULE_DIR ?= $(chipyard_dir)/tools/firrtl
+FIRRTL_JAR ?= $(chipyard_dir)/lib/firrtl.jar
 $(FIRRTL_JAR): $(shell find $(FIRRTL_SUBMODULE_DIR)/src/main/scala -iname "*.scala")
 	$(MAKE) -C $(FIRRTL_SUBMODULE_DIR) SBT="$(SBT)" root_dir=$(FIRRTL_SUBMODULE_DIR) build-scala
 	touch $(FIRRTL_SUBMODULE_DIR)/utils/bin/firrtl.jar
@@ -52,7 +52,7 @@ firrtl: $(FIRRTL_JAR)
 .PHONY: firrtl
 
 else
-# REBAR make variables
+# Chipyard make variables
 base_dir := $(abspath ../../..)
 sim_dir := $(firesim_base_dir)
 chipyard_dir := $(base_dir)

--- a/sim/build.sbt
+++ b/sim/build.sbt
@@ -31,7 +31,7 @@ lazy val firesimAsLibrary = sys.env.get("FIRESIM_STANDALONE") == None
 lazy val chipyardDir = if(firesimAsLibrary) {
   file("../../../")
 } else {
-  file("target-rtl/chipyard")
+  file("../target-design/chipyard")
 }
 
 lazy val chisel        = ProjectRef(chipyardDir, "chisel")

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -33,7 +33,7 @@ HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 common_chisel_args = $(patsubst $(base_dir)/%,%,$(GENERATED_DIR)) $(DESIGN_PACKAGE) $(DESIGN) $(TARGET_CONFIG_PACKAGE) $(TARGET_CONFIG) $(PLATFORM_CONFIG_PACKAGE) $(PLATFORM_CONFIG)
 
 ifdef FIRESIM_STANDALONE
-	firesim_sbt_project := {file:${firesim_base_dir}/target-rtl/chipyard/}firechip
+	firesim_sbt_project := {file:${chipyard_dir}}firechip
 else
 	firesim_sbt_project := firechip
 endif


### PR DESCRIPTION
[This requires a Chipyard bump or a branch of Chipyard. Will not merge until we have reason to bump.] 

Presently, if you're using FireSim-as-top, you can't cd into chipyard and run simulations out of sims/verilator or sims/vcs. This, alongside ucb-bar/chipyard#328, fixes that. 