### PR TITLE
[midasexamples] Fix PeekPoke use in AssertionModule to issue token irrevocably

### DIFF
--- a/sim/src/main/cc/midasexamples/AssertModule.h
+++ b/sim/src/main/cc/midasexamples/AssertModule.h
@@ -19,26 +19,36 @@ public:
         poke(io_c, 0);
         step(1);
         poke(reset, 0);
-        step(1);
-        poke(io_cycleToFail, 1024);
-        poke(io_a, 1);
-        step(4096, false);
-        while (!done()) {
-            assert_endpoint->tick();
-            if (assert_endpoint->terminate()) {
-                if (assertions_thrown == 0) {
-                    poke(io_cycleToFail, 2048);
-                    poke(io_b, 1);
-                    poke(io_a, 0);
-                } else if (assertions_thrown == 1) {
+        int num_test_cases = 3;
+        int test_case = 0;
+        for (int test_case = 0; test_case < num_test_cases; test_case++) {
+            switch(test_case) {
+                case 0:
+                    poke(io_cycleToFail, 1024);
+                    poke(io_a, 1);
+                    step(2048, false);
+                    break;
+                case 1:
                     poke(io_cycleToFail, 3056);
                     poke(io_b, 0);
                     poke(io_c, 1);
-                } else {
+                    step(2048, false);
+                    break;
+                case 2:
                     poke(io_c, 0);
+                    poke(io_cycleToFail, 5183);
+                    step(2048, false);
+                    break;
+                default:
+                    throw new std::runtime_error("No test case associated with id " + std::to_string(test_case));
+                    break;
+            }
+            while (!done()) {
+                assert_endpoint->tick();
+                if (assert_endpoint->terminate()) {
+                    assert_endpoint->resume();
+                    assertions_thrown++;
                 }
-                assert_endpoint->resume();
-                assertions_thrown++;
             }
         }
         expect(assertions_thrown == 3, "EXPECT: Three assertions thrown");


### PR DESCRIPTION
Resolves a failing test in chipyard CI. 