### PR TITLE
Better Marshal Submodule Handling

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -63,7 +63,13 @@ done
 
 # Disable the REBAR submodule initially, and enable if we're not in library mode
 git config submodule.target-design/chipyard.update none
+git config submodule.sw/firesim-software.update none
 git submodule update --init --recursive #--jobs 8
+
+# firesim-software should not be recursively initialized by default (use
+# sw/firesim-software/init-submodules.sh if you need linux deps)
+git config --unset submodule.sw/firesim-software.update
+git submodule update --init sw/firesim-software
 
 if [ "$IS_LIBRARY" = false ]; then
     git config --unset submodule.target-design/chipyard.update

--- a/scripts/first-clone-setup-fast.sh
+++ b/scripts/first-clone-setup-fast.sh
@@ -13,4 +13,5 @@ make f1
 
 # build target software
 cd ../sw/firesim-software
-./marshal -v build workloads/br-base.json
+./init-submodules.sh
+./marshal -v build br-base.json


### PR DESCRIPTION
FireMarshal is no longer initialized recursively by default (you have to manually
./init-submodules.sh in firesim-software). This also removes the sha3 workload (see ucb-bar/sha3#17).