### PR TITLE
Add perl(ExtUtils::Embed) yum package

### DIFF
--- a/scripts/install-nbd-kmod.sh
+++ b/scripts/install-nbd-kmod.sh
@@ -1,4 +1,5 @@
 # This script produces the nbd kernel module to use on run farm nodes.
+set -e
 
 # deps
 sudo yum -y install xmlto asciidoc hmaccalc newt-devel pesign elfutils-devel binutils-devel audit-libs-devel numactl-devel pciutils-devel python-docutils "perl(ExtUtils::Embed)"

--- a/scripts/install-nbd-kmod.sh
+++ b/scripts/install-nbd-kmod.sh
@@ -1,7 +1,7 @@
 # This script produces the nbd kernel module to use on run farm nodes.
 
 # deps
-sudo yum -y install xmlto asciidoc hmaccalc newt-devel pesign elfutils-devel binutils-devel audit-libs-devel numactl-devel pciutils-devel python-docutils
+sudo yum -y install xmlto asciidoc hmaccalc newt-devel pesign elfutils-devel binutils-devel audit-libs-devel numactl-devel pciutils-devel python-docutils "perl(ExtUtils::Embed)"
 
 # update this as FPGA Dev AMI updates
 KSRC="3.10.0-957.5.1.el7"


### PR DESCRIPTION
the ndb kernel object required an additional package that I didn't have by default (perl(ExtUtil::Embed)). This just adds it to the dependency list.