### PR TITLE
make sure SCALA_SOURCES set properly in standalone mode

### DIFF
--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -34,6 +34,10 @@ common_chisel_args = $(patsubst $(base_dir)/%,%,$(GENERATED_DIR)) $(DESIGN_PACKA
 
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := {file:${chipyard_dir}}firechip
+
+	lookup_scala_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "*.scala" -print 2> /dev/null)
+	SOURCE_DIRS = $(chipyard_dir)/generators $(firesim_base_dir)
+	SCALA_SOURCES = $(call lookup_scala_srcs,$(SOURCE_DIRS))
 else
 	firesim_sbt_project := firechip
 endif


### PR DESCRIPTION
This redundancy with the chipyard makefrag is kind of annoying, but I don't really see a better way of doing this.