### PR TITLE
Fix TraceRV driver

### DIFF
--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -253,15 +253,15 @@ class InnerRuntimeConfiguration:
         self.profileinterval = int(runtime_dict['targetconfig']['profileinterval'])
         # Default values
         self.trace_enable = False
-        self.trace_select = 0
-        self.trace_start = 0
-        self.trace_end = -1
+        self.trace_select = "0"
+        self.trace_start = "0"
+        self.trace_end = "-1"
         self.autocounter_readrate = 0
         if 'tracing' in runtime_dict:
             self.trace_enable = runtime_dict['tracing'].get('enable') == "yes"
             self.trace_select = runtime_dict['tracing'].get('selector', "0")
-            self.trace_start = int(runtime_dict['tracing'].get('start', "0"))
-            self.trace_end = int(runtime_dict['tracing'].get('end', "-1"))
+            self.trace_start = runtime_dict['tracing'].get('start', "0")
+            self.trace_end = runtime_dict['tracing'].get('end', "-1")
         if 'autocounter' in runtime_dict:
             self.autocounter_readrate = int(runtime_dict['autocounter'].get('readrate', "0"))
         self.defaulthwconfig = runtime_dict['targetconfig']['defaulthwconfig']

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
@@ -245,12 +245,12 @@ void tracerv_t::flush() {
                 }
             }
         } else {
-            for (int i = 0; i < QUEUE_DEPTH * 8; i+=8) {
+            for (int i = 0; i < beats_available * 8; i+=8) {
                 // this stores as raw binary. stored as little endian.
                 // e.g. to get the same thing as the human readable above,
                 // flip all the bytes in each 512-bit line.
-                for (int q = 0; q < NUM_CORES; q++) {
-                    fwrite(OUTBUF + (i+q), sizeof(uint64_t), 1, this->tracefiles[q]);
+                for (int q = 0; q < 8; q++) {
+                    fwrite(OUTBUF + (i+q), sizeof(uint64_t), 1, this->tracefiles[0]);
                 }
             }
         }

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
@@ -111,7 +111,6 @@ tracerv_t::~tracerv_t() {
 }
 
 void tracerv_t::init() {
-    cur_cycle = 0;
     if (this->trigger_selector == 1)
     {
       write(this->mmio_addrs->triggerSelector, this->trigger_selector);
@@ -194,7 +193,6 @@ void tracerv_t::tick() {
                 }
             }
         }
-        cur_cycle += QUEUE_DEPTH;
     }
 }
 
@@ -255,6 +253,5 @@ void tracerv_t::flush() {
             }
         }
     }
-   cur_cycle += beats_available;
 }
 #endif // TRACERVBRIDGEMODULE_struct_guard


### PR DESCRIPTION
1. TraceRV flush() function wasn't updated to match tick() function, so the final entries in the TRACEFILE weren't correct.
2. Don't need cur_cycle anymore since that's sent in the PCIe output now.
3. Manager start/stop needs to take strings, not ints, since they could be hex values in the case of PC/instruction triggering