### PR TITLE
Fix "Fix Copy Results Failure"

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -279,7 +279,7 @@ class FireSimServerNode(FireSimNode):
                     rfsname = """/home/centos/sim_slot_{}/{}""".format(simserverindex, rfsname)
 
                 run("""sudo mount {blockfile} {mntpt}""".format(blockfile=rfsname, mntpt=mountpoint))
-                run("""sudo chattr -R -i {}""".format(mountpoint))
+                run("""sudo chattr -i {}/etc/sysconfig/nfs""".format(mountpoint))
                 run("""sudo chown -R centos {}""".format(mountpoint))
 
             ## copy back files from inside the rootfs


### PR DESCRIPTION
Ok I trusted that the `-R` flag would work on `chattr` and that is not true. Even if you add the `-f` to it, it still gives an error code of `1` despite it working afterward (similar to `chmod`ing then it working afterwards). So #456 needs to be patched. 

Here are two options for a quick fix (which I think should go into the next Chipyard bump).

1. Just change the file attributes on the faulty file (`nfs`)
2. Ignore the error code 1 and continue with the copying.

IMO # 1 is better since we know that we are going to fix this later down the line. Thoughts?