### PR TITLE
[makefrags] Remove an errant info statement in firesim's makefrag

### DIFF
--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -528,7 +528,7 @@ void firesim_top_t::run() {
     }
 
     if (do_zero_out_dram) {
-        fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few seconds...\n");
+        fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few minutes...\n");
         zero_out_dram();
     }
     fprintf(stderr, "Commencing simulation.\n");

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -60,7 +60,6 @@ DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, firesim/*)))
             $(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* fesvr/*)))  \
 			$(RISCV)/lib/libfesvr.a
 
-$(info $(DRIVER_CC))
 TARGET_CXX_FLAGS := -g -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include
 TARGET_LD_FLAGS :=
 


### PR DESCRIPTION
Also be more forthright about DRAM initialization time. 