### PR TITLE
[manager] Change default build instances to z1d.2xlarge

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -11,42 +11,42 @@
 DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_FireSimRocketChipSingleCoreConfig
 PLATFORM_CONFIG=BaseF1Config
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-singlecore-no-nic-l2-lbp]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_FireSimRocketChipSingleCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-singlecore-nic-lbp]
 DESIGN=FireSim
 TARGET_CONFIG=FireSimRocketChipSingleCoreConfig
 PLATFORM_CONFIG=BaseF1Config
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-singlecore-no-nic-lbp]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=FireSimRocketChipSingleCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F130MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 #[firesim-quadcore-nic-lbp]
 #DESIGN=FireSim
 #TARGET_CONFIG=FireSimRocketChipQuadCoreConfig
 #PLATFORM_CONFIG=BaseF1Config
-#instancetype=c5.4xlarge
+#instancetype=z1d.2xlarge
 #deploytriplet=None
 #
 #[firesim-quadcore-no-nic-lbp]
 #DESIGN=FireSimNoNIC
 #TARGET_CONFIG=FireSimRocketChipQuadCoreConfig
 #PLATFORM_CONFIG=BaseF1Config
-#instancetype=c5.4xlarge
+#instancetype=z1d.2xlarge
 #deploytriplet=None
 
 # Quad-core, Rocket-based recipes
@@ -55,28 +55,28 @@ deploytriplet=None
 DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-quadcore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-quadcore-nic-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-quadcore-no-nic-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # Single-core, BOOM-based targets
@@ -84,42 +84,42 @@ deploytriplet=None
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-singlecore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F50MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-lbp]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-singlecore-nic-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # Dual-core, BOOM-based targets
@@ -127,42 +127,42 @@ deploytriplet=None
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-dualcore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-dualcore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F50MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-dualcore-no-nic-lbp]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-dualcore-no-nic-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-dualcore-nic-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimBoomDualCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F80MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # Quad-core, BOOM-based targets
@@ -170,7 +170,7 @@ deploytriplet=None
 DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F50MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # As above, with Golden Gate multi-ported RAM optimizations
@@ -178,7 +178,7 @@ deploytriplet=None
 DESIGN=FireSim
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F50MHz_MCRams
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # Supernode configurations -- multiple instances of an SoC in a single simulator
@@ -186,28 +186,28 @@ deploytriplet=None
 DESIGN=FireSimSupernode
 TARGET_CONFIG=SupernodeFireSimRocketChipConfig
 PLATFORM_CONFIG=BaseF1Config_F85MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-supernode-quadcore-nic-lbp]
 DESIGN=FireSimSupernode
 TARGET_CONFIG=SupernodeFireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-supernode-singlecore-nic-llc4mb-ddr3]
 DESIGN=FireSimSupernode
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_SupernodeFireSimRocketChipConfig
 PLATFORM_CONFIG=BaseF1Config_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-supernode-quadcore-nic-llc4mb-ddr3]
 DESIGN=FireSimSupernode
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_SupernodeFireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # MIDAS Examples -- BUILD SUPPORT ONLY; Can't launch driver correctly on runfarm
@@ -216,7 +216,7 @@ TARGET_PROJECT=midasexamples
 DESIGN=GCD
 TARGET_CONFIG=NoConfig
 PLATFORM_CONFIG=DefaultF1Config
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # Golden Gate Multi-Cycle RAM Optimization Demo Recipes
@@ -225,14 +225,14 @@ deploytriplet=None
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimRocketChipQuadCoreConfig
 PLATFORM_CONFIG=BaseF1Config_MCRams_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [fireboom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimBoomConfig
 PLATFORM_CONFIG=BaseF1Config_MCRams_F90MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 # ADDITIONAL MICRO DEMO RECIPES
@@ -242,33 +242,33 @@ deploytriplet=None
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipSha3L2Config
 PLATFORM_CONFIG=BaseF1Config_F120MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipSha3L2Config
 PLATFORM_CONFIG=BaseF1Config_F120MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-singlecore-sha3-nic-l2-llc4mb-ddr3-print]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipSha3L2PrintfConfig
 PLATFORM_CONFIG=WithPrintfSynthesis_BaseF1Config_F120MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3-print]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimRocketChipSha3L2PrintfConfig
 PLATFORM_CONFIG=WithPrintfSynthesis_BaseF1Config_F120MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firerocketboom-1rx1b-no-nic-l2-ddr3-llc4mb]
 DESIGN=FireSimNoNIC
 TARGET_CONFIG=L2SingleBank512K_DDR3FRFCFSLLC4MB_FireSimRocketBoomConfig
 PLATFORM_CONFIG=BaseF1Config_F75MHz
-instancetype=c5.4xlarge
+instancetype=z1d.2xlarge
 deploytriplet=None

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -5,6 +5,10 @@
 # edit config_build.ini to actually "turn on" a config to be built when you run
 # buildafi
 
+# Note: For large designs (ones that would fill a EC2.2xlarge/Xilinx VU9P)
+# Vivado uses in excess of 32 GiB. Keep this in mind when selecting a
+# non-default instancetype.
+
 # Single-core, Rocket-based recipes
 
 [firesim-singlecore-nic-l2-lbp]

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -344,7 +344,7 @@ Targets<generating-different-targets>`).
 """""""""""""""""""
 
 This defines the type of instance that the build will run on. Generally, running
-on a ``c5.4xlarge`` is sufficient. In our experience, using more powerful instances
+on a ``z1d.2xlarge`` is sufficient. In our experience, using more powerful instances
 than this provides little gain.
 
 ``deploytriplet``

--- a/docs/Building-a-FireSim-AFI.rst
+++ b/docs/Building-a-FireSim-AFI.rst
@@ -40,7 +40,10 @@ parallel, with the parameters listed in the relevant section of the
 ``deploy/config_build_recipes.ini`` file. Here you can set parameters of the simulated
 system, and also select the type of instance on which the Vivado build will be
 deployed. From our experimentation, there are diminishing returns using
-anything above a ``c5.4xlarge``, so we default to that.
+anything above a ``z1d.2xlarge``, so we default to that. If you do wish to use a
+different build instance type keep in mind that Vivado will consume in excess
+of 32 GiB for large designs.
+
 
 To start out, let's build a simple design, ``firesim-singlecore-no-nic-lbp``.
 This is a design that has one core, no nic, and uses the latency-bandwidth pipe


### PR DESCRIPTION
These are marginally more expensive (0.744 vs 0.68 / hour on-demand) over c5.4xlarges but run significantly faster and have more memory (64 vs 32 GiB). 

The memory increase removes build-failures due to Vivado OOM issues with large designs. 