### PR TITLE
Make SerialBridge +arg behavior consistent between FPGA & SW sim

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/serial.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.cc
@@ -4,12 +4,6 @@
 #include <assert.h>
 #include "serial.h"
 
-#if defined(SIMULATION_XSIM) || defined(RTLSIM)
-#define DEFAULT_STEPSIZE (128)
-#else
-#define DEFAULT_STEPSIZE (2004765L)
-#endif
-
 serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args, SERIALBRIDGEMODULE_struct * mmio_addrs, int serialno, uint64_t mem_host_offset):
         bridge_driver_t(sim), sim(sim), mem_host_offset(mem_host_offset) {
 
@@ -21,7 +15,8 @@ serial_t::serial_t(simif_t* sim, const std::vector<std::string>& args, SERIALBRI
     char** argv_arr;
     int argc_count = 0;
 
-    step_size = DEFAULT_STEPSIZE;
+    // This particular selection is vestigial. You may change it freely.
+    step_size = 2004765L;
     for (auto &arg: args) {
         if (arg.find("+fesvr-step-size=") == 0) {
             step_size = atoi(arg.c_str()+17);

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -81,10 +81,15 @@ nic_args = +shmemportname0=$(NET_SHMEMPORTNAME) +macaddr0=$(NET_MACADDR) \
 tracer_args = +tracefile0=TRACEFILE
 blkdev_args = +blkdev-in-mem0=128 +blkdev-log0=blkdev-log$(NET_SLOT)
 autocounter_args = +autocounter-readrate0=1000 +autocounter-filename0=AUTOCOUNTERFILE
+# Neglecting this +arg will make the simulator use the same step size as on the
+# FPGA. This will make ML simulation more closely match results seen on the
+# FPGA at the expense of dramatically increased target runtime
+#serial_args = +fesvr-step-size=128
+serial_args =
 
 SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
 mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
-COMMON_SIM_ARGS ?= $(mem_model_args) $(nic_args) $(tracer_args) $(blkdev_args) $(autocounter_args)
+COMMON_SIM_ARGS ?= $(serial_args) $(mem_model_args) $(nic_args) $(tracer_args) $(blkdev_args) $(autocounter_args)
 
 # Arguments used only at a particular simulation abstraction
 MIDAS_LEVEL_SIM_ARGS ?= +dramsim +max-cycles=$(TIMEOUT_CYCLES)


### PR DESCRIPTION
In a push to make it easier to reproduce FPGA-observed behavior in ML simulation, i'm trying to make the bridges do the same thing in both contexts when the same set of plus args are provided.

This changes the serial bridge so that providing no plus argument to the serial bridge will do the same thing on the FPGA and in ML simulator.