### PR TITLE
[makefrag] Parallelize verilator-based ML-simulator compilation

### DIFF
--- a/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
@@ -16,6 +16,8 @@
 
 VERILATOR ?= verilator --cc --exe
 override VERILATOR_FLAGS := --assert -Wno-STMTDLY -O3 \
+	--output-split 10000 \
+	--output-split-cfuncs 100 \
 	-CFLAGS "$(CXXFLAGS) $(CFLAGS)" \
 	-LDFLAGS "$(LDFLAGS) " \
 	$(VERILATOR_FLAGS)

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -82,6 +82,7 @@ conf: $(ANNO_FILE)
 ####################################
 
 VERILATOR_CXXOPTS ?= -O0
+VERILATOR_MAKEFLAGS ?= -j8 VM_PARALLEL_BUILDS=1
 
 verilator = $(GENERATED_DIR)/V$(DESIGN)
 verilator_debug = $(GENERATED_DIR)/V$(DESIGN)-debug
@@ -90,11 +91,11 @@ $(verilator) $(verilator_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_fla
 $(verilator) $(verilator_debug): export LDFLAGS := $(LDFLAGS) $(common_ld_flags)
 
 $(verilator): $(HEADER) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
-	$(MAKE) -C $(simif_dir) verilator PLATFORM=$(PLATFORM) DESIGN=$(DESIGN) \
+	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) verilator PLATFORM=$(PLATFORM) DESIGN=$(DESIGN) \
 	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)"
 
 $(verilator_debug): $(HEADER) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
-	$(MAKE) -C $(simif_dir) verilator-debug PLATFORM=$(PLATFORM) DESIGN=$(DESIGN) \
+	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) verilator-debug PLATFORM=$(PLATFORM) DESIGN=$(DESIGN) \
 	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)"
 
 verilator: $(verilator)


### PR DESCRIPTION
In general, this provides at least a 2x speedup when compiling Midas-level simulators. 
Re: @farzadfch comments here: https://groups.google.com/forum/#!topic/firesim/RiU_WKZlZ7E. 

I just copied what we were doing in chipyard. (h/t @jerryz123)