### PR TITLE
Marshal to chipyard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "platforms/f1/aws-fpga"]
 	path = platforms/f1/aws-fpga
 	url = https://github.com/firesim/aws-fpga-firesim
-[submodule "sw/firesim-software"]
-	path = sw/firesim-software
-	url = https://github.com/firesim/firesim-software
 [submodule "target-design/chipyard"]
 	path = target-design/chipyard
 	url = https://github.com/ucb-bar/project-template

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -63,13 +63,7 @@ done
 
 # Disable the Chipyard submodule initially, and enable if we're not in library mode
 git config submodule.target-design/chipyard.update none
-git config submodule.sw/firesim-software.update none
 git submodule update --init --recursive #--jobs 8
-
-# firesim-software should not be recursively initialized by default (use
-# sw/firesim-software/init-submodules.sh if you need linux deps)
-git config --unset submodule.sw/firesim-software.update
-git submodule update --init sw/firesim-software
 
 if [ "$IS_LIBRARY" = false ]; then
     git config --unset submodule.target-design/chipyard.update
@@ -77,6 +71,12 @@ if [ "$IS_LIBRARY" = false ]; then
     cd $RDIR/target-design/chipyard
     ./scripts/init-submodules-no-riscv-tools.sh --no-firesim
     cd $RDIR
+
+    # Configure firemarshal to know where our firesim installation is
+    marshal_cfg=$RDIR/target-design/chipyard/software/firemarshal/marshal-config.yaml
+    if [ ! -f $marshal_cfg]; then
+      echo "firesim-dir: '../../../../'" > $marshal_cfg 
+    fi
 fi
 
 if [ "$SUBMODULES_ONLY" = true ]; then
@@ -145,9 +145,10 @@ if wget -T 1 -t 3 -O /dev/null http://169.254.169.254/; then
     make
 
     # Install firesim-software dependencies
+    marshal_dir=$RDIR/target-design/chipyard/software/firemarshal
     cd $RDIR
-    sudo pip3 install -r sw/firesim-software/python-requirements.txt
-    cat sw/firesim-software/centos-requirements.txt | sudo xargs yum install -y
+    sudo pip3 install -r $marshal_dir/python-requirements.txt
+    cat $marshal_dir/centos-requirements.txt | sudo xargs yum install -y
     wget https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/snapshot/e2fsprogs-1.45.4.tar.gz
     tar xvzf e2fsprogs-1.45.4.tar.gz
     cd e2fsprogs-1.45.4/

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -65,10 +65,12 @@ git config submodule.target-design/chipyard.update none
 git submodule update --init --recursive #--jobs 8
 
 if [ "$IS_LIBRARY" = false ]; then
-    # Detect if the chipyard submodule is being initialized for the first time (true)
-    # or being re-initialized (false). Note that 'git submodule status' is
-    # wrong when the module was skipped via 'chipyard.update none'.
-    if [ `ls -1A target-design/chipyard | wc -l` -eq 0 ]; then
+    # This checks if firemarshal has already been configured by someone. If
+    # not, we will provide our own config. This must be checked before calling
+    # init-submodules-no-riscv-tools.sh because that will configure
+    # firemarshal.
+    marshal_cfg=$RDIR/target-design/chipyard/software/firemarshal/marshal-config.yaml
+    if [ ! -f $marshal_cfg ]; then
       first_init=true
     else
       first_init=false
@@ -83,7 +85,6 @@ if [ "$IS_LIBRARY" = false ]; then
     # Configure firemarshal to know where our firesim installation is.
     # If this is a fresh init of chipyard, we can safely overwrite the marshal
     # config, otherwise we have to assume the user might have changed it
-    marshal_cfg=$RDIR/target-design/chipyard/software/firemarshal/marshal-config.yaml
     if [ $first_init = true ]; then
       echo "firesim-dir: '../../../../'" > $marshal_cfg 
     fi

--- a/sw/firesim-software
+++ b/sw/firesim-software
@@ -1,0 +1,1 @@
+../target-design/chipyard/software/firemarshal


### PR DESCRIPTION
Move FireMarshal into chipyard from FireSim. Most of the changes are in the chipyard submodule ucb-bar/chipyard#415

The main additional change in that PR is that marshal is added to your $PATH now.