### PR TITLE
[synthPrintf] Use topWiringPrefix to prevent name collisions

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
+++ b/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
@@ -57,7 +57,6 @@ private[passes] class PrintSynthesis(dir: File)(implicit p: Parameters) extends 
 
   // Takes a single printPort and emits an FCCA for each field
   def genFCCAsFromPort(mT: ModuleTarget, p: Port): Seq[FAMEChannelConnectionAnnotation] = {
-    println(p)
     p.tpe match {
       case BundleType(fields) =>
         fields.map(field =>
@@ -83,7 +82,7 @@ private[passes] class PrintSynthesis(dir: File)(implicit p: Parameters) extends 
     val topWiringAnnos = mutable.ArrayBuffer[Annotation](
       TopWiringOutputFilesAnnotation("unused", wiringAnnoOutputFunc))
 
-    val topWiringPrefix = ""
+    val topWiringPrefix = "synthesizedPrintf_"
 
     def onModule(m: DefModule): DefModule = m match {
       case m: Module if printMods(mTarget(m)) =>
@@ -138,7 +137,7 @@ private[passes] class PrintSynthesis(dir: File)(implicit p: Parameters) extends 
         val fccaAnnos = ports.flatMap({ case (port, _) => genFCCAsFromPort(mT, port) })
         val bridgeAnno = BridgeIOAnnotation(
           target = portRT,
-          widget = (p: Parameters) => new PrintBridgeModule(topWiringPrefix, addedPrintPorts)(p),
+          widget = (p: Parameters) => new PrintBridgeModule(addedPrintPorts)(p),
           channelNames = fccaAnnos.map(_.globalName)
         )
         bridgeAnno +: fccaAnnos


### PR DESCRIPTION
This works around a bug in TopWiring to unbreak synthesizedPrintfs in the top-level of target module hierarchy.

In synthesizePrintf, annotated printfs are translated to an aggregate wire before calling topWiring on that wire. Since it wasn't being given a prefix, topWiring was trying to create ports using the same name as the aggregate: these ports instead are mapped to <name>_0 to disambiguate them. TopWiring doesn't properly report this in it's mappings causing print synthesis to break when it attempts to look up the generated port.

It also cleans up prefix handling in the BridgeModule.