### PR TITLE
Deterministically Initialize Unreset Target-State

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -8,39 +8,38 @@
 # Only AGFIs for the latest release of FireSim are guaranteed to be available.
 # If you are using an older version of FireSim, you will need to generate your
 # own images.
-
 [fireboom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-05830297afff02ee6
+agfi=agfi-0ba768ea49c61be95
+deploytripletoverride=None
+customruntimeconfig=None
+
+[fireboom-singlecore-no-nic-l2-lbp]
+agfi=agfi-00c689d12d7520249
 deploytripletoverride=None
 customruntimeconfig=None
 
 [fireboom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0f2222f8bf006db8f
-deploytripletoverride=None
-customruntimeconfig=None
-
-[fireboom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
-agfi=agfi-082d20bbf9d6beb81
+agfi=agfi-035a52d63fe5c60d6
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0d2c63e2caef8c786
+agfi=agfi-0634db9528de4c0ed
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-nic-llc4mb-ddr3]
-agfi=agfi-06b32121699407e2c
+agfi=agfi-0e3830e530ffc9c63
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0f796afa194bde6f0
+agfi=agfi-02d8752291fdee83a
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-singlecore-nic-lbp]
-agfi=agfi-02acca4d82562e8db
+agfi=agfi-00c03a97bbf8ca7c2
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/midas/src/main/cc/simif.cc
+++ b/sim/midas/src/main/cc/simif.cc
@@ -28,10 +28,7 @@ simif_t::simif_t() {
 }
 
 void simif_t::init(int argc, char** argv, bool log) {
-  // Simulation reset
-  write(this->master_mmio_addrs->SIM_RESET, 1);
-  while(!done());
-
+  while(!read(this->master_mmio_addrs->INIT_DONE));
   this->log = log;
   std::vector<std::string> args(argv + 1, argv + argc);
   std::string loadmem;

--- a/sim/midas/src/main/scala/midas/core/SimWrapper.scala
+++ b/sim/midas/src/main/scala/midas/core/SimWrapper.scala
@@ -241,7 +241,6 @@ class SimWrapper(config: SimWrapperConfig)(implicit val p: Parameters) extends M
   })
 
   val channelPorts = IO(new SimWrapperChannels(bridgeChAnnos, bridgeAnnos, leafTypeMap))
-  val hostReset = IO(Input(Bool()))
   val target = Module(new TargetBox(chAnnos, leafTypeMap))
 
   // Indicates SimulationMapping which module we want to replace with the simulator
@@ -249,7 +248,7 @@ class SimWrapper(config: SimWrapperConfig)(implicit val p: Parameters) extends M
     TargetBoxAnnotation(outer.toNamed.toTarget.ref(target.instanceName))
   })
 
-  target.io.hostReset := reset.toBool && hostReset
+  target.io.hostReset := reset.toBool
   target.io.clock := clock
   import chisel3.ExplicitCompileOptions.NotStrict // FIXME
 

--- a/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
@@ -68,12 +68,14 @@ private[midas] class MidasTransforms(implicit p: Parameters) extends Transform {
       new fame.FAMEDefaults,
       new fame.ChannelExcision,
       new fame.InferModelPorts,
+      new ResolveAndCheck,
       new EmitFirrtl("post-channel-excision.fir"),
       new fame.FAMETransform,
       DefineAbstractClockGate,
       new EmitFirrtl("post-fame-transform.fir"),
       new ResolveAndCheck,
       new fame.EmitAndWrapRAMModels,
+      ConnectHostClock,
       new EmitFirrtl("post-gen-sram-models.fir"),
       new ResolveAndCheck) ++
     Seq(

--- a/sim/midas/src/main/scala/midas/passes/fame/ConnectHostClock.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/ConnectHostClock.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package midas.passes
+
+import firrtl._
+import firrtl.ir._
+import firrtl.Mappers._
+import Utils._
+
+/** Connects the host clock to each model in the top-level
+  *
+  * This maintains the current bad assumption that the host clock is named
+  * "clock" but this has been changed in the multiclock branch.
+  */
+
+private[passes] object ConnectHostClock extends firrtl.Transform {
+
+  def inputForm = HighForm
+  def outputForm = HighForm
+
+  def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit
+    val topName = state.circuit.main
+    val topModule = state.circuit.modules.find(_.name == topName).get
+    val hostClock = WRef(topModule.ports.find(_.name == "clock").get)
+
+    def addClockConnects(s: Statement): Statement = s.map(addClockConnects) match {
+      case inst: WDefInstance => Block(inst, Connect(NoInfo, WSubField(WRef(inst), "clock"), hostClock))
+      case s => s
+    }
+
+    def onModule(m: DefModule): DefModule = m match {
+      case m if m.name == topName => m.map(addClockConnects)
+      case s => s
+    }
+    state.copy(circuit = state.circuit.map(onModule))
+  }
+}

--- a/sim/midas/src/main/verilog/BUFGCE.v
+++ b/sim/midas/src/main/verilog/BUFGCE.v
@@ -7,7 +7,7 @@ module BUFGCE(
    always @(posedge I)
      enable_latch <= CE;
 `ifdef VERILATOR
-   // Verilator doesn't like procedural clock gates
+   // Note: Verilator doesn't like procedural clock gates
    // They cause combinational loop errors and UNOPT_FLAT
    assign O = (I & enable_latch);
 `else

--- a/sim/midas/src/main/verilog/BUFGCE.v
+++ b/sim/midas/src/main/verilog/BUFGCE.v
@@ -11,7 +11,7 @@ module BUFGCE(
    // They cause combinational loop errors and UNOPT_FLAT
    assign O = (I & enable_latch);
 `else
-   // VCS doesn't like the Verilator clock gate
+   // Note: VCS doesn't like the Verilator clock gate
    // Delays clock edge too much when CE is a register
    // Blocking assignment makes behavior deterministic
    always @(posedge I or negedge I) begin


### PR DESCRIPTION
This PR fixes a non-determinism bug in FPGA simulations where target registers that are not reset in the target design would appear to take on different values between simulation runs. To get deterministic simulation results, FireSim relies upon target-registers and memories (perhaps implemented as BRAMs) taking on a fixed value after FPGA programming (in most cases, 0). 

While this is generally the case, there are circumstances under which this assumption fails to hold. This is detailed in this [Xilinx AR](https://www.xilinx.com/support/answers/44174.html). 

The solution is to keep the target clock-gated until FPGA initialization is complete, which i've implemented using the direct-clock-gating scheme we use in the F1 transform to support verilog black boxes.

As part of this PR, i've also:
- simplified the reset sequence of the simulation to remove the notion of a SimReset
- fixed a bug where ram optimizations failed to work under a direct clock gating scheme
- cherry-picked a bugfix from the multiclock branch to fix verilator simulation of our clock gating 