### PR TITLE
Warn when System Commit Bandwidth Exceeds TracerV Capacity

### DIFF
--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -3,6 +3,7 @@
 package midas
 package core
 
+import logger.{Logger, LogLevel}
 import junctions._
 import widgets._
 import chisel3._
@@ -32,6 +33,8 @@ class FPGATopIO(implicit val p: Parameters) extends WidgetIO {
 
 // Platform agnostic wrapper of the simulation models for FPGA
 class FPGATop(implicit p: Parameters) extends Module with HasWidgets {
+  val previousLogLevel = Logger.getGlobalLevel
+  Logger.setLevel(LogLevel.Warn)
 
   val io = IO(new FPGATopIO)
   val sim = Module(new SimWrapper(p(SimWrapperKey)))
@@ -142,4 +145,5 @@ class FPGATop(implicit p: Parameters) extends Module with HasWidgets {
     "DMA_WIDTH"      -> p(DMANastiKey).dataBits / 8,
     "DMA_SIZE"       -> log2Ceil(p(DMANastiKey).dataBits / 8)
   )
+  Logger.setLevel(previousLogLevel)
 }

--- a/sim/midas/src/main/scala/midas/core/Logging.scala
+++ b/sim/midas/src/main/scala/midas/core/Logging.scala
@@ -1,0 +1,16 @@
+// See LICENSE for license details.
+package midas.core
+
+import logger.Logger
+
+// A wrapper layer around FIRRTL's logger to provide coloured tagging
+trait Logging {
+  lazy private val logger = new Logger(this.getClass.getName)
+
+  protected def tag(name: String, color: String): String =
+    s"[${color}${name}${Console.RESET}] "
+
+  def info(message: => String): Unit  = logger.info(tag("GG Info", Console.GREEN) + message)
+  def warn(message: => String): Unit  = logger.warn(tag("GG Warn", Console.YELLOW) + message)
+  def error(message: => String): Unit = logger.error(tag("GG Error", Console.RED) + message)
+}

--- a/sim/midas/src/main/scala/midas/widgets/Bridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Bridge.scala
@@ -3,7 +3,7 @@
 package midas
 package widgets
 
-import midas.core.{SimWrapperChannels, SimUtils}
+import midas.core.{SimWrapperChannels, SimUtils, Logging}
 import midas.core.SimUtils.{RVChTuple}
 import midas.passes.fame.{FAMEChannelConnectionAnnotation,DecoupledForwardChannel, PipeChannel, DecoupledReverseChannel, WireChannel, JsonProtocol, HasSerializationHints}
 
@@ -13,6 +13,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.{BaseModule, Direction, ChiselAnnotation, annotate}
 import firrtl.annotations.{ReferenceTarget}
+import logger.LazyLogging
 
 import scala.reflect.runtime.{universe => ru}
 
@@ -26,7 +27,7 @@ import scala.reflect.runtime.{universe => ru}
 abstract class TokenizedRecord extends Record with HasChannels
 
 abstract class BridgeModule[HostPortType <: TokenizedRecord]
-  (implicit p: Parameters) extends Widget()(p) {
+  (implicit p: Parameters) extends Widget()(p) with Logging {
   def hPort: HostPortType
 }
 

--- a/sim/midas/src/main/scala/midas/widgets/Widget.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Widget.scala
@@ -3,6 +3,7 @@
 package midas
 package widgets
 
+import logger.LazyLogging
 import chisel3._
 import chisel3.util._
 import chisel3.core.ActualDirection
@@ -32,7 +33,7 @@ class WidgetIO(implicit p: Parameters) extends ParameterizedBundle()(p){
   val ctrl = Flipped(WidgetMMIO())
 }
 
-abstract class Widget(implicit val p: Parameters) extends MultiIOModule {
+abstract class Widget(implicit val p: Parameters) extends MultiIOModule with LazyLogging {
   private var _finalized = false
   protected val crRegistry = new MCRFileMap()
   def numRegs = crRegistry.numRegs


### PR DESCRIPTION
I'm not sure this the right approach, but this lets larger systems pass through compilation without needing to remove the TracerV bridge.

Also add a colored logging layer around FIRRTL's logger for use in Golden Gate.

TODO:
- [ ] Remove LazyLogging mixin to Widget