### PR TITLE
Print target-cycle count before powering off in linux-poweroff workload

### DIFF
--- a/deploy/workloads/Makefile
+++ b/deploy/workloads/Makefile
@@ -74,8 +74,10 @@ simperf-test:
 	python gen-benchmark-rootfs.py -w $@.json -r -b $(BASE_IMAGE) -s $@/overlay
 
 linux-poweroff:
-	mkdir -p $@
-	python gen-benchmark-rootfs.py -w $@.json -r -b $(BASE_IMAGE)
+	mkdir -p $@/overlay
+	cd ../../sw/check-rtc && make print-mcycle-linux
+	cp ../../sw/check-rtc/print-mcycle-linux $@/overlay/
+	python gen-benchmark-rootfs.py -w $@.json -r -b $(BASE_IMAGE) -s $@/overlay
 
 simperf-test-scale: simperf-test
 

--- a/deploy/workloads/linux-poweroff.json
+++ b/deploy/workloads/linux-poweroff.json
@@ -10,8 +10,8 @@
   "workloads" : [
     {
       "name": "poweroffnode",
-      "files": [],
-      "command": "echo 'Powering off immediately.'",
+      "files": ["print-mcycle-linux"],
+      "command": "/print-mcycle-linux && echo 'Powering off immediately.'",
       "simulation_outputs": [],
       "outputs": []
     }

--- a/sw/check-rtc/.gitignore
+++ b/sw/check-rtc/.gitignore
@@ -1,3 +1,5 @@
 *.o
 /check-rtc
 /check-rtc-linux
+/print-mcycle
+/print-mcycle-linux

--- a/sw/check-rtc/Makefile
+++ b/sw/check-rtc/Makefile
@@ -12,6 +12,9 @@ check-rtc-linux: check-rtc-linux.c
 check-rtc: check-rtc.o crt.o syscalls.o
 	$(CC) -T link.ld $(LDFLAGS) $^ -o $@
 
+print-mcycle-linux: print-mcycle.c
+	$(CC_LINUX) $(CFLAGS_LINUX) $(LDFLAGS_LINUX) $< -o $@
+
 %.o: %.c util.h encoding.h
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/sw/check-rtc/print-mcycle.c
+++ b/sw/check-rtc/print-mcycle.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <time.h>
+
+static inline long rdcycle(void)
+{
+    long cycle;
+    asm volatile ("csrr %[cycle], cycle" : [cycle] "=r" (cycle));
+    return cycle;
+}
+
+int main(void)
+{
+    struct timespec ts1;
+    printf("Cycles elapsed: %lu\n", rdcycle());
+    clock_gettime(CLOCK_REALTIME, &ts1);
+    printf("Time elapsed: %lu.%.9lu seconds\n", ts1.tv_sec, ts1.tv_nsec);
+    return 0;
+}


### PR DESCRIPTION
This adds a small target program to read the cycle CSR and print this value to stdout to the linux-poweroff workload. 

This is a useful litmus test for detecting simulation non-determinism, as repeated `firesim infrasetup && firesim runworkload` should produce the same uart output including this cycle count.  FESVR polls of `tohost` and early printk timestamps often do not provide enough resolution to detect small changes in target behavior.

I ran the linux-poweroff workload multiple times for:
- fireboom-singlecore-no-nic-l2-llc4mb-ddr3 
- firesim-quadcore-no-nic-l2-llc4mb-ddr3

under different FMR-regimes (tracing on and off), and both targets produced the same uart output across all runs *with zero-out-dram disabled*.

Boom with Tracing:
```
mcycle: 1704085952
Powering off immediately.
[    0.304946] reboot: Power down
Power off

*** PASSED *** after 1726102682 cycles
time elapsed: 101.4 s, simulation speed = 17.02 MHz
FPGA-Cycles-to-Model-Cycles Ratio (FMR): 4.41
Runs 1726102682 cycles
```
Boom w/o Tracing: 

```
mcycle: 1704085952                    
Powering off immediately.                         
[    0.304946] reboot: Power down             
Power off                                                                                    
*** PASSED *** after 1726102682 cycles       
time elapsed: 41.8 s, simulation speed = 41.28 MHz
FPGA-Cycles-to-Model-Cycles Ratio (FMR): 1.82 
Runs 1726102682 cycles
```

QC rocket with tracing:
```
mcycle: 1604540465                                                     
Powering off immediately.                                                                                                                                               
[    0.225395] reboot: Power down                                       
Power off

*** PASSED *** after 2012784077 cycles
time elapsed: 445.5 s, simulation speed = 4.52 MHz 
FPGA-Cycles-to-Model-Cycles Ratio (FMR): 19.92
Runs 2012784077 cycles
```

QC rocket w/o tracing:
```
mcycle: 1604540465                                                     
Powering off immediately.                                                                                                                                               
[    0.225395] reboot: Power down                                       
Power off

*** PASSED *** after 2012784077 cycles
time elapsed: 40.7 s, simulation speed = 49.44 MHz 
FPGA-Cycles-to-Model-Cycles Ratio (FMR): 1.82 
Runs 2012784077 cycles
```
I suspect the rocket-traced FMR is so much worse only because it's writing so much more to disk.
