### PR TITLE
Bump verilator to v4.028

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -36,7 +36,7 @@ sudo yum -y install git2u
 # install verilator
 git clone http://git.veripool.org/git/verilator
 cd verilator/
-git checkout v4.002
+git checkout v4.028
 autoconf && ./configure && make -j16 && sudo make install
 cd ..
 


### PR DESCRIPTION
Chipyard uses v4.016 but I am bumping to v4.028 in other locations (including Chipyard). I think it would be good to follow.