### PR TITLE
Fix synthesized_prints SW driver

### DIFF
--- a/sim/midas/src/main/cc/bridges/synthesized_prints.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.cc
@@ -83,7 +83,7 @@ synthesized_prints_t::synthesized_prints_t(
 
   this->printfile.open(printfilename.c_str(), std::ios_base::out | std::ios_base::binary);
   if (!this->printfile.is_open()) {
-      fprintf(stderr, "Could not open print log file: %s\n", printfilename);
+      fprintf(stderr, "Could not open print log file: %s\n", printfilename.c_str());
       abort();
   }
 


### PR DESCRIPTION
Resolves the error:
```
2020-04-03 21:55:52,008 [flush       ] [DEBUG]  [localhost] out: /home/centos/chipyard4/sims/firesim/sim/midas/src/main/cc/bridges/synthesized_prints.cc: In constructor ‘synthesized_prints_t::synthesized_prints_
t(simif_t*, std::vector<std::basic_string<char> >&, PRINTBRIDGEMODULE_struct*, unsigned int, unsigned int, unsigned int, const unsigned int*, const char* const*, const unsigned int*, const unsigned int*, unsigne
d int, const char*, unsigned int, unsigned int, int)’:
2020-04-03 21:55:52,008 [flush       ] [DEBUG]  [localhost] out: /home/centos/chipyard4/sims/firesim/sim/midas/src/main/cc/bridges/synthesized_prints.cc:86:75: error: cannot pass objects of non-trivially-copyabl
e type ‘class std::basic_string<char>’ through ‘...’
2020-04-03 21:55:52,008 [flush       ] [DEBUG]  [localhost] out:        fprintf(stderr, "Could not open print log file: %s\n", printfilename);
2020-04-03 21:55:52,008 [flush       ] [DEBUG]  [localhost] out:
```