### PR TITLE
Add small NVDLA build recipe

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build.ini
+++ b/deploy/sample-backup-configs/sample_config_build.ini
@@ -23,6 +23,8 @@ firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3-half-freq-uncore
 
 firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3
 
+#firesim-rocket-singlecore-small-nvdla-no-nic-l2-llc4mb-ddr3
+
 # SHA3 configs for tutorial
 # firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3
 # firesim-singlecore-sha3-print-no-nic-l2-llc4mb-ddr3
@@ -38,6 +40,8 @@ firesim-supernode-rocket-singlecore-nic-l2-lbp
 firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3-half-freq-uncore
 
 firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3
+
+#firesim-rocket-singlecore-small-nvdla-no-nic-l2-llc4mb-ddr3
 
 # SHA3 configs for tutorial
 # firesim-singlecore-sha3-no-nic-l2-llc4mb-ddr3

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -62,7 +62,7 @@ deploytriplet=None
 # Single-core, Rocket-based recipes with Small NVDLA
 [firesim-rocket-singlecore-small-nvdla-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=WithNVDLASmall_DDR3FRFCFSLLC4MB_FireSimGemminiRocketConfig
+TARGET_CONFIG=WithNVDLASmall_DDR3FRFCFSLLC4MB_FireSimQuadRocketConfig
 PLATFORM_CONFIG=F75MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -100,5 +100,4 @@ TARGET_CONFIG=NoConfig
 PLATFORM_CONFIG=DefaultF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
 

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -59,6 +59,13 @@ PLATFORM_CONFIG=F110MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
+# Single-core, Rocket-based recipes with Small NVDLA
+[firesim-rocket-singlecore-small-nvdla-no-nic-l2-llc4mb-ddr3]
+DESIGN=FireSim
+TARGET_CONFIG=WithNVDLASmall_DDR3FRFCFSLLC4MB_FireSimGemminiRocketConfig
+PLATFORM_CONFIG=F75MHz_BaseF1Config
+instancetype=z1d.2xlarge
+deploytriplet=None
 
 # RAM Optimizations enabled by adding _MCRams PLATFORM_CONFIG string
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]


### PR DESCRIPTION
Corresponds with https://github.com/ucb-bar/chipyard/pull/505

This adds a build recipe for the Small NVDLA @ 75MHz. We could potentially also add the Large NVDLA recipe (@ 50MHz) but figured I would just leave it to the small.