### PR TITLE
Fix Host AXI4 ID Truncation

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,32 +10,37 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0750d8ac4485b4e76
+agfi=agfi-06d21f6b5f11986d4
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-007fdc3c4a4e949df
+agfi=agfi-032ebefe1a7315a24
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-020a1193820c0e816
+agfi=agfi-0a2f47fbcee5613de
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-02e5a53156f96b894
+agfi=agfi-0bb51f1e2869cd696
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
-agfi=agfi-0cc11126d33e96c64
+agfi=agfi-0962bc0a3286267c0
+deploytripletoverride=None
+customruntimeconfig=None
+
+[firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
+agfi=agfi-0caeed17d14f4f012
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-0907892375b36dc59
+agfi=agfi-018c9e1f0c40fffbb
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -64,11 +64,9 @@ class SimConfig extends Config((site, here, up) => {
   case SynthPrints      => false
   case EnableSnapshot   => false
   case KeepSamplesInMem => true
-  case CtrlNastiKey     => NastiParameters(32, 32, 12)
   case DMANastiKey      => NastiParameters(512, 64, 6)
   case FpgaMMIOSize     => BigInt(1) << 12 // 4 KB
   case AXIDebugPrint    => false
-  case HostMemNumChannels => 1
 
   // Remove once AXI4 port is complete
   case MemNastiKey      => {
@@ -79,20 +77,27 @@ class SimConfig extends Config((site, here, up) => {
   }
 })
 
-class ZynqConfig extends Config(new Config((site, here, up) => {
+class ZynqBaseConfig extends Config(new Config((site, here, up) => {
+  case CtrlNastiKey     => NastiParameters(32, 32, 12)
   case Platform       => (p: Parameters) => new ZynqShim()(p)
+  case HostMemNumChannels => 1
   case HasDMAChannel  => false
-  case HostMemChannelKey => HostMemChannelParams(
-    size      = 0x100000000L, // 4 GiB
-    beatBytes = 8,
-    idBits    = 4)
 }) ++ new SimConfig)
 
-class ZynqConfigWithSnapshot extends Config(new Config((site, here, up) => {
-  case EnableSnapshot => true
-}) ++ new ZynqConfig)
+class ZC706Config extends Config(new Config((site, here, up) => {
+  case HostMemChannelKey => HostMemChannelParams(
+    size      = 0x40000000L, // 1 GiB
+    beatBytes = 8,
+    idBits    = 6)
+}) ++ new ZynqBaseConfig)
 
-// we are assuming the host-DRAM size is 2^chAddrBits
+class ZedboardConfig extends Config(new Config((site, here, up) => {
+  case HostMemChannelKey => HostMemChannelParams(
+    size      = 0x10000000L, // 256 MiB
+    beatBytes = 8,
+    idBits    = 6)
+}) ++ new ZynqBaseConfig)
+
 class F1Config extends Config(new Config((site, here, up) => {
   case Platform       => (p: Parameters) => new F1Shim()(p)
   case HasDMAChannel  => true
@@ -100,13 +105,9 @@ class F1Config extends Config(new Config((site, here, up) => {
   case HostMemChannelKey => HostMemChannelParams(
     size      = 0x400000000L, // 16 GiB
     beatBytes = 8,
-    idBits    = 4)
+    idBits    = 16)
   case HostMemNumChannels => 4
 }) ++ new SimConfig)
-
-class F1ConfigWithSnapshot extends Config(new Config((site, here, up) => {
-  case EnableSnapshot => true
-}) ++ new F1Config)
 
 // Turns on all additional synthesizable debug features for checking the
 // implementation of the simulator.

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -29,7 +29,29 @@ case object HostMemChannelKey extends Field[HostMemChannelParams]
 case object HostMemNumChannels extends Field[Int]
 // See widgets/Widget.scala for CtrlNastiKey -> Configures the simulation control bus
 
-// Legacy: the aggregate memory-space seen by masters wanting DRAM. Derived from the above.
+
+/**
+  * DRAM Allocation Knobs
+  *
+  * Constrains how much of memory controller's id space is used. If no
+  * constraint is provided, the unified id space of all masters is presented
+  * directly to each memory controller. If this id width exceeds that of the
+  * controller, Golden Gate will throw an get an elaboration-time error
+  * requesting a constraint. See [[AXI4IdSpaceConstraint]].
+  */
+case object HostMemIdSpaceKey extends Field[Option[AXI4IdSpaceConstraint]](None)
+
+/**  Constrains how many id bits of the host memory channel are used, as well
+  *  as how many requests are issued per id. This generates hardware
+  *  proportional to (2^idBits) * maxFlight.
+  *
+  * @param idBits The number of lower idBits of the host memory channel to use.
+  * @param maxFlight A bound on the number of requests the simulator will make per id.
+  *
+  */
+case class AXI4IdSpaceConstraint(idBits: Int = 4, maxFlight: Int = 8)
+
+// Legacy: the aggregate memory-space seen by masters wanting DRAM. Derived from HostMemChannelKey
 case object MemNastiKey extends Field[NastiParameters]
 
 case object FpgaMMIOSize extends Field[BigInt]
@@ -102,7 +124,18 @@ class FPGATop(implicit p: Parameters) extends LazyModule with HasWidgets {
 
   // In keeping with the Nasti implementation, we put all channels on a single XBar.
   val xbar = AXI4Xbar()
-  memAXI4Node :*= AXI4Buffer() :*= xbar
+  p(HostMemIdSpaceKey) match {
+    case Some(AXI4IdSpaceConstraint(idBits, maxFlight)) =>
+      (memAXI4Node :*= AXI4Buffer()
+                   :*= AXI4UserYanker(Some(maxFlight))
+                   :*= AXI4IdIndexer(idBits)
+                   :*= AXI4Buffer()
+                   :*= xbar)
+    case None =>
+      (memAXI4Node :*= AXI4Buffer()
+                   :*= xbar)
+  }
+
   xbar := loadMem.toHostMemory
   val targetMemoryRegions = sortedRegionTuples.zip(dramOffsets).map({ case ((bridgeSeq, addresses), hostBaseAddr) =>
     val regionName = bridgeSeq.head.memoryRegionName

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -184,7 +184,13 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
 
   val io = IO(new FPGATopIO)
   val mem = IO(HeterogeneousBag.fromNode(outer.memAXI4Node.in))
-  (mem zip outer.memAXI4Node.in).foreach({ case (io, (bundle, _)) => io <> bundle })
+  (mem zip outer.memAXI4Node.in).foreach { case (io, (bundle, _)) =>
+    require(bundle.params.idBits <= p(HostMemChannelKey).idBits,
+      s"""| Required memory channel ID bits exceeds that present on host.
+          | Required: ${bundle.params.idBits} Available: ${p(HostMemChannelKey).idBits}
+          | Enable host ID reuse with the HostMemIdSpaceKey""".stripMargin)
+    io <> bundle
+  }
 
   val sim = Module(new SimWrapper(p(SimWrapperKey)))
   val simIo = sim.channelPorts

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -218,7 +218,9 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
     Seq(AXI4MasterPortParameters(
       masters = Seq(AXI4MasterParameters(
         name = "fased-memory-timing-model",
-        id   = IdRange(0, 1 << p(NastiKey).idBits))))))
+        id   = IdRange(0, 1 << p(NastiKey).idBits),
+        maxFlight = Some(math.max(cfg.maxReadsPerID, cfg.maxWritesPerID))
+      )))))
 
   val memorySlaveConstraints = MemorySlaveConstraints(cfg.targetAddressSpace, cfg.targetRTransfer, cfg.targetWTransfer)
   val memoryRegionName = completeConfig.memoryRegionName.getOrElse(getWName)


### PR DESCRIPTION
I restricted the memory ID space without actually adding a ID Indexer. This fixes that by using the full ID width available on the host. If the required ID space of all bridges exceeds the available width, users can inject the IDIndexer using `HostMemIdSpaceKey`.

This also bumps chipyard to work around out issue with the SiFive UART driver. 