### PR TITLE
Host DRAM allocation and ID interleaving bug fixes

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -30,7 +30,7 @@ deploytriplet=None
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_FireSimLargeBoomConfig
-PLATFORM_CONFIG=F70MHz_BaseF1Config
+PLATFORM_CONFIG=F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,37 +10,37 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-06d21f6b5f11986d4
+agfi=agfi-000ecbd024947e535
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-032ebefe1a7315a24
+agfi=agfi-0671ec0046ac9cb4c
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0a2f47fbcee5613de
+agfi=agfi-028942ad9ca73a3dd
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0bb51f1e2869cd696
+agfi=agfi-0b73a22e47efa36fd
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
-agfi=agfi-0962bc0a3286267c0
+agfi=agfi-0b6e4f0eecee7866d
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0caeed17d14f4f012
+agfi=agfi-0670edf3d59be86cc
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-018c9e1f0c40fffbb
+agfi=agfi-0754151f854da72ea
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -201,7 +201,6 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
   // Instantiate bridge widgets.
   outer.bridgeModuleMap.map({ case (bridgeAnno, bridgeMod) =>
     val widgetChannelPrefix = s"${bridgeAnno.target.ref}"
-    bridgeMod.module.suggestName(bridgeMod.wName.get)
     bridgeMod match {
       case peekPoke: PeekPokeBridgeModule =>
         peekPoke.module.io.step <> master.module.io.step

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -89,7 +89,7 @@ class FPGATop(implicit p: Parameters) extends LazyModule with HasWidgets {
   }
 
   // Tie-break with the name of the region.
-  val sortedRegionTuples = regionTuples.toSeq.sortBy(r => (BytesOfDRAMRequired(r._2), r._1.head.memoryRegionName))
+  val sortedRegionTuples = regionTuples.toSeq.sortBy(r => (BytesOfDRAMRequired(r._2), r._1.head.memoryRegionName)).reverse
 
   // Allocate memory regions using a base-and-bounds scheme
   val dramOffsetsRev = sortedRegionTuples.foldLeft(Seq(BigInt(0)))({

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -141,8 +141,13 @@ class FPGATop(implicit p: Parameters) extends LazyModule with HasWidgets {
     val regionName = bridgeSeq.head.memoryRegionName
     val virtualBaseAddr = addresses.map(_.base).min
     val offset = hostBaseAddr - virtualBaseAddr
-    val preTranslationPort = (xbar :=* AXI4Buffer() :=* AXI4AddressTranslation(offset, addresses, regionName))
-    bridgeSeq.foreach { preTranslationPort := _.memoryMasterNode }
+    val preTranslationPort = (xbar
+      :=* AXI4Buffer()
+      :=* AXI4AddressTranslation(offset, addresses, regionName))
+    bridgeSeq.foreach { bridge =>
+      (preTranslationPort := AXI4Deinterleaver(bridge.memorySlaveConstraints.supportsRead.max)
+                          := bridge.memoryMasterNode)
+    }
     HostMemoryMapping(regionName, offset)
   })
 

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -226,10 +226,6 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
   val memoryRegionName = completeConfig.memoryRegionName.getOrElse(getWName)
   // End: Implementation of UsesHostDRAM
 
-  require(p(NastiKey).idBits <= p(MemNastiKey).idBits,
-    "Target AXI4 IDs cannot be mapped 1:1 onto host AXI4 IDs"
-  )
-
   lazy val module = new BridgeModuleImp(this) {
     val io = IO(new WidgetIO)
     val hPort = IO(HostPort(new FASEDTargetIO))

--- a/sim/midas/src/main/scala/midas/widgets/Widget.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Widget.scala
@@ -36,6 +36,7 @@ class WidgetIO(implicit p: Parameters) extends ParameterizedBundle()(p){
 abstract class Widget()(implicit p: Parameters) extends LazyModule()(p) {
   override def module: WidgetImp
   val wName = Some(Widget.assignName(this))
+  this.suggestName(wName.get)
   // Legacy API
   def getWName = wName.get
 

--- a/sim/src/main/scala/fasedtests/Config.scala
+++ b/sim/src/main/scala/fasedtests/Config.scala
@@ -1,23 +1,25 @@
 //See LICENSE for license details.
 package firesim.fasedtests
 
+import chisel3.util.{isPow2, log2Ceil}
+
 import freechips.rocketchip.config.{Field, Config}
 import freechips.rocketchip.subsystem.{ExtMem, WithoutTLMonitors, WithNMemoryChannels, MemoryPortParams, MasterPortParams}
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
-
 import firesim.configs._
 
-object AXI4SlavePort extends Field[AXI4SlavePortParameters]
-object MaxTransferSize extends Field[Int](64)
-object BeatBytes extends Field[Int](8)
-object IDBits extends Field[Int](4)
-object AddrBits extends Field[Int](18)
-object NumTransactions extends Field[Int](10000)
-object MaxFlight extends Field[Int](128)
-object NumMemoryChannels extends Field[Int](1)
+case object AXI4SlavePort extends Field[AXI4SlavePortParameters]
+case object MaxTransferSize extends Field[Int](64)
+case object BeatBytes extends Field[Int](8)
+case object IDBits extends Field[Int](4)
+case object AddrBits extends Field[Int](22)
+case object NumTransactions extends Field[Int](10000)
+case object MaxFlight extends Field[Int](128)
+case object NumMemoryChannels extends Field[Int](1)
+case object FuzzerAddressMaskKey extends Field[BigInt]
 
 class WithSlavePortParams extends Config((site, here, up) => {
   case AXI4SlavePort => AXI4SlavePortParameters(
@@ -34,11 +36,20 @@ class WithSlavePortParams extends Config((site, here, up) => {
 class WithDefaultMemPort extends Config((site, here, up) => {
   case ExtMem => Some(MemoryPortParams(MasterPortParams(
                       base = BigInt(0),
-                      size = BigInt(1) << 16,
+                      size = BigInt(1) << site(AddrBits),
                       beatBytes = site(BeatBytes),
                       idBits = site(IDBits)), 1))
 })
 
+class WithDefaultFuzzer extends Config((site, here, up) => {
+  case FuzzerAddressMaskKey => (BigInt(1) << site(AddrBits)) - 1
+  case FuzzerParametersKey => Seq(FuzzerParameters(
+    site(NumTransactions),
+    site(MaxFlight),
+    Some(AddressSet(0, site(FuzzerAddressMaskKey)))))
+})
+
+// Configures the total number of transactions generated
 class WithNTransactions(num: Int) extends Config((site, here, up) => {
   case NumTransactions => num
 })
@@ -47,11 +58,42 @@ class NT10e5 extends WithNTransactions(100000)
 class NT10e6 extends WithNTransactions(1000000)
 class NT10e7 extends WithNTransactions(10000000)
 
+// Provides an address mask to fuzzer to constrain generated addresses
+class WithFuzzerMask(mask: BigInt) extends Config((site, here, up) => {
+  case FuzzerAddressMaskKey => mask
+})
+class FuzzMask3FFF extends WithFuzzerMask(0x3FFF)
 
+// Generates N fuzzers mastering non-overlapping chunks of the target memory space
+class WithNFuzzers(numFuzzers: Int) extends Config((site, here, up) => {
+  case FuzzerParametersKey => Seq.tabulate(numFuzzers) { i =>
+    require(isPow2(numFuzzers))
+    val regionSize = (BigInt(1) << site(AddrBits)) / numFuzzers
+    FuzzerParameters(
+      site(NumTransactions) / numFuzzers,
+      site(MaxFlight),
+      Some(AddressSet(regionSize * i, (regionSize - 1) & site(FuzzerAddressMaskKey)))) 
+  }
+})
+class QuadFuzzer extends WithNFuzzers(4)
+
+// Configures the size of the target memory system
+class WithNAddressBits(num: Int) extends Config((site, here, up) => {
+  case AddrBits => num
+})
+class AddrBits16 extends WithNAddressBits(16)
+class AddrBits22 extends WithNAddressBits(22)
+
+// Number of target memory channels -> number of FASED instances
 class QuadChannel extends WithNMemoryChannels(4)
+
+/**
+  * Complete target configurations
+  */
 
 class DefaultConfig extends Config(
   new WithoutTLMonitors ++
+  new WithDefaultFuzzer ++
   new WithDefaultMemPort ++
   new WithDefaultMemModel ++
   new Config((site, here, up) => {
@@ -71,6 +113,33 @@ class LLCDRAMConfig extends Config(
   new FRFCFS16GBQuadRankLLC4MB ++
   new DefaultConfig)
 
+/**
+  * Host memory system fragments
+  */
 
-// Platform Configs
+class WithNHostIdBits(num: Int) extends Config((site, here, up) => {
+  case midas.core.HostMemChannelKey => up(midas.core.HostMemChannelKey, site).copy(idBits = num)
+})
+
+class ConstrainHostIds(idBits: Int) extends Config((site, here, up) => {
+  case midas.core.HostMemIdSpaceKey => Some(midas.core.AXI4IdSpaceConstraint(idBits))
+})
+
+/**
+  * Complete platform / compiler configurations
+  */
+
 class DefaultF1Config extends Config(new midas.F1Config)
+
+class SmallQuadChannelHostConfig extends Config(new Config((site, here, up) => {
+  case midas.core.HostMemNumChannels => 4
+  case midas.core.HostMemChannelKey => midas.core.HostMemChannelParams(
+    size      = (BigInt(1) << site(AddrBits)) / site(midas.core.HostMemNumChannels),
+    beatBytes = 8,
+    idBits    = 6)
+}) ++ new midas.F1Config)
+
+class ConstrainedIdHostConfig extends Config(
+  new ConstrainHostIds(2) ++
+  new WithNHostIdBits(2) ++
+  new midas.F1Config)

--- a/sim/src/test/scala/fasedtests/FASEDTestSuite.scala
+++ b/sim/src/test/scala/fasedtests/FASEDTestSuite.scala
@@ -50,7 +50,7 @@ abstract class FASEDTest(
   def runTest(backend: String, debug: Boolean, args: Seq[String] = Nil, name: String = "pass") = {
     compileMlSimulator(backend, debug)
     if (isCmdAvailable(backend)) {
-      it should name in {
+      it should s"run on $backend" in {
         assert(invokeMlSimulator(backend, debug, args) == 0)
       }
     }
@@ -64,11 +64,11 @@ abstract class FASEDTest(
   mkdirs
   elaborate
   behavior of s"FASED Instance configured with ${platformConfigs} driven by target: ${topModuleClass}"
-  runTests()
+  runTest("verilator", false)
 }
 
 class AXI4FuzzerLBPTest extends FASEDTest("AXI4Fuzzer", "DefaultConfig", "DefaultF1Config")
-class AXI4FuzzerMultiChannelTest extends FASEDTest("AXI4Fuzzer", "QuadChannel_DefaultConfig", "DefaultF1Config")
+class AXI4FuzzerMultiChannelTest extends FASEDTest("AXI4Fuzzer", "FuzzMask3FFF_QuadFuzzer_QuadChannel_DefaultConfig", "DefaultF1Config")
 class AXI4FuzzerFCFSTest extends FASEDTest("AXI4Fuzzer", "FCFSConfig", "DefaultF1Config")
 class AXI4FuzzerFRFCFSTest extends FASEDTest("AXI4Fuzzer", "FRFCFSConfig", "DefaultF1Config")
 class AXI4FuzzerLLCDRAMTest extends FASEDTest("AXI4Fuzzer", "LLCDRAMConfig", "DefaultF1Config") {
@@ -84,3 +84,15 @@ class AXI4FuzzerLLCDRAMTest extends FASEDTest("AXI4Fuzzer", "LLCDRAMConfig", "De
      })
   }
 }
+
+// Generate a target memory system that uses the whole host memory system.
+class BaselineMultichannelTest extends FASEDTest(
+    "AXI4Fuzzer",
+    "AddrBits22_QuadFuzzer_DefaultConfig",
+    "AddrBits22_SmallQuadChannelHostConfig") {
+  runTest("vcs", true)
+}
+
+// Checks that id-reallocation works for platforms with limited ID space
+class NarrowIdConstraint extends FASEDTest("AXI4Fuzzer", "DefaultConfig", "ConstrainedIdHostConfig")
+


### PR DESCRIPTION
Fixes a couple more issues with the new host DRAM allocation scheme:

1) Adds an AXI4Deinterleaver to each bridge. This is only strictly required if Bridge's memory region spans two memory channels as the AXI4 Xbar can and will interleave responses. FASED timing models cannot handle interleaved resposnes.

2) Fixes the sort to put larger memory regions at lower addresses.

Also, expands the fasedtests to better test some host-memory system corners. 

h/t @zhemao for reporting this issue.