### PR TITLE
Remove DRAMSim2 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "deploy/workloads/coremark/riscv-coremark"]
 	path = deploy/workloads/coremark/riscv-coremark
 	url = https://github.com/riscv-boom/riscv-coremark
-[submodule "sim/midas/src/main/cc/dramsim2"]
-	path = sim/midas/src/main/cc/dramsim2
-	url = https://github.com/firesim/DRAMSim2.git
 [submodule "utils/FlameGraph"]
 	path = utils/fireperf/FlameGraph
 	url = https://github.com/brendangregg/FlameGraph.git

--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -83,7 +83,7 @@ $(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h) $(platform_h)
 $(OUT_DIR)/$(DESIGN)-$(PLATFORM): $(design_h) $(lib) $(DRIVER) $(driver_h) $(platform_o) $(bridge_o)
 	mkdir -p $(OUT_DIR)
 	$(CXX) $(CXXFLAGS) -include $< \
-	-o $@ $(DRIVER) $(dramsim_o) $(lib_o) $(platform_o) $(bridge_o) $(LDFLAGS)
+	-o $@ $(DRIVER) $(lib_o) $(platform_o) $(bridge_o) $(LDFLAGS)
 
 $(PLATFORM): $(OUT_DIR)/$(DESIGN)-$(PLATFORM) $(OUT_DIR)/$(DESIGN).chain
 

--- a/sim/midas/src/main/cc/utils/utils.mk
+++ b/sim/midas/src/main/cc/utils/utils.mk
@@ -1,6 +1,6 @@
 # Compile DRAMSim2
 dramsim_o := $(foreach f, \
-                $(patsubst %.cpp, %.o, $(wildcard $(midas_dir)/dramsim2/*.cpp)), \
+                $(patsubst %.cpp, %.o, $(wildcard $(dramsim_dir)/*.cpp)), \
                 $(GEN_DIR)/$(notdir $(f)))
 $(dramsim_o): $(GEN_DIR)/%.o: $(dramsim_dir)/%.cpp
 	$(CXX) $(CXXFLAGS) -DNO_STORAGE -DNO_OUTPUT -Dmain=nomain -c -o $@ $<


### PR DESCRIPTION
Today is a good day -- we are about to be rid of another submodule.

@zhemao Did most of the hard work when stuff was migrated into testchipip. This completes that work. 