### PR TITLE
Bump verilator to v4.034

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -36,7 +36,7 @@ sudo yum -y install git2u
 # install verilator
 git clone http://git.veripool.org/git/verilator
 cd verilator/
-git checkout v4.028
+git checkout v4.034
 autoconf && ./configure && make -j16 && sudo make install
 cd ..
 

--- a/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
@@ -17,7 +17,9 @@
 
 VERILATOR ?= verilator --cc --exe
 
+# Use --timescale to approximate timescale behavior of pre-4.034
 override VERILATOR_FLAGS := \
+	--timescale 1ns/1ps \
 	-Wno-STMTDLY \
 	-O3 \
 	--output-split 10000 \

--- a/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
@@ -18,8 +18,9 @@
 VERILATOR ?= verilator --cc --exe
 
 # Use --timescale to approximate timescale behavior of pre-4.034
+TIMESCALE_OPTS := $(shell verilator --version | perl -lne 'if (/(\d.\d+)/ && $$1 >= 4.034) { print "--timescale 1ns/1ps"; }')
 override VERILATOR_FLAGS := \
-	--timescale 1ns/1ps \
+	$(TIMESCALE_OPTS) \
 	-Wno-STMTDLY \
 	-O3 \
 	--output-split 10000 \


### PR DESCRIPTION
**Related issue:** verilator/verilator#2300
**Type of change:** bug fix
**Impact:** tool change
**Release Notes:**
The default version of Verilator has changed to v4.034. Since this release adds enhanced support for Verilog timescales, a simpler behavior closer to that seen with previous versions is emulated by default with a flat --timescale argument.

* Add new timescale flag to Makefrag-verilator

See ucb-bar/chipyard#547