### PR TITLE
Separate plusargs per memory channel and synthesized print settings in manager

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -159,7 +159,8 @@ class FireSimServerNode(FireSimNode):
     def __init__(self, server_hardware_config=None, server_link_latency=None,
                  server_bw_max=None, server_profile_interval=None,
                  trace_enable=None, trace_select=None, trace_start=None, trace_end=None, trace_output_format=None, autocounter_readrate=None,
-                 zerooutdram=None):
+                 zerooutdram=None,
+                 print_start=None, print_end=None, print_cycle_prefix=None):
         super(FireSimServerNode, self).__init__()
         self.server_hardware_config = server_hardware_config
         self.server_link_latency = server_link_latency
@@ -172,6 +173,9 @@ class FireSimServerNode(FireSimNode):
         self.trace_output_format = trace_output_format
         self.autocounter_readrate = autocounter_readrate
         self.zerooutdram = zerooutdram
+        self.print_start = print_start
+        self.print_end = print_end
+        self.print_cycle_prefix = print_cycle_prefix
         self.job = None
         self.server_id_internal = FireSimServerNode.SERVERS_CREATED
         FireSimServerNode.SERVERS_CREATED += 1
@@ -245,7 +249,8 @@ class FireSimServerNode(FireSimNode):
             slotno, all_macs, all_rootfses, all_linklatencies, all_maxbws,
             self.server_profile_interval, all_bootbins, self.trace_enable,
             self.trace_select, self.trace_start, self.trace_end, self.trace_output_format,
-            self.autocounter_readrate, all_shmemportnames, self.zerooutdram)
+            self.autocounter_readrate, all_shmemportnames, self.zerooutdram,
+            self.print_start, self.print_end, self.print_cycle_prefix)
 
         run(runcommand)
 

--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -37,7 +37,8 @@ class FireSimTopologyWithPasses:
                  defaulttraceenable, defaulttraceselect, defaulttracestart, defaulttraceend,
                  defaulttraceoutputformat,
                  defaultautocounterreadrate, terminateoncompletion,
-                 defaultzerooutdram):
+                 defaultzerooutdram,
+                 defaultprintstart, defaultprintend, defaultprintcycleprefix):
         self.passes_used = []
         self.user_topology_name = user_topology_name
         self.no_net_num_nodes = no_net_num_nodes
@@ -57,6 +58,9 @@ class FireSimTopologyWithPasses:
         self.defaulttraceoutputformat = defaulttraceoutputformat
         self.defaultautocounterreadrate = defaultautocounterreadrate
         self.defaultzerooutdram = defaultzerooutdram
+        self.defaultprintstart = defaultprintstart
+        self.defaultprintend = defaultprintend
+        self.defaultprintcycleprefix = defaultprintcycleprefix
         self.terminateoncompletion = terminateoncompletion
 
         self.phase_one_passes()
@@ -321,6 +325,12 @@ class FireSimTopologyWithPasses:
                     node.autocounter_readrate = self.defaultautocounterreadrate
                 if node.zerooutdram is None:
                     node.zerooutdram = self.defaultzerooutdram
+                if node.print_start is None:
+                    node.print_start = self.defaultprintstart
+                if node.print_end is None:
+                    node.print_end = self.defaultprintend
+                if node.print_cycle_prefix is None:
+                    node.print_cycle_prefix = self.defaultprintcycleprefix
 
 
     def pass_allocate_nbd_devices(self):

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -86,7 +86,9 @@ class RuntimeHWConfig:
                                               trace_select, trace_start, trace_end,
                                               trace_output_format,
                                               autocounter_readrate, all_shmemportnames,
-                                              enable_zerooutdram):
+                                              enable_zerooutdram,
+                                              print_start, print_end,
+                                              enable_print_cycle_prefix):
         """ return the command used to boot the simulation. this has to have
         some external params passed to it, because not everything is contained
         in a runtimehwconfig. TODO: maybe runtimehwconfig should be renamed to
@@ -125,13 +127,16 @@ class RuntimeHWConfig:
 
         command_bootbinaries = array_to_plusargs(all_bootbinaries, "+prog")
         zero_out_dram = "+zero-out-dram" if (enable_zerooutdram) else ""
+        print_cycle_prefix = "+print-no-cycle-prefix" if not enable_print_cycle_prefix else ""
 
         # TODO supernode support
         dwarf_file_name = "+dwarf-file-name=" + all_bootbinaries[0] + "-dwarf"
 
         # TODO: supernode support (tracefile, trace-select.. etc)
-        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo sudo LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +slotid={slotid} +profile-interval={profile_interval} {zero_out_dram} {command_macs} {command_rootfses} {command_niclogs} {command_blkdev_logs}  {tracefile} +trace-select={trace_select} +trace-start={trace_start} +trace-end={trace_end} +trace-output-format={trace_output_format} {dwarf_file_name} +autocounter-readrate={autocounter_readrate} {autocounterfile} {command_linklatencies} {command_netbws}  {command_shmemportnames} +permissive-off {command_bootbinaries} && stty intr ^c' uartlog"; sleep 1""".format(
-            slotid=slotid, driver=driver, runtimeconf=runtimeconf,
+        basecommand = """screen -S fsim{slotid} -d -m bash -c "script -f -c 'stty intr ^] && sudo sudo LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./{driver} +permissive $(sed \':a;N;$!ba;s/\\n/ /g\' {runtimeconf}) +slotid={slotid} +profile-interval={profile_interval} {zero_out_dram} {command_macs} {command_rootfses} {command_niclogs} {command_blkdev_logs}  {tracefile} +trace-select={trace_select} +trace-start={trace_start} +trace-end={trace_end} +trace-output-format={trace_output_format} {dwarf_file_name} +autocounter-readrate={autocounter_readrate} {autocounterfile} {print_cycle_prefix} +print-start={print_start} +print-end={print_end} {command_linklatencies} {command_netbws}  {command_shmemportnames} +permissive-off {command_bootbinaries} && stty intr ^c' uartlog"; sleep 1""".format(
+            slotid=slotid,
+            driver=driver,
+            runtimeconf=runtimeconf,
             command_macs=command_macs,
             command_rootfses=command_rootfses,
             command_niclogs=command_niclogs,
@@ -145,7 +150,11 @@ class RuntimeHWConfig:
             trace_start=trace_start, trace_end=trace_end, tracefile=tracefile,
             trace_output_format=trace_output_format,
             dwarf_file_name=dwarf_file_name,
-            autocounterfile=autocounterfile, autocounter_readrate=autocounter_readrate)
+            autocounterfile=autocounterfile,
+            autocounter_readrate=autocounter_readrate,
+            print_cycle_prefix=print_cycle_prefix,
+            print_start=print_start,
+            print_end=print_end)
 
         return basecommand
 
@@ -260,6 +269,10 @@ class InnerRuntimeConfiguration:
         self.trace_output_format = "0"
         self.autocounter_readrate = 0
         self.zerooutdram = False
+        self.print_start = "0"
+        self.print_end = "-1"
+        self.print_cycle_prefix = True
+
         if 'tracing' in runtime_dict:
             self.trace_enable = runtime_dict['tracing'].get('enable') == "yes"
             self.trace_select = runtime_dict['tracing'].get('selector', "0")
@@ -271,6 +284,10 @@ class InnerRuntimeConfiguration:
         self.defaulthwconfig = runtime_dict['targetconfig']['defaulthwconfig']
         if 'hostdebug' in runtime_dict:
             self.zerooutdram = runtime_dict['hostdebug'].get('zerooutdram') == "yes"
+        if 'synthprint' in runtime_dict:
+            self.print_start = runtime_dict['synthprint'].get("start", "0")
+            self.print_end = runtime_dict['synthprint'].get("end", "-1")
+            self.print_cycle_prefix = runtime_dict['synthprint'].get("cycleprefix", "yes") == "yes"
 
         self.workload_name = runtime_dict['workload']['workloadname']
         # an extra tag to differentiate workloads with the same name in results names
@@ -326,7 +343,9 @@ class RuntimeConfig:
             self.innerconf.trace_select, self.innerconf.trace_start, self.innerconf.trace_end,
             self.innerconf.trace_output_format,
             self.innerconf.autocounter_readrate, self.innerconf.terminateoncompletion,
-            self.innerconf.zerooutdram)
+            self.innerconf.zerooutdram,
+            self.innerconf.print_start, self.innerconf.print_end,
+            self.innerconf.print_cycle_prefix)
 
     def launch_run_farm(self):
         """ directly called by top-level launchrunfarm command. """

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -57,3 +57,8 @@ suffixtag=
 # In general, this is not required to produce deterministic simulations on
 # target machines running linux. Enable if you observe simulation non-determinism.
 zerooutdram=no
+
+[synthprint]
+start=0
+end=-1
+cycleprefix=yes

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -59,6 +59,10 @@ suffixtag=
 zerooutdram=no
 
 [synthprint]
+# Start and end cycles for outputting synthesized prints.
+# They are given in terms of the base clock and will be converted
+# for each clock domain.
 start=0
 end=-1
+# When enabled (=yes), prefix print output with the target cycle at which the print was triggered
 cycleprefix=yes

--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Printf-Synthesis.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Printf-Synthesis.rst
@@ -76,6 +76,19 @@ Runtime Arguments
     binary-output mode, since the target cycle is implicit in the token stream,
     this flag has no effect.
 
+You can set some of these options by changing the fields in the "synthprint"
+section of your config_runtime.ini.
+
+::
+
+    [synthprint]
+    start=0
+    end=-1
+    cycleprefix=yes
+
+The "start" field corresponds to "print-start", "end" to "print-end", and
+"cycleprefix" to "print-no-cycle-prefix".
+
 Related Publications
 --------------------
 

--- a/sim/midas/src/main/cc/bridges/fased_memory_timing_model.cc
+++ b/sim/midas/src/main/cc/bridges/fased_memory_timing_model.cc
@@ -52,15 +52,16 @@ void AddrRangeCounter::finish() {
 
 FASEDMemoryTimingModel::FASEDMemoryTimingModel(
     simif_t* sim, AddressMap addr_map, int argc,char** argv,
-    std::string stats_file_name, size_t mem_size)
+    std::string stats_file_name, size_t mem_size, std::string suffix)
   : FpgaModel(sim, addr_map), mem_size(mem_size) {
 
   std::vector<std::string> args(argv + 1, argv + argc);
   for (auto &arg: args) {
-    if(arg.find("+mm_") == 0) {
-      auto sub_arg = std::string(arg.c_str() + 4);
-      size_t delimit_idx = sub_arg.find_first_of("=");
-      std::string key = sub_arg.substr(0, delimit_idx).c_str();
+    if(arg.find("+mm_") == 0 && arg.find(suffix) != std::string::npos) {
+      auto sub_arg = arg.substr(4);
+      size_t delimit_idx = sub_arg.find("=");
+      size_t suffix_idx = sub_arg.find(suffix);
+      std::string key = sub_arg.substr(0, suffix_idx).c_str();
       int value = std::stoi(sub_arg.substr(delimit_idx+1).c_str());
       model_configuration[key] = value;
     }

--- a/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
+++ b/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
@@ -28,7 +28,8 @@
                 FASEDMEMORYTIMINGMODEL_ ## IDX ## _W_num_registers, \
                 (const unsigned int*) FASEDMEMORYTIMINGMODEL_ ## IDX ## _W_addrs, \
                 (const char* const*) FASEDMEMORYTIMINGMODEL_ ## IDX ## _W_names), \
-            argc, argv, "memory_stats" #IDX ".csv", 1L << FASEDMEMORYTIMINGMODEL_ ## IDX ## _target_addr_bits)); \
+            argc, argv, "memory_stats" #IDX ".csv", \
+            1L << FASEDMEMORYTIMINGMODEL_ ## IDX ## _target_addr_bits, "_" #IDX)); \
 
 
 // MICRO HACKS.
@@ -79,7 +80,7 @@ class FASEDMemoryTimingModel: public FpgaModel
 {
 public:
   FASEDMemoryTimingModel(simif_t* s, AddressMap addr_map, int argc, char** argv,
-                  std::string stats_file_name, size_t mem_size);
+                  std::string stats_file_name, size_t mem_size, std::string suffix);
   void init();
   void profile();
   void finish();

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -168,7 +168,7 @@ class FPGATop(implicit p: Parameters) extends LazyModule with HasWidgets {
     println("Host-FPGA DRAM Allocation Map:")
     sortedRegionTuples.zip(dramOffsets).foreach({ case ((bridgeSeq, addresses), offset) =>
       val regionName = bridgeSeq.head.memoryRegionName
-      val bridgeNames = bridgeSeq.map(_.wName.get).mkString(", ")
+      val bridgeNames = bridgeSeq.map(_.getWName).mkString(", ")
       println(f"  ${regionName} -> [0x${offset}%X, 0x${offset + BytesOfDRAMRequired(addresses) - 1}%X]")
       println(f"    Associated bridges: ${bridgeNames}")
     })

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -22,6 +22,10 @@ import Console.{UNDERLINED, RESET}
 
 import java.io.{File, FileWriter}
 
+object ModelID {
+  var id = 0
+}
+
 // Note: NASTI -> legacy rocket chip implementation of AXI4
 case object FasedAXI4Edge extends Field[Option[AXI4EdgeSummary]](None)
 
@@ -552,10 +556,11 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
     // Accepts an elaborated memory model and generates a runtime configuration for it
     private def emitSettings(fileName: String, settings: Seq[(String, String)])(implicit p: Parameters): Unit = {
       val file = new File(p(OutputDir), fileName)
-      val writer = new FileWriter(file)
+      val writer = new FileWriter(file, ModelID.id != 0)
       settings.foreach({
-        case (field, value) => writer.write(s"+mm_${field}=${value}\n")
+        case (field, value) => writer.write(s"+mm_${field}_${ModelID.id}=${value}\n")
       })
+      ModelID.id += 1
       writer.close
     }
 

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -22,10 +22,6 @@ import Console.{UNDERLINED, RESET}
 
 import java.io.{File, FileWriter}
 
-object ModelID {
-  var id = 0
-}
-
 // Note: NASTI -> legacy rocket chip implementation of AXI4
 case object FasedAXI4Edge extends Field[Option[AXI4EdgeSummary]](None)
 
@@ -556,11 +552,10 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
     // Accepts an elaborated memory model and generates a runtime configuration for it
     private def emitSettings(fileName: String, settings: Seq[(String, String)])(implicit p: Parameters): Unit = {
       val file = new File(p(OutputDir), fileName)
-      val writer = new FileWriter(file, ModelID.id != 0)
+      val writer = new FileWriter(file, wId != 0)
       settings.foreach({
-        case (field, value) => writer.write(s"+mm_${field}_${ModelID.id}=${value}\n")
+        case (field, value) => writer.write(s"+mm_${field}_${wId}=${value}\n")
       })
-      ModelID.id += 1
       writer.close
     }
 

--- a/sim/midas/src/main/scala/midas/widgets/AutoCounterBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AutoCounterBridge.scala
@@ -105,7 +105,7 @@ class AutoCounterBridgeModule(events: Seq[(String, String)], triggerName: String
       headerComment(sb)
       // Exclude counter addresses as their names can vary across AutoCounter instances, but 
       // we only generate a single struct typedef
-      val headerWidgetName = wName.getOrElse(name).toUpperCase
+      val headerWidgetName = wName.toUpperCase
       crRegistry.genHeader(headerWidgetName, base, sb, lowCountAddrs ++ highCountAddrs)
       crRegistry.genArrayHeader(headerWidgetName, base, sb)
       emitClockDomainInfo(headerWidgetName, sb)

--- a/sim/midas/src/main/scala/midas/widgets/Widget.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Widget.scala
@@ -35,10 +35,10 @@ class WidgetIO(implicit p: Parameters) extends ParameterizedBundle()(p){
 }
 abstract class Widget()(implicit p: Parameters) extends LazyModule()(p) {
   override def module: WidgetImp
-  val wName = Some(Widget.assignName(this))
-  this.suggestName(wName.get)
-  // Legacy API
-  def getWName = wName.get
+  val (wName, wId) = Widget.assignName(this)
+  this.suggestName(wName)
+
+  def getWName = wName
 
   // Returns widget-relative word address
   def getCRAddr(name: String): Int = {
@@ -170,7 +170,7 @@ abstract class WidgetImp(wrapper: Widget) extends LazyModuleImp(wrapper) {
 
 object Widget {
   private val widgetInstCount = mutable.HashMap[String, Int]().withDefaultValue(0)
-  def assignName[T <: Widget](m: T): String = {
+  def assignName[T <: Widget](m: T): (String, Int) = {
     // Assign stable widget names by using the class name and suffix using the
     // number of other instances.
     // We could let the user specify this in their bridge --> we'd need to consider:
@@ -180,7 +180,7 @@ object Widget {
     val widgetBasename = m.getClass.getSimpleName
     val idx = widgetInstCount(widgetBasename)
     widgetInstCount(widgetBasename) = idx + 1
-    widgetBasename + "_" + idx
+    (widgetBasename + "_" + idx, idx)
   }
 }
 

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -95,7 +95,7 @@ EXTRA_VERILATOR_FLAGS = \
 # SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #
 ################################################################
 TIMEOUT_CYCLES = 100000000
-DRAMSIM = +dramsim
+HOST_MEM_ARGS = +dramsim
 
 NET_SLOT ?= 0
 NET_LINK_LATENCY ?= 6405
@@ -120,7 +120,7 @@ mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
 COMMON_SIM_ARGS ?= $(serial_args) $(mem_model_args) $(nic_args) $(tracer_args) $(blkdev_args) $(autocounter_args)
 
 # Arguments used only at a particular simulation abstraction
-MIDAS_LEVEL_SIM_ARGS ?= $(DRAMSIM) +max-cycles=$(TIMEOUT_CYCLES)
+MIDAS_LEVEL_SIM_ARGS ?= $(HOST_MEM_ARGS) +max-cycles=$(TIMEOUT_CYCLES)
 FPGA_LEVEL_SIM_ARGS ?=
 
 ################################

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -95,6 +95,7 @@ EXTRA_VERILATOR_FLAGS = \
 # SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #
 ################################################################
 TIMEOUT_CYCLES = 100000000
+DRAMSIM = +dramsim
 
 NET_SLOT ?= 0
 NET_LINK_LATENCY ?= 6405
@@ -119,7 +120,7 @@ mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
 COMMON_SIM_ARGS ?= $(serial_args) $(mem_model_args) $(nic_args) $(tracer_args) $(blkdev_args) $(autocounter_args)
 
 # Arguments used only at a particular simulation abstraction
-MIDAS_LEVEL_SIM_ARGS ?= +dramsim +max-cycles=$(TIMEOUT_CYCLES)
+MIDAS_LEVEL_SIM_ARGS ?= $(DRAMSIM) +max-cycles=$(TIMEOUT_CYCLES)
 FPGA_LEVEL_SIM_ARGS ?=
 
 ################################


### PR DESCRIPTION
Three unrelated changes here

1. Make dramsim a standalone makefrag variable so that it's easier to disable for midas-level sim
2. Allow the DRAM timing model for each channel to have a different set of parameters
3. Expose options for synthesized prints in the config_runtime.ini