### PR TITLE
Add Chipyard env by default to FireSim env

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -164,8 +164,9 @@ if [ "$SKIP_TOOLCHAIN" != true ]; then
         fi
     )
     source "$target_chipyard_dir/env.sh"
-    env_append "source $target_chipyard_dir/env.sh"
 fi
+
+env_append "source $target_chipyard_dir/env.sh"
 
 cd $RDIR
 


### PR DESCRIPTION
For Chipyard-as-top systems, the `firesim-setup.sh` script is normally used with `--library`. This will disable building the toolchain, but as a result, the Chipyard env script is not sourced when running `source sourceme-f1-manager.sh`. This changes it so that the proper source is added by default (whether `SKIP_TOOLCHAIN` is disabled or not).

Note: This requires that `build-toolchains` is run before `source sourceme-f1-manager.sh` (which is implied in the Chipyard documentation)