### PR TITLE
Chipyard-as-Top RISC-V variables used in buildafi/infrasetup

### DIFF
--- a/deploy/buildtools/buildafi.py
+++ b/deploy/buildtools/buildafi.py
@@ -4,6 +4,7 @@ import time
 import random
 import string
 import logging
+import os
 
 from fabric.api import *
 from fabric.contrib.console import confirm
@@ -41,7 +42,14 @@ def replace_rtl(conf, buildconfig):
         run("""cp $CL_DIR/design/cl_firesim_generated.sv {}/results-build/{}/cl_firesim_generated.sv""".format(ddir, builddir))
 
     # build the fpga driver that corresponds with this version of the RTL
-    with prefix('cd ' + ddir + '/../'), prefix('source sourceme-f1-manager.sh'), prefix('cd sim/'), StreamLogger('stdout'), StreamLogger('stderr'):
+    with prefix('cd ' + ddir + '/../'), \
+         prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+         prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+         prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
+         prefix('source sourceme-f1-manager.sh'), \
+         prefix('cd sim/'), \
+         StreamLogger('stdout'), \
+         StreamLogger('stderr'):
         run(buildconfig.make_recipe("f1"))
 
 @parallel

--- a/deploy/buildtools/buildafi.py
+++ b/deploy/buildtools/buildafi.py
@@ -32,6 +32,9 @@ def replace_rtl(conf, buildconfig):
     rootLogger.info("Running replace-rtl to generate verilog for " + str(buildconfig.get_chisel_triplet()))
 
     with prefix('cd ' + ddir + '/../'), \
+         prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+         prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+         prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
          prefix('source sourceme-f1-manager.sh'), \
          prefix('export CL_DIR={}/../platforms/f1/aws-fpga/{}'.format(ddir, fpgabuilddir)), \
          prefix('cd sim/'), \

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -17,7 +17,6 @@ from runtools.run_farm import RunFarm
 from util.streamlogger import StreamLogger
 import os
 
-
 LOCAL_DRIVERS_BASE = "../sim/output/f1/"
 LOCAL_DRIVERS_GENERATED_SRC = "../sim/generated-src/f1/"
 CUSTOM_RUNTIMECONFS_BASE = "../sim/custom-runtime-configs/"
@@ -182,7 +181,14 @@ class RuntimeHWConfig:
         target_config = triplet_pieces[1]
         platform_config = triplet_pieces[2]
         rootLogger.info("Building FPGA software driver for " + str(self.get_deploytriplet_for_config()))
-        with prefix('cd ../'), prefix('source ./sourceme-f1-manager.sh'), prefix('cd sim/'), StreamLogger('stdout'), StreamLogger('stderr'):
+        with prefix('cd ../'), \
+             prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+             prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+             prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
+             prefix('source ./sourceme-f1-manager.sh'), \
+             prefix('cd sim/'), \
+             StreamLogger('stdout'), \
+             StreamLogger('stderr'):
             localcap = None
             with settings(warn_only=True):
                 driverbuildcommand = """make DESIGN={} TARGET_CONFIG={} PLATFORM_CONFIG={} f1""".format(design, target_config, platform_config)


### PR DESCRIPTION
This fixes the problem mentioned in #559 where Chipyard-as-Top FireSim would not use the RISC-V variables during `buildafi` and `infrasetup`. This makes it so that the default `RISCV/LD_LIB_PATH/PATH` are added before FireSim's `sourceme` so that it can be present and overridden by FireSim's `sourceme`.