### PR TITLE
add expect to machine-launch-script.sh

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -49,6 +49,9 @@ sudo yum -y install bash-completion
 # graphviz for manager
 sudo yum -y install graphviz python-devel
 
+# used for CI
+sudo yum -y expect
+
 # these need to match what's in deploy/requirements.txt
 sudo pip2 install fabric==1.14.0
 sudo pip2 install boto3==1.6.2

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -50,7 +50,7 @@ sudo yum -y install bash-completion
 sudo yum -y install graphviz python-devel
 
 # used for CI
-sudo yum -y expect
+sudo yum -y install expect
 
 # these need to match what's in deploy/requirements.txt
 sudo pip2 install fabric==1.14.0


### PR DESCRIPTION
I was hoping to add `expect` to the launch script so that BOOM's FireSim CI doesn't have to install it on the manager itself (`expect` is used to talk to interactive programs so that they can be scripted). Currently, I just append the install to the end of the launch script in my own CI every time I launch a manager instance. Depending on how FireSim wants to do its CI (and Chipyard's FireSim CI), we may want to add this globally.