### PR TITLE
Make machine-launch fail on error. 

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -36,7 +36,7 @@ rm -rf $DTCversion
 # get a proper version of git
 sudo yum -y remove git
 sudo yum -y install epel-release
-sudo yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
 sudo yum -y install git224
 
 # install verilator

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -ex
+set -o pipefail
+
 echo "machine launch script started" > /home/centos/machine-launchstatus
 
 {


### PR DESCRIPTION
CI will correctly pick up problems and the log will end at the problematic command. 

h/t @abejgonzalez 