### PR TITLE
Don't include hidden files in make source file lists

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -44,7 +44,7 @@ FIRRTL_SUBMODULE_DIR ?= $(chipyard_dir)/tools/firrtl
 FIRRTL_JAR ?= $(chipyard_dir)/lib/firrtl.jar
 FIRRTL_TEST_JAR ?= $(chipyard_dir)/test_lib/firrtl.jar
 
-firrtl_srcs := $(shell find $(FIRRTL_SUBMODULE_DIR) -iname "*.scala")
+firrtl_srcs := $(shell find $(FIRRTL_SUBMODULE_DIR) -iname "[!.]*.scala")
 
 $(FIRRTL_JAR): $(firrtl_srcs)
 	$(MAKE) -C $(FIRRTL_SUBMODULE_DIR) SBT="$(SBT)" root_dir=$(FIRRTL_SUBMODULE_DIR) build-scala

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -44,7 +44,7 @@ submodules = \
 		$(addprefix tools/, firrtl chisel3))
 
 chisel_srcs = $(foreach submodule,$(submodules),\
-	$(shell find -L $(submodule)/ -name target -prune -o -iname "*.scala" -print 2> /dev/null))
+	$(shell find -L $(submodule)/ -name target -prune -o -iname "[!.]*.scala" -print 2> /dev/null))
 
 $(FIRRTL_FILE) $(ANNO_FILE): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -32,7 +32,7 @@ HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := {file:${chipyard_dir}}firechip
 
-	lookup_scala_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "*.scala" -print 2> /dev/null)
+	lookup_scala_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "[!.]*.scala" -print 2> /dev/null)
 	SOURCE_DIRS = $(chipyard_dir)/generators $(firesim_base_dir)
 	SCALA_SOURCES = $(call lookup_scala_srcs,$(SOURCE_DIRS))
 else

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -38,7 +38,7 @@ submodules = \
 
 
 chisel_srcs = $(foreach submodule,$(submodules),\
-	$(shell find -L $(submodule)/ -name target -prune -o -iname "*.scala" -print 2> /dev/null))
+	$(shell find -L $(submodule)/ -name target -prune -o -iname "[!.]*.scala" -print 2> /dev/null))
 
 CONF_NAME ?= runtime.conf
 


### PR DESCRIPTION
If editor autosaves are hidden, they'll appear in source lists (and therefore make prerequisites), which can mess things up for some of the make flows in FireSim. SBT will ignore hidden Scala source files in all cases, so it's fine to ignore them as build prerequisites.