### PR TITLE
Machinery for Generating ScalaDoc and Publishing to FireSim's GitHub Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sim[0-9]
 build-setup-log
 tags
 build
+scala-doc-env.sh

--- a/scripts/build-setup-docs.sh
+++ b/scripts/build-setup-docs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# A minimal build-setup script to pull in all of the scala sources required to
+# build scala doc.
+set -e
+set -o pipefail
+
+RDIR=$(pwd)
+git submodule update --init target-design/chipyard
+cd $RDIR/target-design/chipyard
+./scripts/init-submodules-no-riscv-tools.sh --no-firesim
+cd $RDIR
+echo "export FIRESIM_ENV_SOURCED=1" > scala-doc-env.sh
+echo "export FIRESIM_STANDALONE=1" >> scala-doc-env.sh

--- a/sim/project/plugins.sbt
+++ b/sim/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 
 resolvers += "simplytyped" at "https://simplytyped.github.io/repo/releases"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
 

--- a/sim/src/site/index.html
+++ b/sim/src/site/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>FireSim Documentation</title>
+        <script language="JavaScript">
+        <!--
+        function doRedirect()
+        {
+            window.location.replace("latest/api");
+        }
+        doRedirect();
+        //-->
+        </script>
+    </head>
+    <body>
+        <a href="https://docs.fires.im">Main Documentation</a>
+        <a href="latest/api">Scala API Documentation</a>
+    </body>
+</html>


### PR DESCRIPTION
This leverages a triplet of nifty SBT plugins to:
1) Unify scala doc across FireSim's three library projects (targetutils, midas, firesim-lib)
2) Generate a site using that unified scaladoc
3) Copy site sources into the `gh-page` branch and push it to remote

An initial version of the API documentation can be found at: https://fires.im/firesim/latest/api/
(redirected from https://firesim.github.io/firesim -> https://fires.im/firesim)

PRs to:
- automatically regenerate API docs on PR merges to dev and release tags
- link to API documentation from docs.fires.im 
will follow. 
