### PR TITLE
Update nbd install

### DIFF
--- a/scripts/install-nbd-kmod.sh
+++ b/scripts/install-nbd-kmod.sh
@@ -13,37 +13,43 @@ KURL="http://vault.centos.org/7.6.1810/updates/Source/SPackages/$KRPM"
 
 GENERICBUILDDIR=$(pwd)/build
 NBDBUILDDIR=$GENERICBUILDDIR/nbdbuild
+KBUILDDIR=$NBDBUILDDIR/BUILD/kernel-$KSRC/linux-$KSRC.x86_64
+OUTPUTFILE=$GENERICBUILDDIR/nbd.ko
 
 mkdir -p $GENERICBUILDDIR
 cd $GENERICBUILDDIR
 echo $(pwd)
 mkdir -p $NBDBUILDDIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
+rm -rf "$NBDBUILDDIR"
+rm -rf "$KRPM"* $OUTPUTFILE
 wget $KURL
 
 # unpack
+cd $GENERICBUILDDIR
 rpm --define="_topdir $NBDBUILDDIR" -ivh $KRPM
 
 cd $NBDBUILDDIR/SPECS
 rpmbuild --define="_topdir $NBDBUILDDIR" -bp --target=$(uname -m) kernel.spec
 
-KBUILDDIR=$NBDBUILDDIR/BUILD/kernel-$KSRC/linux-$KSRC.x86_64/
-cd $KBUILDDIR
 
 # this file is not kept up to date and does not compile, need to patch it
+cd $KBUILDDIR
 sed -i 's/REQ_TYPE_SPECIAL/REQ_TYPE_DRV_PRIV/g' $KBUILDDIR/drivers/block/nbd.c
 
-# now build
-make -j32 prepare
-make -j32 modules_prepare
+# now clean/setup .config
+cd $KBUILDDIR
+make -j32 mrproper
+make -j32 oldconfig
 
 # turn on NBD in the config
+cd $KBUILDDIR
 sed -i 's/# CONFIG_BLK_DEV_NBD is not set/CONFIG_BLK_DEV_NBD=m/g' $KBUILDDIR/.config
+make -j32 modules_prepare
 
+# now build
 make -j32
-make M=drivers/block -j32
 modinfo drivers/block/nbd.ko
 
-OUTPUTFILE=$GENERICBUILDDIR/nbd.ko
 cp $KBUILDDIR/drivers/block/nbd.ko $OUTPUTFILE
 echo "NBD kernel module available in $OUTPUTFILE"


### PR DESCRIPTION
Occasionally, the NBD module is built incorrectly causing `infrasetup` to fail inserting the module. This is a solution done by Sam Steffl that seems to resolve the issue.