### PR TITLE
Build nbd module without the full kernel

### DIFF
--- a/scripts/install-nbd-kmod.sh
+++ b/scripts/install-nbd-kmod.sh
@@ -1,49 +1,52 @@
+#!/bin/sh
 # This script produces the nbd kernel module to use on run farm nodes.
-set -e
+set -ex
 
 # deps
 sudo yum -y install xmlto asciidoc hmaccalc newt-devel pesign elfutils-devel binutils-devel audit-libs-devel numactl-devel pciutils-devel python-docutils "perl(ExtUtils::Embed)"
 
 # update this as FPGA Dev AMI updates
-KSRC="3.10.0-957.5.1.el7"
+KSRC='3.10.0-957.5.1.el7'
 
 # other vars
-KRPM="kernel-$KSRC.src.rpm"
-KURL="http://vault.centos.org/7.6.1810/updates/Source/SPackages/$KRPM"
+TARGET=x86_64
+DISTSITE='http://vault.centos.org/7.6.1810'
 
 GENERICBUILDDIR=$(pwd)/build
 NBDBUILDDIR=$GENERICBUILDDIR/nbdbuild
+OUTPUTFILE=$GENERICBUILDDIR/nbd.ko
 
-mkdir -p $GENERICBUILDDIR
-cd $GENERICBUILDDIR
-echo $(pwd)
-mkdir -p $NBDBUILDDIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+rm -rf -- "$NBDBUILDDIR" "$OUTPUTFILE"
 
-wget $KURL
+# fetch and unpack source RPM
+rpm -i --verbose --define="_topdir $NBDBUILDDIR" \
+    "${DISTSITE}/updates/Source/SPackages/kernel-${KSRC}.src.rpm"
 
-# unpack
-rpm --define="_topdir $NBDBUILDDIR" -ivh $KRPM
+# run %prep stage
+cd "${NBDBUILDDIR}/SPECS"
+rpmbuild --define="_topdir $NBDBUILDDIR" -bp --target="$TARGET" kernel.spec
 
-cd $NBDBUILDDIR/SPECS
-rpmbuild --define="_topdir $NBDBUILDDIR" -bp --target=$(uname -m) kernel.spec
+cd "${NBDBUILDDIR}/BUILD/kernel-${KSRC}/linux-${KSRC}.${TARGET}"
 
-KBUILDDIR=$NBDBUILDDIR/BUILD/kernel-$KSRC/linux-$KSRC.x86_64/
-cd $KBUILDDIR
+# acquire Module.symvers from kernel-devel binary package;
+# this enables proper symbol versioning (modversions) without requiring
+# a full kernel build
+rpm2cpio "${DISTSITE}/updates/${TARGET}/Packages/kernel-devel-${KSRC}.${TARGET}.rpm" |
+    cpio -iv --to-stdout "./usr/src/kernels/${KSRC}.${TARGET}/Module.symvers" > Module.symvers
 
 # this file is not kept up to date and does not compile, need to patch it
-sed -i 's/REQ_TYPE_SPECIAL/REQ_TYPE_DRV_PRIV/g' $KBUILDDIR/drivers/block/nbd.c
-
-# now build
-make -j32 prepare
-make -j32 modules_prepare
+sed -i 's/REQ_TYPE_SPECIAL/REQ_TYPE_DRV_PRIV/g' drivers/block/nbd.c
 
 # turn on NBD in the config
-sed -i 's/# CONFIG_BLK_DEV_NBD is not set/CONFIG_BLK_DEV_NBD=m/g' $KBUILDDIR/.config
+sed -i 's/# CONFIG_BLK_DEV_NBD is not set/CONFIG_BLK_DEV_NBD=m/g' .config
 
-make -j32
-make M=drivers/block -j32
-modinfo drivers/block/nbd.ko
+make olddefconfig
+make prepare
+make modules_prepare
+make M=drivers/block nbd.ko
 
-OUTPUTFILE=$GENERICBUILDDIR/nbd.ko
-cp $KBUILDDIR/drivers/block/nbd.ko $OUTPUTFILE
-echo "NBD kernel module available in $OUTPUTFILE"
+KMOD=drivers/block/nbd.ko
+
+modinfo "$KMOD"
+modprobe --dump-modversions "$KMOD" | grep -F module_layout
+cp "$KMOD" "$OUTPUTFILE"

--- a/scripts/install-nbd-kmod.sh
+++ b/scripts/install-nbd-kmod.sh
@@ -37,8 +37,15 @@ rpm2cpio "${DISTSITE}/updates/${TARGET}/Packages/kernel-devel-${KSRC}.${TARGET}.
 # this file is not kept up to date and does not compile, need to patch it
 sed -i 's/REQ_TYPE_SPECIAL/REQ_TYPE_DRV_PRIV/g' drivers/block/nbd.c
 
-# turn on NBD in the config
-sed -i 's/# CONFIG_BLK_DEV_NBD is not set/CONFIG_BLK_DEV_NBD=m/g' .config
+# use non-debug kernel config
+(
+    export LC_ALL='' LC_COLLATE=C
+    for KCFG in configs/kernel-*-"$TARGET".config ; do break ; done
+    test -r "$KCFG"
+
+    # turn on NBD in the config
+    sed 's/# CONFIG_BLK_DEV_NBD is not set/CONFIG_BLK_DEV_NBD=m/g' "$KCFG" > .config
+)
 
 make olddefconfig
 make prepare


### PR DESCRIPTION
Kernel modules compiled for CentOS must have correct symbol versioning information (`CONFIG_MODVERSIONS`) to be loaded successfully.  This originally meant that building `nbd.ko` also required building the entire kernel to generate the `Module.symvers` file, a potentially brittle procedure as any divergence in the kernel configuration could lead to compatibility issues.

This shortcut skips the full kernel build by directly acquiring `Module.symvers` from the corresponding `kernel-devel` RPM.  It is also a brute-force measure to ensure that the modversions info matches exactly with the official kernel image.

This subsumes #570.