### PR TITLE
Add most non-FireChip ScalaTests to CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: firesim/firesim-ci:v1.0
         user: "centos"
     environment:
-        JVM_MEMORY: 2200m # Customize the JVM maximum heap limit
+        JVM_MEMORY: 2200M # Default JVM maximum heap limit
         LANG: en_US.UTF-8 # required by sbt when it sees boost directories
 
 commands:
@@ -67,6 +67,9 @@ commands:
   run-scala-test:
     description: "Runs the scala test with name <test-package>.<test-name>"
     parameters:
+      project:
+        type: string
+        default: "firesim"
       test-name:
         type: string
       test-package:
@@ -79,7 +82,8 @@ commands:
         - run:
             command: |
                 source env.sh
-                make -C sim TARGET_PROJECT=midasexamples testOnly SCALA_TEST=<< parameters.test-package >>.<< parameters.test-name >>
+                make -C sim TARGET_PROJECT=midasexamples sbt \
+                    SBT_COMMAND="project << parameters.project >>; testOnly << parameters.test-package >>.<< parameters.test-name >>"
             no_output_timeout: << parameters.timeout >>
 
   repo-setup:
@@ -108,6 +112,10 @@ jobs:
       - repo-setup
       - run-scala-test:
           test-name: "CIGroupB"
+      - run-scala-test:
+           project: "midas"
+           test-package: "*"
+           test-name: "*"
 
   publish-scala-doc:
     executor: main-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,6 @@ commands:
             source env.sh
             make -C sim TARGET_PROJECT=midasexamples sbt SBT_COMMAND=test:compile
 
-  firesimtest-manual-midasexamples:
-    description: "Run a test"
-    steps:
-      - run:
-          command: |
-            source env.sh
-            make -C sim run-verilator LOGFILE= WAVEFORM= ARGS=+tracelen=8 TARGET_PROJECT=midasexamples DESIGN=Stack TARGET_CONFIG=NoConfig PLATFORM_CONFIG=HostDebugFeatures_DefaultF1Config PLATFORM=f1
-
   build-scala-doc:
     description: "Compiles Scala Doc"
     steps:
@@ -72,6 +64,24 @@ commands:
                 export SBT_GHPAGES_COMMIT_MESSAGE="[ci skip] Update scaladoc for dev:<< pipeline.git.revision >>"
                 make -C sim TARGET_PROJECT=midasexamples sbt SBT_COMMAND="ghpagesPushSite"
 
+  run-scala-test:
+    description: "Runs the scala test with name <test-package>.<test-name>"
+    parameters:
+      test-name:
+        type: string
+      test-package:
+        type: string
+        default: "firesim.midasexamples"
+      timeout:
+        type: string
+        default: "120m"
+    steps:
+        - run:
+            command: |
+                source env.sh
+                make -C sim TARGET_PROJECT=midasexamples testOnly SCALA_TEST=<< parameters.test-package >>.<< parameters.test-name >>
+            no_output_timeout: << parameters.timeout >>
+
   repo-setup:
     description: "Runs all baseline setup tasks up to scala compilation."
     steps:
@@ -84,12 +94,20 @@ commands:
       - scala-build
 
 jobs:
-  run-tests:
+  run-test-groupA:
     executor: main-env
     steps:
       - repo-setup
-      - firesimtest-manual-midasexamples
+      - run-scala-test:
+          test-name: "CIGroupA"
       - build-scala-doc
+
+  run-test-groupB:
+    executor: main-env
+    steps:
+      - repo-setup
+      - run-scala-test:
+          test-name: "CIGroupB"
 
   publish-scala-doc:
     executor: main-env
@@ -103,12 +121,8 @@ workflows:
 
    firesimCIall:
      jobs:
-       - run-tests:
-           filters:
-             branches:
-               ignore:
-                 - gh-pages
-
+       - run-test-groupA
+       - run-test-groupB
        - publish-scala-doc:
            filters:
              branches:

--- a/sim/build.sbt
+++ b/sim/build.sbt
@@ -35,8 +35,6 @@ def isolateAllTests(tests: Seq[TestDefinition]) = tests map { test =>
       new Group(test.name, Seq(test), SubProcess(options))
   } toSeq
 
-testGrouping in Test := isolateAllTests( (definedTests in Test).value )
-
 lazy val firesimAsLibrary = sys.env.get("FIRESIM_STANDALONE") == None
 
 lazy val chipyardDir = if(firesimAsLibrary) {
@@ -93,6 +91,7 @@ lazy val firesim    = (project in file("."))
     // Clobber the existing doc task to instead have it use the unified one
     Compile / doc := (doc in ScalaUnidoc).value,
     // Registers the unidoc-generated html with sbt-site
-    addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc)
+    addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc),
+    concurrentRestrictions += Tags.limit(Tags.Test, 1)
   )
   .dependsOn(chisel, rocketchip, midas, firesimLib % "test->test;compile->compile", chipyard)

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -36,15 +36,12 @@ ifdef FIRESIM_STANDALONE
 else
 	firesim_sbt_project := {file:${firesim_base_dir}/}firesim
 endif
+chisel_src_dirs = \
+		$(addprefix $(firesim_base_dir)/,. midas midas/targetutils firesim-lib) \
+		$(addprefix $(chipyard_dir)/generators/, chipyard rocket-chip/src, rocket-chip/api-config-chipsalliance)
 
-submodules = \
-    $(addprefix $(firesim_base_dir)/,. midas midas/targetutils firesim-lib) \
-    $(addprefix $(chipyard_dir)/, \
-		$(addprefix generators/, rocket-chip) \
-		$(addprefix tools/, firrtl chisel3))
-
-chisel_srcs = $(foreach submodule,$(submodules),\
-	$(shell find -L $(submodule)/ -name target -prune -o -iname "[!.]*.scala" -print 2> /dev/null))
+chisel_srcs = $(foreach submodule,$(chisel_src_dirs),\
+	$(shell find $(submodule)/ -iname "[!.]*.scala" -print 2> /dev/null | grep 'src/main/scala'))
 
 $(FIRRTL_FILE) $(ANNO_FILE): $(chisel_srcs) $(FIRRTL_JAR)
 	mkdir -p $(@D)

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -67,7 +67,7 @@ DROMAJO_ROM = $(GENERATED_DIR)/$(long_name).rom
 DTS_FILE = $(GENERATED_DIR)/$(long_name).dts
 DROMAJO_DTB = $(GENERATED_DIR)/$(long_name).dtb
 
-DROMAJO_LIB:
+$(DROMAJO_LIB):
 	$(MAKE) -C $(DROMAJO_DIR)
 
 $(DROMAJO_LONG_H) $(DTS_FILE): $(VERILOG)

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -30,15 +30,12 @@ else
 	firesim_sbt_project := {file:${firesim_base_dir}/}firesim
 endif
 
-submodules = \
-    $(addprefix $(firesim_base_dir)/,. midas midas/targetutils firesim-lib) \
-    $(addprefix $(chipyard_dir)/, \
-		$(addprefix generators/, rocket-chip) \
-		$(addprefix tools/, firrtl chisel3))
+chisel_src_dirs = \
+		$(addprefix $(firesim_base_dir)/,. midas midas/targetutils firesim-lib) \
+		$(addprefix $(chipyard_dir)/generators/, chipyard rocket-chip/src, rocket-chip/api-config-chipsalliance)
 
-
-chisel_srcs = $(foreach submodule,$(submodules),\
-	$(shell find -L $(submodule)/ -name target -prune -o -iname "[!.]*.scala" -print 2> /dev/null))
+chisel_srcs = $(foreach submodule,$(chisel_src_dirs),\
+	$(shell find $(submodule)/ -iname "[!.]*.scala" -print 2> /dev/null | grep 'src/main/scala'))
 
 CONF_NAME ?= runtime.conf
 

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -39,7 +39,6 @@ chisel_srcs = $(foreach submodule,$(chisel_src_dirs),\
 
 CONF_NAME ?= runtime.conf
 
-$(info $(chisel_srcs))
 SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
 mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
 COMMON_SIM_ARGS ?= $(mem_model_args)

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -39,6 +39,7 @@ chisel_srcs = $(foreach submodule,$(chisel_src_dirs),\
 
 CONF_NAME ?= runtime.conf
 
+$(info $(chisel_srcs))
 SIM_RUNTIME_CONF ?= $(GENERATED_DIR)/$(CONF_NAME)
 mem_model_args = $(shell cat $(SIM_RUNTIME_CONF))
 COMMON_SIM_ARGS ?= $(mem_model_args)

--- a/sim/src/test/scala/fasedtests/FASEDTestSuite.scala
+++ b/sim/src/test/scala/fasedtests/FASEDTestSuite.scala
@@ -85,7 +85,6 @@ class AXI4FuzzerZedboardTest extends FASEDTest("AXI4Fuzzer", "DefaultConfig", "D
 // Suite Collections for CI
 class CIGroupA extends Suites(
   new AXI4FuzzerLBPTest,
-  new AXI4FuzzerMultiChannelTest,
   new AXI4FuzzerFRFCFSTest
 )
 

--- a/sim/src/test/scala/fasedtests/FASEDTestSuite.scala
+++ b/sim/src/test/scala/fasedtests/FASEDTestSuite.scala
@@ -4,8 +4,8 @@ package firesim.fasedtests
 import java.io.File
 
 import scala.concurrent.{Future, Await, ExecutionContext}
-import scala.sys.process.{stringSeqToProcess, ProcessLogger}
 import scala.util.Random
+import org.scalatest.Suites
 
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.system.{RocketTestSuite, BenchmarkTestSuite}
@@ -81,3 +81,16 @@ class BaselineMultichannelTest extends FASEDTest(
 class NarrowIdConstraint extends FASEDTest("AXI4Fuzzer", "DefaultConfig", "ConstrainedIdHostConfig")
 class AXI4FuzzerZC706LBPTest extends FASEDTest("AXI4Fuzzer", "DefaultConfig", "DefaultZC706Config")
 class AXI4FuzzerZedboardTest extends FASEDTest("AXI4Fuzzer", "DefaultConfig", "DefaultZedboardConfig")
+
+// Suite Collections for CI
+class CIGroupA extends Suites(
+  new AXI4FuzzerLBPTest,
+  new AXI4FuzzerMultiChannelTest,
+  new AXI4FuzzerFRFCFSTest
+)
+
+class CIGroupB extends Suites(
+  new AXI4FuzzerLLCDRAMTest,
+  new NarrowIdConstraint
+)
+

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -196,4 +196,6 @@ class CIGroupB extends Suites(
   new MulticlockAssertF1Test,
   new GoldenGateMiscCITests,
   new firesim.fasedtests.CIGroupB,
+  new firesim.AllMidasUnitTests,
+  new firesim.FailingUnitTests
 )

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -2,8 +2,8 @@
 package firesim.midasexamples
 
 import java.io.File
-import scala.sys.process.{stringSeqToProcess, ProcessLogger}
 import scala.io.Source
+import org.scalatest.Suites
 
 abstract class TutorialSuite(
     val targetName: String, // See GeneratorUtils
@@ -147,3 +147,53 @@ class MulticlockAutoCounterF1Test extends TutorialSuite("MulticlockAutoCounterMo
 }
 // Basic test for deduplicated extracted models
 class TwoAddersF1Test extends TutorialSuite("TwoAdders")
+
+// Suite Collections
+class ChiselExampleDesigns extends Suites(
+  new GCDF1Test,
+  new ParityF1Test,
+  new ResetShiftRegisterF1Test,
+  new EnableShiftRegisterF1Test,
+  new StackF1Test,
+  new RiscF1Test,
+  new RiscSRAMF1Test
+)
+
+class PrintfSynthesisCITests extends Suites(
+  new PrintfModuleF1Test,
+  new NarrowPrintfModuleF1Test,
+  new MulticlockPrintF1Test
+)
+
+class AssertionSynthesisCITests extends Suites(
+  new AssertModuleF1Test,
+  new MulticlockAssertF1Test
+)
+
+class AutoCounterCITests extends Suites(
+  new AutoCounterModuleF1Test,
+  new AutoCounterCoverModuleF1Test,
+  new AutoCounterPrintfF1Test,
+  new MulticlockAutoCounterF1Test
+)
+
+class GoldenGateMiscCITests extends Suites(
+  new TwoAddersF1Test,
+  new TriggerWiringModuleF1Test,
+  new WireInterconnectF1Test,
+  new TrivialMulticlockF1Test
+)
+
+// Each group runs on a single worker instance
+class CIGroupA extends Suites(
+  new ChiselExampleDesigns,
+  new PrintfSynthesisCITests,
+  new firesim.fasedtests.CIGroupA,
+)
+
+class CIGroupB extends Suites(
+  new AssertModuleF1Test,
+  new MulticlockAssertF1Test,
+  new GoldenGateMiscCITests,
+  new firesim.fasedtests.CIGroupB,
+)

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -284,6 +284,6 @@ tags: $(HEADER) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 
 .PRECIOUS: $(OUTPUT_DIR)/%.vpd $(OUTPUT_DIR)/%.out $(OUTPUT_DIR)/%.run
 
-# Remove all implicit suffix rules; THis improves make performance substantially as it no longer
+# Remove all implicit suffix rules; This improves make performance substantially as it no longer
 # attempts to resolve implicit rules on 1000+ scala files.
 .SUFFIXES:

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -283,3 +283,7 @@ tags: $(HEADER) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 .PHONY: mostlyclean clean
 
 .PRECIOUS: $(OUTPUT_DIR)/%.vpd $(OUTPUT_DIR)/%.out $(OUTPUT_DIR)/%.run
+
+# Remove all implicit suffix rules; THis improves make performance substantially as it no longer
+# attempts to resolve implicit rules on 1000+ scala files.
+.SUFFIXES:


### PR DESCRIPTION
This includes:
- Most tests under fasedtests
- All tests under midasexamples
- All midas FIRRTL pass tests
- Synthesizable unittests

Most of the work is divided into two suites which will run concurrently. This seems to balance concurrency and amortizing the enormous cost of doing machine-launch + build-setup + 1st scala compile (~ 30m). 

Circle CI memory limitations preclude running larger FASEDTests and FireChip at the moment. 

It also speeds up `make` invocations which should help with test throughput. 