### PR TITLE
Port multi-port serialized mem optimization to multi-clock

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/RemoveTrivialPartialConnects.scala
+++ b/sim/midas/src/main/scala/midas/passes/RemoveTrivialPartialConnects.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package midas.passes
+
+import firrtl._
+import firrtl.ir._
+import firrtl.passes._
+import firrtl.Utils._
+import firrtl.Mappers._
+import firrtl.options.{Dependency, PreservesAll}
+
+object RemoveTrivialPartialConnects extends Pass with PreservesAll[Transform] {
+
+  override def prerequisites =
+    Dependency(InferTypes) +: Dependency(ResolveKinds) +: stage.Forms.WorkingIR
+
+  private def onStmt(stmt: Statement): Statement = stmt match {
+    case PartialConnect(i, l, e) if (l.tpe == e.tpe) => Connect(i, l, e)
+    case s => s.map(onStmt)
+  }
+
+  private def onModule(m: DefModule): DefModule = m.map(onStmt)
+
+  def run(c: Circuit): Circuit = {
+    c.map(onModule)
+  }
+}

--- a/sim/midas/src/main/scala/midas/passes/SimulationMapping.scala
+++ b/sim/midas/src/main/scala/midas/passes/SimulationMapping.scala
@@ -17,7 +17,6 @@ import firrtl.Mappers._
 import firrtl.passes.LowerTypes.loweredName
 import firrtl.Utils.{BoolType, splitRef, mergeRef, create_exps, flow, module_type}
 import firrtl.passes.wiring._
-import fame.{FAMEChannelConnectionAnnotation, FAMEChannelPortsAnnotation, FAMEChannelAnalysis, FAME1Transform}
 import Utils._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.LazyModule
@@ -117,7 +116,7 @@ private[passes] class SimulationMapping(targetName: String) extends firrtl.Trans
       Map(CircuitName(innerCircuit.main) -> Seq(CircuitName(outerCircuit.main))))
 
     val innerAnnos = loweredInnerState.annotations.filter(_ match {
-      case _: FAMEChannelConnectionAnnotation | _: FAMEChannelPortsAnnotation => false
+      case _: midas.targetutils.FAMEAnnotation => false
       case _: BridgeIOAnnotation => false
       case _ => true
     })

--- a/sim/midas/src/main/scala/midas/passes/fame/RTLUtils.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/RTLUtils.scala
@@ -65,6 +65,10 @@ object Or extends BinaryBooleanOp {
   val op = PrimOps.Or
 }
 
+object Xor extends BinaryBooleanOp {
+  val op = PrimOps.Xor
+}
+
 object Neq extends BinaryBooleanOp {
   val op = PrimOps.Neq
 }
@@ -75,4 +79,12 @@ object Neq extends BinaryBooleanOp {
 object RegZeroPreset {
   def apply(info: Info, name: String, tpe: Type, clock: Expression): DefRegister =
     DefRegister(info, name, tpe, clock, zero, WRef(name))
+  def apply(info: Info, name: String, clock: Expression): DefRegister =
+    DefRegister(info, name, BoolType, clock, zero, WRef(name))
+}
+
+object ConditionalConnect {
+  def apply(cond: Expression, lhs: Expression, rhs: Expression): Conditionally = {
+    Conditionally(NoInfo, cond, Connect(NoInfo, lhs, rhs), EmptyStmt)
+  }
 }


### PR DESCRIPTION
This updates some pieces of the multi-ported memory model replacement flow to accommodate both a) the multi-clock changes and b) FIRRTL 1.3 changes.