### PR TITLE
Replace full instance Connects with PartialConnects in PromoteSubmodule

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/fame/PromoteSubmodule.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/PromoteSubmodule.scala
@@ -77,7 +77,9 @@ class PromoteSubmodule extends Transform {
       promotedNames += childPeerInst.name
       val connection = PartialConnect(childTemplate.info, instanceField(retypedParentInst, childTemplate.name), instanceRef(childPeerInst))
       Block(Seq(retypedParentInst, childPeerInst, connection))
-  case Block(stmts) => Block(stmts map (s => transformParentInstances(s, parentTemplate, childTemplate, namespace, promotedNames)))
+    case Block(stmts) => Block(stmts map (s => transformParentInstances(s, parentTemplate, childTemplate, namespace, promotedNames)))
+    case Connect(info, iref @ WRef(_, _, InstanceKind, _), rhs) => PartialConnect(info, iref, rhs)
+    case Connect(info, lhs, iref @ WRef(_, _, InstanceKind, _)) => PartialConnect(info, lhs, iref)
     case s => s
   }
 


### PR DESCRIPTION
If the parent of the promoted instance is bulk-connected to in its entirety, promoting its child instance may lead to errors downstream in `CheckTypes`. This removes the potential for that problem.

E.g.:
```
module grandparent:
  ...
  inst p of parent
  p <= whole_module_connect
```
This will cause issues when they type of `p` changes after `p.child` is promoted.