### PR TITLE
fix ILATopWiring optionalPrerequisiteOf

### DIFF
--- a/sim/firesim-lib/src/main/scala/passes/ILATopWiring.scala
+++ b/sim/firesim-lib/src/main/scala/passes/ILATopWiring.scala
@@ -132,7 +132,8 @@ class ILATopWiringTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def optionalPrerequisiteOf = Seq.empty
+  // We want this pass to run before any emitters
+  override def optionalPrerequisiteOf = Forms.HighEmitters
 
   override def invalidates(a: Transform): Boolean = a match {
     case InferTypes | ResolveKinds | ResolveFlows | ExpandConnects => true


### PR DESCRIPTION
So it turns out changing this definition to empty in the previous PR was incorrect. This changes it back to match FIRRTL's TopWiring transform. I'll see if I can add midasexamples tests too, so that we don't regress on this unknowingly in the future.