### PR TITLE
Use more =? to improve ability to customize and reuse makefrags

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -34,6 +34,10 @@ base_dir := $(firesim_base_dir)
 chipyard_dir := $(abspath ..)/target-design/chipyard
 rocketchip_dir := $(chipyard_dir)/generators/rocket-chip
 
+FIRRTL_SUBMODULE_DIR ?= $(chipyard_dir)/tools/firrtl
+FIRRTL_JAR ?= $(chipyard_dir)/lib/firrtl.jar
+FIRRTL_TEST_JAR ?= $(chipyard_dir)/test_lib/firrtl.jar
+
 else
 # Chipyard make variables
 base_dir := $(abspath ../../..)
@@ -91,10 +95,6 @@ $(BLOOP_CONFIG_DIR)/TIMESTAMP: $(sbt_sources)
 	touch $@
 
 # Manage the FIRRTL dependency manually
-FIRRTL_SUBMODULE_DIR ?= $(chipyard_dir)/tools/firrtl
-FIRRTL_JAR ?= $(chipyard_dir)/lib/firrtl.jar
-FIRRTL_TEST_JAR ?= $(chipyard_dir)/test_lib/firrtl.jar
-
 firrtl_srcs := $(shell find $(FIRRTL_SUBMODULE_DIR) -iname "[!.]*.scala")
 
 $(FIRRTL_JAR): $(firrtl_srcs)

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -34,6 +34,19 @@ base_dir := $(firesim_base_dir)
 chipyard_dir := $(abspath ..)/target-design/chipyard
 rocketchip_dir := $(chipyard_dir)/generators/rocket-chip
 
+else
+# Chipyard make variables
+base_dir := $(abspath ../../..)
+sim_dir := $(firesim_base_dir)
+chipyard_dir := $(base_dir)
+include $(base_dir)/variables.mk
+endif
+
+# Include target-specific sources and input generation recipes
+include $(TARGET_PROJECT_MAKEFRAG)
+
+ifdef FIRESIM_STANDALONE
+
 # Scala invocation options
 JVM_MEMORY ?= 16G
 SCALA_VERSION ?= 2.12.10
@@ -98,16 +111,9 @@ firrtl: $(FIRRTL_JAR)
 .PHONY: firrtl
 
 else
-# Chipyard make variables
-base_dir := $(abspath ../../..)
-sim_dir := $(firesim_base_dir)
-chipyard_dir := $(base_dir)
-include $(base_dir)/variables.mk
+# Chipyard make targets
 include $(base_dir)/common.mk
 endif
-
-# Include target-specific sources and input generation recipes
-include $(TARGET_PROJECT_MAKEFRAG)
 
 verilog: $(VERILOG)
 compile: $(VERILOG)

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -40,6 +40,8 @@ base_dir := $(abspath ../../..)
 sim_dir := $(firesim_base_dir)
 chipyard_dir := $(base_dir)
 include $(base_dir)/variables.mk
+# target-agnostic.mk wants lower-case rocketchip_dir but CY defines it upper-case
+rocketchip_dir := $(ROCKETCHIP_DIR)
 endif
 
 # Include target-specific sources and input generation recipes

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -30,22 +30,25 @@ VERILOG := $(GENERATED_DIR)/FPGATop.v
 HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
 
 ifdef FIRESIM_STANDALONE
-	firesim_sbt_project := {file:${chipyard_dir}}firechip
+	firesim_sbt_project ?= {file:${chipyard_dir}}firechip
 
 	lookup_scala_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "[!.]*.scala" -print 2> /dev/null)
-	SOURCE_DIRS = $(chipyard_dir)/generators $(firesim_base_dir)
-	SCALA_SOURCES = $(call lookup_scala_srcs,$(SOURCE_DIRS))
+	SOURCE_DIRS ?= $(chipyard_dir)/generators $(firesim_base_dir)
+	SCALA_SOURCES ?= $(call lookup_scala_srcs,$(SOURCE_DIRS))
 else
-	firesim_sbt_project := firechip
+	firesim_sbt_project ?= firechip
 endif
 
 $(FIRRTL_FILE) $(ANNO_FILE): $(SCALA_SOURCES) $(FIRRTL_JAR) $(SCALA_BUILDTOOL_DEPS)
 	mkdir -p $(@D)
-	$(call run_scala_main,$(firesim_sbt_project),chipyard.Generator,\
+	$(call run_scala_main,$(firesim_sbt_project),$(GENERATOR_NAME),$(GENERATOR_ARGS))
+
+GENERATOR_NAME ?= chipyard.Generator
+GENERATOR_ARGS ?= \
 		--target-dir $(GENERATED_DIR) \
 		--name $(long_name) \
 		--top-module $(DESIGN_PACKAGE).$(DESIGN) \
-		--legacy-configs $(TARGET_CONFIG_PACKAGE).$(TARGET_CONFIG))
+		--legacy-configs $(TARGET_CONFIG_PACKAGE).$(TARGET_CONFIG)
 
 # DOC include start: Bridge Build System Changes
 ##########################

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -237,7 +237,6 @@ xsim: $(xsim)
 #########################
 UNITTEST_CONFIG ?= AllUnitTests
 
-rocketchip_dir := $(chipyard_dir)/generators/rocket-chip
 unittest_generated_dir := $(base_dir)/generated-src/unittests/$(UNITTEST_CONFIG)
 unittest_args = \
 		BASE_DIR=$(base_dir) \


### PR DESCRIPTION
These are changes I needed while writing my TARGET_PROJECT_MAKEFRAG that is sourced
by `sim/Makefile` and in turn sources `sim/src/main/makefrag/firesim/Makefrag`