### PR TITLE
UARTBridge: Obtain baud rate from UARTParams

### DIFF
--- a/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala
@@ -45,7 +45,7 @@ class UARTBridge(uParams: UARTParams)(implicit p: Parameters) extends BlackBox
 
   // Do some intermediate work to compute our host-side BridgeModule's constructor argument
   val frequency = p(PeripheryBusKey).dtsFrequency.get
-  val baudrate = 3686400L
+  val baudrate = uParams.initBaudRate
   val div = (frequency / baudrate).toInt
 
   // And then implement the constructorArg member


### PR DESCRIPTION
Ensure that the UART device and bridge pair agree on the same baud rate.

This depends on ucb-bar/chipyard#625 for the sifive-blocks bump.