### PR TITLE
[ILA] Also ensure ILATopWiring runs before any optimizations

### DIFF
--- a/sim/firesim-lib/src/main/scala/passes/ILATopWiring.scala
+++ b/sim/firesim-lib/src/main/scala/passes/ILATopWiring.scala
@@ -133,7 +133,7 @@ class ILATopWiringTransform extends Transform with DependencyAPIMigration {
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   // We want this pass to run before any emitters
-  override def optionalPrerequisiteOf = Forms.HighEmitters
+  override def optionalPrerequisiteOf = Forms.HighEmitters ++ Forms.LowFormOptimized.filterNot(Forms.LowForm.contains)
 
   override def invalidates(a: Transform): Boolean = a match {
     case InferTypes | ResolveKinds | ResolveFlows | ExpandConnects => true


### PR DESCRIPTION
Turns out running before any emitter is not a sufficient prerequisite. This pass was being scheduled to run after the optimizations and as a result certain expressions in the output verilog were not being padded to the correct width, leading to verilator croaking about truncation issues.

I'm not convinced this is a complete fix but the resulting transform order now should match was it was pre firrtl 1.3. 
