### PR TITLE
Mergify-based Automatic Backporting Support

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,19 @@
+pull_request_rules:
+  - name: backport to master
+    conditions:
+      - merged
+      - base=dev
+      - label="please backport"
+    actions:
+      backport:
+        branches:
+          - master
+        ignore_conflicts: True
+        label_conflicts: "bp-conflict"
+
+  - name: label Mergify backport PR
+    conditions:
+      - body~=This is an automated backport of pull request \#\d+ done by Mergify
+    actions:
+      label:
+        add: [backported]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,17 +3,19 @@ pull_request_rules:
     conditions:
       - merged
       - base=dev
-      - label="please backport"
+      - label="Please Backport"
     actions:
       backport:
         branches:
           - master
         ignore_conflicts: True
         label_conflicts: "bp-conflict"
+      label:
+        add: [Backported]
 
   - name: label Mergify backport PR
     conditions:
       - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:
-        add: [backported]
+        add: [Backport]


### PR DESCRIPTION
PRs made to dev can be labeled with "please backport", and Mergify will create a new PR against master. Developers will still need manually regenerate AGFIs (if necessary) and merge the backport PR. 

This was shamelessly ripped from the FIRRTL repo. 