### PR TITLE
Fix Address Space Offset Generation Under Small Host Address Spaces

### DIFF
--- a/sim/midas/src/main/scala/midas/widgets/AXI4AddressTranslation.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AXI4AddressTranslation.scala
@@ -20,6 +20,12 @@ class AXI4AddressTranslation(offset: BigInt, bridgeAddressSets: Seq[AddressSet],
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       val maxHostAddr = BigInt(1) << out.ar.bits.params.addrBits
       out <> in
+      // Adjust the target address to the correct host memory location. offset
+      // may be negative (when the target address space itself is
+      // offset; typically to 2 GiB in rocket-chip targets), so adding
+      // maxHostAddr produces a non-negative UInt literal.  Additionally, offset
+      // may be larger than the total available memory space (ex. if the host
+      // has less than < 2 GiB of host DRAM), hence %.
       out.aw.bits.addr := in.aw.bits.addr + (maxHostAddr + (offset % maxHostAddr)).U
       out.ar.bits.addr := in.ar.bits.addr + (maxHostAddr + (offset % maxHostAddr)).U
       assert(~in.aw.valid || in.aw.bits.addr <= virtualBound.U, s"AW request address in memory region ${regionName} exceeds region bound.")

--- a/sim/midas/src/main/scala/midas/widgets/AXI4AddressTranslation.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AXI4AddressTranslation.scala
@@ -18,9 +18,10 @@ class AXI4AddressTranslation(offset: BigInt, bridgeAddressSets: Seq[AddressSet],
   val virtualBound = bridgeAddressSets.map(_.max).max
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      val maxHostAddr = BigInt(1) << out.ar.bits.params.addrBits
       out <> in
-      out.aw.bits.addr := in.aw.bits.addr + ((BigInt(1) << out.aw.bits.addr.getWidth) + offset).U
-      out.ar.bits.addr := in.ar.bits.addr + ((BigInt(1) << out.ar.bits.addr.getWidth) + offset).U
+      out.aw.bits.addr := in.aw.bits.addr + (maxHostAddr + (offset % maxHostAddr)).U
+      out.ar.bits.addr := in.ar.bits.addr + (maxHostAddr + (offset % maxHostAddr)).U
       assert(~in.aw.valid || in.aw.bits.addr <= virtualBound.U, s"AW request address in memory region ${regionName} exceeds region bound.")
       assert(~in.ar.valid || in.ar.bits.addr <= virtualBound.U, s"AR request address in memory region ${regionName} exceeds region bound.")
       assert(~in.aw.valid || in.aw.bits.addr >= virtualBase.U,  s"AW request address in memory region ${regionName} is less than region base.")


### PR DESCRIPTION
This manifests when you try to generate a system for a host whose AS size is less than the offset of 0x8000_0000, as it tries to create a UInt literal from a negative integer. Yes, I could've used an SInt.