### PR TITLE
Make peek/poke tests more reliable for testing Golden Gate simulators

### DIFF
--- a/sim/midas/src/main/verilog/vcs_top.v
+++ b/sim/midas/src/main/verilog/vcs_top.v
@@ -422,6 +422,8 @@ module emul;
   reg  [1:0]                 mem_3_b_resp;
   reg  [`MEM_ID_BITS-1:0]    mem_3_b_id;
 
+  wire                       reset_delay;
+
   wire                       ctrl_ar_valid_delay;
   wire                       ctrl_ar_ready_delay;
   wire [`CTRL_ADDR_BITS-1:0] ctrl_ar_addr_delay;
@@ -806,6 +808,8 @@ module emul;
   assign #0.1 mem_3_b_resp_delay = mem_3_b_resp;
   assign #0.1 mem_3_b_id_delay = mem_3_b_id;
 
+  assign #0.1 reset_delay = reset;
+
   FPGATop FPGATop(
 
     .ctrl_ar_valid(ctrl_ar_valid_delay),
@@ -1004,7 +1008,7 @@ module emul;
     .mem_3_b_bits_id(mem_3_b_id_delay),
 `endif
     .clock(clock),
-    .reset(reset)
+    .reset(reset_delay)
   );
 
   always @(posedge clock) begin

--- a/sim/src/main/cc/fasedtests/test_harness_bridge.cc
+++ b/sim/src/main/cc/fasedtests/test_harness_bridge.cc
@@ -24,7 +24,7 @@ test_harness_bridge_t::test_harness_bridge_t(
 // it then reads uarch event counts from the FASED instance and compares them against
 // expected values
 void test_harness_bridge_t::tick(){
-  this->done = sim->peek(done, false); // use a non-blocking peek since this signal is monotonic
+  this->done = sim->sample_value(done); // use a non-blocking sample since this signal is monotonic
   if(done) {
     this->error = 0;
     // Iterate through all uarch values we want to validate

--- a/sim/src/main/cc/fasedtests/test_harness_bridge.cc
+++ b/sim/src/main/cc/fasedtests/test_harness_bridge.cc
@@ -24,7 +24,7 @@ test_harness_bridge_t::test_harness_bridge_t(
 // it then reads uarch event counts from the FASED instance and compares them against
 // expected values
 void test_harness_bridge_t::tick(){
-  this->done = sim->peek(done);
+  this->done = sim->peek(done, false); // use a non-blocking peek since this signal is monotonic
   if(done) {
     this->error = 0;
     // Iterate through all uarch values we want to validate


### PR DESCRIPTION
This fixes a few outstanding issues:
- Ensures that the tokens for the current cycle have arrived for all outputs before executing an `expect`
- Adds a pound delay to reset across the DPI boundary in VCS. This makes host reset deassertion behave more sensibly.

There still is the question of whether to add this constraint to peeks. I think a case could be made either way. Regardless, it's still possible to write peek/poke tests that have a broken underlying model of how test stimuli propagate, since the peek/poke bridge has different semantics from peek/poke Chisel tests, which let you do multiple combinationally propagated pokes per input per cycle.