### PR TITLE
Add unit tests for Golden-Gate-optimized simulators

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
@@ -88,6 +88,7 @@ private[midas] class MidasTransforms extends Transform {
       new EmitFirrtl("post-fame-transform.fir"),
       new fame.EmitFAMEAnnotations("post-fame-transform.json"),
       new ResolveAndCheck,
+      fame.MultiThreadFAME5Models,
       new ResolveAndCheck,
       new fame.EmitAndWrapRAMModels,
       new EmitFirrtl("post-gen-sram-models.fir"),

--- a/sim/src/main/cc/midasexamples/Driver.cc
+++ b/sim/src/main/cc/midasexamples/Driver.cc
@@ -63,6 +63,8 @@
 #include "MultiRegfile.h"
 #elif defined DESIGNNAME_NestedModels
 #include "NestedModels.h"
+#elif defined DESIGNNAME_MultiReg
+#include "MultiReg.h"
 #endif
 
 class dut_emul_t:

--- a/sim/src/main/cc/midasexamples/Driver.cc
+++ b/sim/src/main/cc/midasexamples/Driver.cc
@@ -57,6 +57,12 @@
 #include "TriggerWiringModule.h"
 #elif defined DESIGNNAME_TwoAdders
 #include "TwoAdders.h"
+#elif defined DESIGNNAME_Regfile
+#include "Regfile.h"
+#elif defined DESIGNNAME_MultiRegfile
+#include "MultiRegfile.h"
+#elif defined DESIGNNAME_NestedModels
+#include "NestedModels.h"
 #endif
 
 class dut_emul_t:

--- a/sim/src/main/cc/midasexamples/MultiReg.h
+++ b/sim/src/main/cc/midasexamples/MultiReg.h
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+#include "simif.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <utility>
+#include <map>
+
+constexpr size_t multireg_n_copies = 4;
+
+const size_t multireg_input_ios[multireg_n_copies] =
+  { io_pipeIOs_0_i,
+    io_pipeIOs_1_i,
+    io_pipeIOs_2_i,
+    io_pipeIOs_3_i  };
+
+const size_t multireg_output_ios[multireg_n_copies] =
+  { io_pipeIOs_0_o,
+    io_pipeIOs_1_o,
+    io_pipeIOs_2_o,
+    io_pipeIOs_3_o  };
+
+uint32_t inputs[] = { 45, 9, 11, 13, 99, 2, 8, 15, 16, 12, 1 };
+
+class MultiReg_t: virtual simif_t
+{
+public:
+  MultiReg_t(int argc, char** argv) {}
+
+  void run() {
+    target_reset();
+    for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); i++) {
+      for (int j = 0; j < multireg_n_copies; j++) {
+        poke(multireg_input_ios[j], inputs[i] + j);
+        if (i > 0)
+          expect(multireg_output_ios[j], inputs[i-1] + j);
+        step(1);
+      }
+    }
+  }
+};

--- a/sim/src/main/cc/midasexamples/MultiRegfile.h
+++ b/sim/src/main/cc/midasexamples/MultiRegfile.h
@@ -1,0 +1,101 @@
+// See LICENSE for license details.
+
+#include "simif.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <utility>
+#include <map>
+
+constexpr size_t multireg_n_copies = 4;
+constexpr size_t multireg_n_reads = 2;
+constexpr size_t multireg_n_writes = 2;
+
+const size_t multireg_w_addr_ios[multireg_n_copies][multireg_n_writes] =
+  { { io_accesses_0_writes_0_addr, io_accesses_0_writes_1_addr },
+    { io_accesses_1_writes_0_addr, io_accesses_1_writes_1_addr },
+    { io_accesses_2_writes_0_addr, io_accesses_2_writes_1_addr },
+    { io_accesses_3_writes_0_addr, io_accesses_3_writes_1_addr } };
+
+const size_t multireg_w_data_ios[multireg_n_copies][multireg_n_writes] =
+  { { io_accesses_0_writes_0_data, io_accesses_0_writes_1_data },
+    { io_accesses_1_writes_0_data, io_accesses_1_writes_1_data },
+    { io_accesses_2_writes_0_data, io_accesses_2_writes_1_data },
+    { io_accesses_3_writes_0_data, io_accesses_3_writes_1_data } };
+
+const size_t multireg_w_en_ios[multireg_n_copies][multireg_n_writes] =
+  { { io_accesses_0_writes_0_en, io_accesses_0_writes_1_en },
+    { io_accesses_1_writes_0_en, io_accesses_1_writes_1_en },
+    { io_accesses_2_writes_0_en, io_accesses_2_writes_1_en },
+    { io_accesses_3_writes_0_en, io_accesses_3_writes_1_en } };
+
+const size_t multireg_r_addr_ios[multireg_n_copies][multireg_n_reads] =
+  { { io_accesses_0_reads_0_addr, io_accesses_0_reads_1_addr },
+    { io_accesses_1_reads_0_addr, io_accesses_1_reads_1_addr },
+    { io_accesses_2_reads_0_addr, io_accesses_2_reads_1_addr },
+    { io_accesses_3_reads_0_addr, io_accesses_3_reads_1_addr } };
+
+const size_t multireg_r_data_ios[multireg_n_copies][multireg_n_reads] =
+  { { io_accesses_0_reads_0_data, io_accesses_0_reads_1_data },
+    { io_accesses_1_reads_0_data, io_accesses_1_reads_1_data },
+    { io_accesses_2_reads_0_data, io_accesses_2_reads_1_data },
+    { io_accesses_3_reads_0_data, io_accesses_3_reads_1_data } };
+
+class MultiRegfile_t: virtual simif_t
+{
+public:
+
+  MultiRegfile_t(int argc, char** argv) {}
+
+  void run() {
+    target_reset();
+    for (size_t cycle = 0; cycle < 100; cycle++) {
+      do_iteration(cycle);
+    }
+  }
+
+private:
+
+  size_t mem_depth = 10;
+
+  void do_iteration(size_t cycle_num) {
+    for (size_t i = 0; i < multireg_n_copies; i++) {
+      for (size_t w_idx = 0; w_idx < multireg_n_writes; w_idx++) {
+        if (rand() % 2) {
+          data_t rand_data = rand();
+          data_t rand_addr = rand() % mem_depth;
+          auto mem_slot = std::make_pair(i, rand_addr);
+          while (history.count(mem_slot) && history[mem_slot].second == cycle_num) {
+            // already written this cycle => would be undefined write collision
+            mem_slot.second = rand() % mem_depth;
+          }
+          history[mem_slot] = std::make_pair(rand_data, cycle_num);
+          poke(multireg_w_addr_ios[i][w_idx], mem_slot.second);
+          poke(multireg_w_data_ios[i][w_idx], rand_data);
+          poke(multireg_w_en_ios[i][w_idx], 1);
+        } else {
+          poke(multireg_w_en_ios[i][w_idx], 0);
+        }
+      }
+      for (size_t r_idx = 0; r_idx < multireg_n_reads; r_idx++) {
+        data_t rand_addr = rand() % mem_depth;
+        prev_reads[std::make_pair(i, r_idx)] = rand_addr;
+        poke(multireg_r_addr_ios[i][r_idx], rand_addr);
+      }
+    }
+    step(1);
+    for (size_t i = 0; i < multireg_n_copies; i++) {
+      for (size_t r_idx = 0; r_idx < multireg_n_reads; r_idx++) {
+        data_t prev_addr = prev_reads[std::make_pair(i, r_idx)];
+        auto mem_slot = std::make_pair(i, prev_addr);
+        if (history.count(mem_slot)) {
+          expect(multireg_r_data_ios[i][r_idx], history[mem_slot].first);
+        }
+      }
+    }
+  }
+
+  std::map< std::pair<size_t, data_t>, std::pair<data_t, size_t> > history;
+  std::map< std::pair<size_t, size_t>, data_t > prev_reads;
+};

--- a/sim/src/main/cc/midasexamples/NestedModels.h
+++ b/sim/src/main/cc/midasexamples/NestedModels.h
@@ -1,0 +1,38 @@
+//See LICENSE for license details.
+
+#include "simif.h"
+#include "stdio.h"
+
+uint32_t i0[] = { 4, 8, 7, 3, 2, 0, 4, 9, 11, 3, 7, 2, 5, 2, 7, 8 };
+uint32_t i1[] = { 9, 1, 2, 6, 5, 3, 5, 2,  1, 7, 6, 5, 4, 3, 2, 1 };
+
+class NestedModels_t: virtual simif_t
+{
+public:
+  NestedModels_t(int argc, char** argv) {}
+  int ntests = sizeof(i0) / sizeof(i0[0]);
+  int latency = 3;
+  void run() {
+    int i;
+    target_reset();
+    for (int i = 0; i < latency; i++) {
+      poke(io_a_i0, i0[i]);
+      poke(io_a_i1, i1[i]);
+      poke(io_b_i0, i1[i]);
+      poke(io_b_i1, i0[i]);
+      step(1);
+    }
+    for (i = 0; i < ntests; i++) {
+      expect(io_a_o0, i0[i] + 1);
+      expect(io_a_o1, i1[i] + 1);
+      expect(io_b_o0, i1[i] + 1);
+      expect(io_b_o1, i0[i] + 1);
+      poke(io_a_i0, (i >= ntests-latency) ? 0 : i0[i+latency]);
+      poke(io_a_i1, (i >= ntests-latency) ? 0 : i1[i+latency]);
+      poke(io_b_i0, (i >= ntests-latency) ? 0 : i1[i+latency]);
+      poke(io_b_i1, (i >= ntests-latency) ? 0 : i0[i+latency]);
+      step(1);
+     }
+    step(10);
+  }
+};

--- a/sim/src/main/cc/midasexamples/Regfile.h
+++ b/sim/src/main/cc/midasexamples/Regfile.h
@@ -1,0 +1,72 @@
+// See LICENSE for license details.
+
+#include "simif.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <utility>
+#include <map>
+
+constexpr size_t reg_n_reads = 2;
+constexpr size_t reg_n_writes = 2;
+
+const size_t reg_w_addr_ios[reg_n_writes] = { io_writes_0_addr, io_writes_1_addr };
+const size_t reg_w_data_ios[reg_n_writes] = { io_writes_0_data, io_writes_1_data };
+const size_t reg_w_en_ios[reg_n_writes] = { io_writes_0_en, io_writes_1_en };
+
+const size_t reg_r_addr_ios[reg_n_reads] = { io_reads_0_addr, io_reads_1_addr };
+const size_t reg_r_data_ios[reg_n_reads] = { io_reads_0_data, io_reads_1_data };
+
+struct Regfile_t: virtual simif_t
+{
+
+  Regfile_t(int argc, char** argv) {}
+
+  void run() {
+    target_reset();
+    for (size_t cycle = 0; cycle < 100; cycle++) {
+      do_iteration(cycle);
+    }
+  }
+
+private:
+
+  size_t mem_depth = 10;
+
+  void do_iteration(size_t cycle_num) {
+    for (size_t w_idx = 0; w_idx < reg_n_writes; w_idx++) {
+      if (rand() % 2) {
+        data_t rand_data = rand();
+        data_t rand_addr = rand() % mem_depth;
+        while (history.count(rand_addr) && history[rand_addr].second == cycle_num) {
+          // already written this cycle => would be undefined write collision
+          rand_addr = rand() % mem_depth;
+        }
+        history[rand_addr] = std::make_pair(rand_data, cycle_num);
+        poke(reg_w_addr_ios[w_idx], rand_addr);
+        poke(reg_w_data_ios[w_idx], rand_data);
+        poke(reg_w_en_ios[w_idx], 1);
+      } else {
+        poke(reg_w_en_ios[w_idx], 0);
+      }
+    }
+    for (size_t r_idx = 0; r_idx < reg_n_reads; r_idx++) {
+      data_t rand_addr = rand() % mem_depth;
+      prev_reads[r_idx] = rand_addr;
+      poke(reg_r_addr_ios[r_idx], rand_addr);
+    }
+    step(1);
+    for (size_t r_idx = 0; r_idx < reg_n_reads; r_idx++) {
+      data_t prev_addr = prev_reads[r_idx];
+      if (history.count(prev_addr)) {
+        expect(reg_r_data_ios[r_idx], history[prev_addr].first);
+      }
+    }
+  }
+
+ private:
+
+  std::map< data_t, std::pair<data_t, size_t> > history;
+  std::map< size_t, data_t > prev_reads;
+};

--- a/sim/src/main/scala/midasexamples/MultiReg.scala
+++ b/sim/src/main/scala/midasexamples/MultiReg.scala
@@ -1,0 +1,37 @@
+// See LICENSE for license details
+
+package firesim.midasexamples
+
+import chisel3._
+import chisel3.experimental.annotate
+
+import freechips.rocketchip.config.Parameters
+
+import midas.widgets.PeekPokeBridge
+import midas.targetutils._
+
+class PipeIO extends Bundle {
+  val i = Input(UInt(32.W))
+  val o = Output(UInt(32.W))
+}
+
+class RegPipe extends Module {
+  val io = IO(new PipeIO)
+  io.o := RegNext(io.i)
+}
+
+class MultiRegDUT extends Module {
+  val nCopies = 4
+  val io = IO(new Bundle {
+    val pipeIOs = Vec(nCopies, new PipeIO)
+  })
+  val pipes = Seq.fill(nCopies)(Module(new RegPipe))
+  (io.pipeIOs zip pipes).foreach {
+    case (pio, p) =>
+      p.io <> pio
+      annotate(FAMEModelAnnotation(p))
+      annotate(EnableModelMultiThreadingAnnotation(p))
+  }
+}
+
+class MultiReg(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiRegDUT)

--- a/sim/src/main/scala/midasexamples/MultiRegfile.scala
+++ b/sim/src/main/scala/midasexamples/MultiRegfile.scala
@@ -1,0 +1,39 @@
+// See LICENSE for license details
+
+package firesim.midasexamples
+
+import chisel3._
+import chisel3.experimental.annotate
+
+import freechips.rocketchip.config.Parameters
+
+import midas.widgets.PeekPokeBridge
+import midas.targetutils._
+
+class RegfileInner extends Module {
+  val io = IO(new RegfileIO)
+  val mem = Mem(1024, UInt(64.W))
+  annotate(MemModelAnnotation(mem))
+  io.reads.foreach {
+    rp => rp.data := mem.read(RegNext(rp.addr))
+  }
+  io.writes.foreach {
+    wp => when (wp.en) { mem.write(wp.addr, wp.data) }
+  }
+}
+
+class MultiRegfileDUT extends Module {
+  val nCopies = 4
+  val io = IO(new Bundle {
+    val accesses = Vec(nCopies, new RegfileIO)
+  })
+  val rfs = Seq.fill(nCopies)(Module(new RegfileInner))
+  rfs.zip(io.accesses).foreach {
+    case (rf, rfio) =>
+      rf.io <> rfio
+      annotate(FAMEModelAnnotation(rf))
+      annotate(EnableModelMultiThreadingAnnotation(rf))
+  }
+}
+
+class MultiRegfile(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiRegfileDUT)

--- a/sim/src/main/scala/midasexamples/NestedModels.scala
+++ b/sim/src/main/scala/midasexamples/NestedModels.scala
@@ -1,0 +1,51 @@
+// See LICENSE for license details
+
+package firesim.midasexamples
+
+import chisel3._
+import chisel3.experimental.annotate
+
+import freechips.rocketchip.config.Parameters
+
+import midas.widgets.PeekPokeBridge
+import midas.targetutils._
+
+class SimpleIO extends Bundle {
+  val i0 = Input(UInt(4.W))
+  val i1 = Input(UInt(4.W))
+  val o0 = Output(UInt(4.W))
+  val o1 = Output(UInt(4.W))
+}
+
+class Inner extends Module {
+  val io = IO(new SimpleIO)
+  io.o0 := RegNext(io.i0 + 1.U)
+  io.o1 := RegNext(RegNext(io.i1 + 1.U))
+}
+
+class Mid extends Module {
+  val io = IO(new SimpleIO)
+  val inner = Module(new Inner)
+  annotate(FAMEModelAnnotation(inner))
+  inner.io.i0 := RegNext(RegNext(io.i0))
+  inner.io.i1 := RegNext(io.i1)
+  io.o0 := inner.io.o0
+  io.o1 := inner.io.o1
+}
+
+class NestedModelsDUT extends Module {
+  val io = IO(new Bundle {
+    val a = new SimpleIO
+    val b = new SimpleIO
+  })
+  val midA = Module(new Mid)
+  val midB = Module(new Mid)
+  annotate(FAMEModelAnnotation(midA))
+  annotate(FAMEModelAnnotation(midB))
+  annotate(EnableModelMultiThreadingAnnotation(midA))
+  annotate(EnableModelMultiThreadingAnnotation(midB))
+  midA.io <> io.a
+  midB.io <> io.b
+}
+
+class NestedModels(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new NestedModelsDUT)

--- a/sim/src/main/scala/midasexamples/Regfile.scala
+++ b/sim/src/main/scala/midasexamples/Regfile.scala
@@ -1,0 +1,41 @@
+// See LICENSE for license details
+
+package firesim.midasexamples
+
+import chisel3._
+import chisel3.experimental.annotate
+
+import freechips.rocketchip.config.Parameters
+
+import midas.widgets.PeekPokeBridge
+import midas.targetutils._
+
+class RegfileRead extends Bundle {
+  val addr = Input(UInt(5.W))
+  val data = Output(UInt(64.W))
+}
+
+class RegfileWrite extends Bundle {
+  val addr = Input(UInt(5.W))
+  val data = Input(UInt(64.W))
+  val en = Input(Bool())
+}
+
+class RegfileIO extends Bundle {
+  val reads = Vec(2, new RegfileRead)
+  val writes = Vec(2, new RegfileWrite)
+}
+
+class RegfileDUT extends Module {
+  val io = IO(new RegfileIO)
+  val mem = Mem(1024, UInt(64.W))
+  annotate(MemModelAnnotation(mem))
+  io.reads.foreach {
+    rp => rp.data := mem.read(RegNext(rp.addr))
+  }
+  io.writes.foreach {
+    wp => when (wp.en) { mem.write(wp.addr, wp.data) }
+  }
+}
+
+class Regfile(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new RegfileDUT)

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -178,6 +178,8 @@ class MultiRegfileF1Test extends TutorialSuite("MultiRegfile")
 
 class NestedModelsF1Test extends TutorialSuite("NestedModels")
 
+class MultiRegF1Test extends TutorialSuite("MultiReg")
+
 // Suite Collections
 class ChiselExampleDesigns extends Suites(
   new GCDF1Test,

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -172,6 +172,12 @@ class MulticlockAutoCounterF1Test extends TutorialSuite("MulticlockAutoCounterMo
 // Basic test for deduplicated extracted models
 class TwoAddersF1Test extends TutorialSuite("TwoAdders")
 
+class RegfileF1Test extends TutorialSuite("Regfile")
+
+class MultiRegfileF1Test extends TutorialSuite("MultiRegfile")
+
+class NestedModelsF1Test extends TutorialSuite("NestedModels")
+
 // Suite Collections
 class ChiselExampleDesigns extends Suites(
   new GCDF1Test,

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -214,7 +214,11 @@ class GoldenGateMiscCITests extends Suites(
   new TwoAddersF1Test,
   new TriggerWiringModuleF1Test,
   new WireInterconnectF1Test,
-  new TrivialMulticlockF1Test
+  new TrivialMulticlockF1Test,
+  new RegfileF1Test,
+  new MultiRegfileF1Test,
+  new NestedModelsF1Test,
+  new MultiRegF1Test
 )
 
 // Each group runs on a single worker instance


### PR DESCRIPTION
This PR adds four unit tests for Golden Gate optimizations, including model multi-threading. In order to support these tests, the multi-threading pass is added to `MidasTransforms`, but it will function as an identity transform unless the appropriate annotations are added.