### PR TITLE
Make memory loading compatible with new testchipip API

### DIFF
--- a/sim/midas/src/main/cc/emul/mmio.cc
+++ b/sim/midas/src/main/cc/emul/mmio.cc
@@ -90,13 +90,16 @@ extern std::unique_ptr<mmio_t> master;
 extern std::unique_ptr<mmio_t> dma;
 std::unique_ptr<mm_t> slave[MEM_NUM_CHANNELS];
 
-void* init(uint64_t memsize, bool dramsim) {
+void init(uint64_t memsize, bool dramsim) {
   master.reset(new mmio_t(CTRL_BEAT_BYTES));
   dma.reset(new mmio_t(DMA_BEAT_BYTES));
   for (int mem_channel_index=0; mem_channel_index < MEM_NUM_CHANNELS; mem_channel_index++) {
     slave[mem_channel_index].reset(dramsim ? (mm_t*) new mm_dramsim2_t(1 << MEM_ID_BITS) : (mm_t*) new mm_magic_t);
     slave[mem_channel_index]->init(memsize, MEM_BEAT_BYTES, 64);
   }
-  return slave[0]->get_data();
 }
 
+void load_mems(const char *fname) {
+  for (int i = 0; i < MEM_NUM_CHANNELS; i++)
+    slave[i]->load_mem(0, fname);
+}

--- a/sim/midas/src/main/cc/emul/mmio.cc
+++ b/sim/midas/src/main/cc/emul/mmio.cc
@@ -100,6 +100,6 @@ void init(uint64_t memsize, bool dramsim) {
 }
 
 void load_mems(const char *fname) {
-  for (int i = 0; i < MEM_NUM_CHANNELS; i++)
-    slave[i]->load_mem(0, fname);
+  slave[0]->load_mem(0, fname);
+  // TODO: allow file to be split across slaves
 }

--- a/sim/midas/src/main/cc/emul/mmio.h
+++ b/sim/midas/src/main/cc/emul/mmio.h
@@ -98,6 +98,7 @@ private:
   bool write_inflight;
   std::vector<char> dummy_data;
 };
-void* init(uint64_t memsize, bool dram);
+void init(uint64_t memsize, bool dram);
+void load_mems(const char *fname);
 
 #endif // __MMIO_H

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -79,11 +79,10 @@ void simif_emul_t::init(int argc, char** argv, bool log) {
     }
   }
 
-  void* mems[1];
-  mems[0] = ::init(memsize, dramsim);
-  if (mems[0] && fastloadmem && !loadmem.empty()) {
+  ::init(memsize, dramsim);
+  if (fastloadmem && !loadmem.empty()) {
     fprintf(stdout, "[fast loadmem] %s\n", loadmem.c_str());
-    ::load_mem(mems, loadmem.c_str(), MEM_DATA_BITS / 8, 1);
+    ::load_mems(loadmem.c_str());
   }
 
   signal(SIGTERM, handle_sigterm);


### PR DESCRIPTION
I changed the way loadmem works in testchipip with this PR. 

https://github.com/ucb-bar/testchipip/pull/94

So this changes firesim to be compatible. As a helpful side-effect, it also allows firesim software sim to properly simulate multiple host channels.