### PR TITLE
[docs] Update config_runtime.ini example with profileinterval setting

### DIFF
--- a/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
@@ -90,6 +90,7 @@ to change a few items in this section:
     linklatency=6405
     switchinglatency=10
     netbandwidth=200
+    profileinterval=-1
 
     # This references a section from config_hwconfigs.ini
     # In homogeneous configurations, use this to set the hardware config deployed
@@ -137,6 +138,7 @@ As a final sanity check, your ``config_runtime.ini`` file should now look like t
 	linklatency=6405
 	switchinglatency=10
 	netbandwidth=200
+    profileinterval=-1
 
 	# This references a section from config_hwconfigs.ini
 	# In homogeneous configurations, use this to set the hardware config deployed


### PR DESCRIPTION
The example `config_runtime.ini` that's included inline in the single-node docs is currently broken. This fixes that.