### PR TITLE
ILADepth override needs to be left-of BaseF1Config

### DIFF
--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
@@ -53,7 +53,7 @@ Below is an example `PLATFORM_CONFIG` that can be used in the `build_recipes` co
 
 ::
    
-   PLATFORM_CONFIG=BaseF1Config_ILADepth8192
+   PLATFORM_CONFIG=ILADepth8192_BaseF1Config
 
 
 


### PR DESCRIPTION
There isn't something special about this, the override needs to be to the left of `BaseF1Config` correct?