### PR TITLE
Support for Mirroring Chipyard's Idealized PLL

### DIFF
--- a/deploy/runtools/user_topology.py
+++ b/deploy/runtools/user_topology.py
@@ -372,7 +372,7 @@ class UserTopologies(object):
         hwdb_entries = [
             "firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3",
             "firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3",
-            "firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3-half-freq-uncore",
+            "firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore",
         ]
         assert len(hwdb_entries) == self.no_net_num_nodes
         self.roots = [FireSimServerNode(hwdb_entries[x]) for x in range(self.no_net_num_nodes)]

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,32 +10,32 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0582543861de06f9c
+agfi=agfi-012bb49f458e29bf8
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0564f6f9a4b7e45cd
+agfi=agfi-0906b5e743ded7918
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0909e56f82c35b7d7
+agfi=agfi-04a29fa8a0ac59b2d
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-06807e6987b70ef22
+agfi=agfi-0fa2162c2c1a475d4
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
-agfi=agfi-09c3ce55b710f13a0
+agfi=agfi-036da5af24c4b81e0
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-0c1bbfe7a51831f4b
+agfi=agfi-07a863530eba38448
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/docs/Advanced-Usage/Generating-Different-Targets.rst
+++ b/docs/Advanced-Usage/Generating-Different-Targets.rst
@@ -70,8 +70,8 @@ Further documentation can be found in the source
 The Base Clock
 =================
 By convention, target time is specified in cycles of the `base clock`,
-which is defined to be the zeroth output clock of the ``RationalClockBridge``.
-While we suggest making the base clock the fastest clock in your system, as in any
+which is defined to be the clock of the ``RationalClockBridge`` whose clock ratio (multiplier / divisor)
+is one.  While we suggest making the base clock the fastest clock in your system, as in any
 microprocessor-based system it will likely correspond to your core clock
 frequency, this is not a constraint.
 

--- a/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
@@ -50,7 +50,7 @@ class TracerVBridge(insnWidths: TracedInstructionWidths, numInsns: Int) extends 
 object TracerVBridge {
   def apply(tracedInsns: TileTraceIO)(implicit p:Parameters): TracerVBridge = {
     val ep = Module(new TracerVBridge(tracedInsns.insnWidths, tracedInsns.numInsns))
-    ep.generateTriggerAnnotations
+    withClockAndReset(tracedInsns.clock, tracedInsns.reset) { ep.generateTriggerAnnotations }
     ep.io.trace := tracedInsns
     ep
   }

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -47,7 +47,6 @@ sealed trait ClockBridgeConsts {
   *
   * @param clocks The associated clock information for each output clock
   *
-  * @param clocks The name of the clock in the clocks parameter which will be used as the base
   */
 
 case class ClockBridgeAnnotation(val target: ModuleTarget, clocks: Seq[RationalClock])

--- a/sim/src/main/scala/fasedtests/AXI4Fuzzer.scala
+++ b/sim/src/main/scala/fasedtests/AXI4Fuzzer.scala
@@ -84,7 +84,7 @@ class AXI4FuzzerDUT(implicit p: Parameters) extends LazyModule with HasFuzzTarge
 
 class AXI4Fuzzer(implicit val p: Parameters) extends RawModule {
   val reset = WireInit(false.B)
-  val clockBridge = Module(new RationalClockBridge())
+  val clockBridge = RationalClockBridge()
   val clock = clockBridge.io.clocks(0)
   withClockAndReset(clock, reset) {
     val fuzzer = Module((LazyModule(new AXI4FuzzerDUT)).module)

--- a/sim/src/main/scala/midasexamples/AssertModule.scala
+++ b/sim/src/main/scala/midasexamples/AssertModule.scala
@@ -82,7 +82,7 @@ class StimulusGenerator extends MultiIOModule {
 
 
 class MulticlockAssertModule(implicit p: Parameters) extends RawModule {
-  val clockBridge = Module(new RationalClockBridge(RationalClock("HalfRate", 1, 2)))
+  val clockBridge = RationalClockBridge(RationalClock("HalfRate", 1, 2))
   val List(refClock, div2Clock) = clockBridge.io.clocks.toList
   val reset = WireInit(false.B)
   withClockAndReset(refClock, reset) {

--- a/sim/src/main/scala/midasexamples/AssertTorture.scala
+++ b/sim/src/main/scala/midasexamples/AssertTorture.scala
@@ -83,7 +83,7 @@ class AssertTortureModule(
 class AssertTorture(implicit p: Parameters) extends RawModule {
   val clockInfo = Seq.tabulate(p(AssertionClockCount))(i => RationalClock(s"By${i+1}", 1, i+1))
   // Drop the first clock because the RCB generates it implicitly
-  val clockBridge = Module(new RationalClockBridge((clockInfo.tail):_*))
+  val clockBridge = RationalClockBridge((clockInfo.tail):_*)
   val baseClock = clockBridge.io.clocks.head
   val reset = WireInit(false.B)
   withClockAndReset(baseClock, reset) {

--- a/sim/src/main/scala/midasexamples/MulticlockAutoCounterModule.scala
+++ b/sim/src/main/scala/midasexamples/MulticlockAutoCounterModule.scala
@@ -13,7 +13,7 @@ import midas.widgets.{RationalClockBridge, PeekPokeBridge, RationalClock}
 // from verilator/vcs and compare against the two files produced by
 // the bridges
 class MulticlockAutoCounterModule(implicit p: Parameters) extends RawModule {
-  val clockBridge = Module(new RationalClockBridge(RationalClock("ThirdRate", 1, 3)))
+  val clockBridge = RationalClockBridge(RationalClock("ThirdRate", 1, 3))
   val List(refClock, div2Clock) = clockBridge.io.clocks.toList
   val reset = WireInit(false.B)
   val resetHalfRate = ResetCatchAndSync(div2Clock, reset.toBool)

--- a/sim/src/main/scala/midasexamples/MulticlockPrintfModule.scala
+++ b/sim/src/main/scala/midasexamples/MulticlockPrintfModule.scala
@@ -13,7 +13,7 @@ import midas.widgets.{RationalClockBridge, PeekPokeBridge, RationalClock}
 // from verilator/vcs and compare against the two files produced by
 // the bridges
 class MulticlockPrintfModule(implicit p: Parameters) extends RawModule {
-  val clockBridge = Module(new RationalClockBridge(RationalClock("HalfRate",1 , 2)))
+  val clockBridge = RationalClockBridge(RationalClock("HalfRate",1 , 2))
   val List(refClock, div2Clock) = clockBridge.io.clocks.toList
   val reset = WireInit(false.B)
   val resetHalfRate = ResetCatchAndSync(div2Clock, reset.toBool)

--- a/sim/src/main/scala/midasexamples/TriggerWiringModule.scala
+++ b/sim/src/main/scala/midasexamples/TriggerWiringModule.scala
@@ -101,7 +101,7 @@ object ReferenceSourceCounters {
 // implement in FIRRTL. The test fails if the firrtl-generated trigger-enables,
 // as seen by all nodes with a trigger sink, fail to match their references.
 class TriggerWiringModule(implicit p: Parameters) extends RawModule {
-  val clockBridge = Module(new RationalClockBridge(RationalClock("HalfRate", 1, 2)))
+  val clockBridge = RationalClockBridge(RationalClock("HalfRate", 1, 2))
   val refClock :: div2Clock :: _ = clockBridge.io.clocks.toList
   val refSourceCounts = new mutable.ArrayBuffer[ReferenceSourceCounters]()
   val refSinks = new mutable.ArrayBuffer[Bool]()

--- a/sim/src/main/scala/midasexamples/TrivialMulticlock.scala
+++ b/sim/src/main/scala/midasexamples/TrivialMulticlock.scala
@@ -31,8 +31,8 @@ class TrivialMulticlock(implicit p: Parameters) extends RawModule {
   // clocks beyond the base clock are specified using the RationalClock case
   // class which gives the clock domain's name, and its clock multiplier and
   // divisor relative to the base clock.
-  val clockBridge = Module(new RationalClockBridge(RationalClock("HalfRate", 1, 2), 
-                                                   RationalClock("ThirdRate", 1, 3)))
+  val clockBridge = RationalClockBridge(RationalClock("HalfRate", 1, 2),
+                                        RationalClock("ThirdRate", 1, 3))
 
   // The clock bridge has a single output: a Vec[Clock] of the requested clocks
   // in the order they were specified, which we are now free to use through our

--- a/sim/src/main/scala/midasexamples/Util.scala
+++ b/sim/src/main/scala/midasexamples/Util.scala
@@ -11,7 +11,7 @@ import midas.widgets.{RationalClockBridge, PeekPokeBridge}
 // module DUT (it has a single io: Data member) and connects all of
 // its IO to a PeekPokeBridge
 class PeekPokeMidasExampleHarness(dutGen: () => Module) extends RawModule {
-  val clock = Module(new RationalClockBridge()).io.clocks.head
+  val clock = RationalClockBridge().io.clocks.head
   val reset = WireInit(false.B)
 
   withClockAndReset(clock, reset) {


### PR DESCRIPTION
See ucb-bar/chipyard#676

This no longer assumes the base clock is implicit when instantiating the ClockBridge. At least one clock must have a unity clock ratio --> that clock is assumed to be the base clock. (Previously, this unity-ratio clock was assumed to be the zeroth element of the clock vector). 

The old API has been pushed into a companion object. 