### PR TITLE
rm FpgaMMIOSize, instead enforce CtrlNastiKey.addrBits

### DIFF
--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -59,7 +59,6 @@ class SimConfig extends Config (new Config((site, here, up) => {
   case SynthAsserts     => false
   case SynthPrints      => false
   case DMANastiKey      => NastiParameters(512, 64, 6)
-  case FpgaMMIOSize     => BigInt(1) << 12 // 4 KB
   case AXIDebugPrint    => false
 
   // Remove once AXI4 port is complete

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -54,8 +54,6 @@ case class AXI4IdSpaceConstraint(idBits: Int = 4, maxFlight: Int = 8)
 // Legacy: the aggregate memory-space seen by masters wanting DRAM. Derived from HostMemChannelKey
 case object MemNastiKey extends Field[NastiParameters]
 
-case object FpgaMMIOSize extends Field[BigInt]
-
 class FPGATopIO(implicit val p: Parameters) extends WidgetIO {
   val dma  = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
 }
@@ -260,7 +258,7 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
     dmaPorts.zip(router.io.slaves).foreach { case (dma, slave) => dma <> NastiQueue(slave)(dmaParams) }
   }
 
-  outer.genCtrlIO(ctrl, p(FpgaMMIOSize))
+  outer.genCtrlIO(ctrl)
   outer.printHostDRAMSummary
 
   val addrConsts = dmaAddrMap.map {


### PR DESCRIPTION
Silent truncation of ctrl addresses is not needed.  Instead
add an assertion that ensures the design has not exceeded
the number of MMIO registers addressable on the ctrl bus.