### PR TITLE
Improve QoR when threading models with SyncReadMems

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
@@ -90,6 +90,7 @@ private[midas] class MidasTransforms extends Transform {
       new fame.EmitFAMEAnnotations("post-fame-transform.json"),
       new ResolveAndCheck,
       fame.MultiThreadFAME5Models,
+      fame.ImplementThreadedSyncReadMems,
       new ResolveAndCheck,
       new fame.EmitAndWrapRAMModels,
       new EmitFirrtl("post-gen-sram-models.fir"),

--- a/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
@@ -90,7 +90,6 @@ private[midas] class MidasTransforms extends Transform {
       new fame.EmitFAMEAnnotations("post-fame-transform.json"),
       new ResolveAndCheck,
       fame.MultiThreadFAME5Models,
-      fame.ImplementThreadedSyncReadMems,
       new ResolveAndCheck,
       new fame.EmitAndWrapRAMModels,
       new EmitFirrtl("post-gen-sram-models.fir"),

--- a/sim/midas/src/main/scala/midas/passes/VerilogMemDelays.scala
+++ b/sim/midas/src/main/scala/midas/passes/VerilogMemDelays.scala
@@ -1,0 +1,190 @@
+// See LICENSE for license info.
+
+package midas.passes
+
+import firrtl._
+import firrtl.ir._
+import firrtl.Utils._
+import firrtl.Mappers._
+import firrtl.traversals.Foreachers._
+import firrtl.transforms
+import firrtl.options.Dependency
+import firrtl.passes.MemPortUtils._
+import firrtl.WrappedExpression._
+
+import collection.mutable
+
+object MemDelayAndReadwriteTransformer {
+  // Representation of a group of signals and associated valid signals
+  case class WithValid(valid: Expression, payload: Seq[Expression])
+
+  // Grouped statements that are split into declarations and connects to ease ordering
+  case class SplitStatements(decls: Seq[Statement], conns: Seq[Connect])
+
+  // Utilities for generating hardware
+  def NOT(e:         Expression) = DoPrim(PrimOps.Not, Seq(e), Nil, BoolType)
+  def AND(e1:        Expression, e2: Expression) = DoPrim(PrimOps.And, Seq(e1, e2), Nil, BoolType)
+  def connect(l:     Expression, r:  Expression): Connect = Connect(NoInfo, l, r)
+  def condConnect(c: Expression)(l:  Expression, r: Expression): Connect = connect(l, Mux(c, r, l, l.tpe))
+
+  // Utilities for working with WithValid groups
+  def connect(l: WithValid, r: WithValid): Seq[Connect] = {
+    val paired = (l.valid +: l.payload).zip(r.valid +: r.payload)
+    paired.map { case (le, re) => connect(le, re) }
+  }
+
+  def condConnect(l: WithValid, r: WithValid): Seq[Connect] = {
+    connect(l.valid, r.valid) +: (l.payload.zip(r.payload)).map { case (le, re) => condConnect(r.valid)(le, re) }
+  }
+
+  // Internal representation of a pipeline stage with an associated valid signal
+  private case class PipeStageWithValid(idx: Int, ref: WithValid, stmts: SplitStatements = SplitStatements(Nil, Nil))
+
+  // Utilities for creating legal names for registers
+  private val metaChars = raw"[\[\]\.]".r
+  private def flatName(e: Expression) = metaChars.replaceAllIn(e.serialize, "_")
+
+  // Pipeline a group of signals with an associated valid signal. Gate registers when possible.
+  def pipelineWithValid(
+    ns:           Namespace
+  )(clock:        Expression,
+    depth:        Int,
+    src:          WithValid,
+    nameTemplate: Option[WithValid] = None
+  ): (WithValid, Seq[Statement], Seq[Connect]) = {
+
+    def asReg(e: Expression) = DefRegister(NoInfo, e.serialize, e.tpe, clock, zero, e)
+    val template = nameTemplate.getOrElse(src)
+
+    val stages = Seq.iterate(PipeStageWithValid(0, src), depth + 1) {
+      case prev =>
+        def pipeRegRef(e: Expression) = WRef(ns.newName(s"${flatName(e)}_pipe_${prev.idx}"), e.tpe, RegKind)
+        val ref = WithValid(pipeRegRef(template.valid), template.payload.map(pipeRegRef))
+        val regs = (ref.valid +: ref.payload).map(asReg)
+        PipeStageWithValid(prev.idx + 1, ref, SplitStatements(regs, condConnect(ref, prev.ref)))
+    }
+    (stages.last.ref, stages.flatMap(_.stmts.decls), stages.flatMap(_.stmts.conns))
+  }
+}
+
+/**
+  * This class performs the primary work of the transform: splitting readwrite ports into separate
+  * read and write ports while simultaneously compiling memory latencies to combinational-read
+  * memories with delay pipelines. It is represented as a class that takes a module as a constructor
+  * argument, as it encapsulates the mutable state required to analyze and transform one module.
+  *
+  * @note The final transformed module is found in the (sole public) field [[transformed]]
+  */
+class MemDelayAndReadwriteTransformer(m: DefModule) {
+  import MemDelayAndReadwriteTransformer._
+
+  private val ns = Namespace(m)
+  private val netlist = new collection.mutable.HashMap[WrappedExpression, Expression]
+  private val exprReplacements = new collection.mutable.HashMap[WrappedExpression, Expression]
+  private val newConns = new mutable.ArrayBuffer[Connect]
+
+  private def findMemConns(s: Statement): Unit = s match {
+    case Connect(_, loc, expr) if (kind(loc) == MemKind) => netlist(we(loc)) = expr
+    case _                                               => s.foreach(findMemConns)
+  }
+
+  private def swapMemRefs(e: Expression): Expression = e.map(swapMemRefs) match {
+    case sf: WSubField => exprReplacements.getOrElse(we(sf), sf)
+    case ex => ex
+  }
+
+  private def transform(s: Statement): Statement = s.map(transform) match {
+    case mem: DefMemory =>
+      // Per-memory bookkeeping
+      val portNS = Namespace(mem.readers ++ mem.writers)
+      val rMap = mem.readwriters.map(rw => (rw -> portNS.newName(s"${rw}_r"))).toMap
+      val wMap = mem.readwriters.map(rw => (rw -> portNS.newName(s"${rw}_w"))).toMap
+      val newReaders = mem.readers ++ mem.readwriters.map(rMap(_))
+      val newWriters = mem.writers ++ mem.readwriters.map(wMap(_))
+      val newMem = DefMemory(mem.info, mem.name, mem.dataType, mem.depth, 1, 0, newReaders, newWriters, Nil)
+      val rCmdDelay = if (mem.readUnderWrite == ReadUnderWrite.Old) 0 else mem.readLatency
+      val rRespDelay = if (mem.readUnderWrite == ReadUnderWrite.Old) mem.readLatency else 0
+      val wCmdDelay = mem.writeLatency - 1
+
+      val readStmts = (mem.readers ++ mem.readwriters).map {
+        case r =>
+          def oldDriver(f: String) = swapMemRefs(netlist(we(memPortField(mem, r, f))))
+          def newField(f:  String) = memPortField(newMem, rMap.getOrElse(r, r), f)
+          val clk = oldDriver("clk")
+
+          // Pack sources of read command inputs into WithValid object -> different for readwriter
+          val enSrc = if (rMap.contains(r)) AND(oldDriver("en"), NOT(oldDriver("wmode"))) else oldDriver("en")
+          val cmdSrc = WithValid(enSrc, Seq(oldDriver("addr")))
+          val cmdSink = WithValid(newField("en"), Seq(newField("addr")))
+          val (cmdPiped, cmdDecls, cmdConns) =
+            pipelineWithValid(ns)(clk, rCmdDelay, cmdSrc, nameTemplate = Some(cmdSink))
+          val cmdPortConns = connect(cmdSink, cmdPiped) :+ connect(newField("clk"), clk)
+
+          // Pipeline read response using *last* command pipe stage enable as the valid signal
+          val resp = WithValid(cmdPiped.valid, Seq(newField("data")))
+          val respPipeNameTemplate =
+            Some(resp.copy(valid = cmdSink.valid)) // base pipeline register names off field names
+          val (respPiped, respDecls, respConns) =
+            pipelineWithValid(ns)(clk, rRespDelay, resp, nameTemplate = respPipeNameTemplate)
+
+          // Make sure references to the read data get appropriately substituted
+          val oldRDataName = if (rMap.contains(r)) "rdata" else "data"
+          exprReplacements(we(memPortField(mem, r, oldRDataName))) = respPiped.payload.head
+
+          // Return all statements; they're separated so connects can go after all declarations
+          SplitStatements(cmdDecls ++ respDecls, cmdConns ++ cmdPortConns ++ respConns)
+      }
+
+      val writeStmts = (mem.writers ++ mem.readwriters).map {
+        case w =>
+          def oldDriver(f: String) = swapMemRefs(netlist(we(memPortField(mem, w, f))))
+          def newField(f:  String) = memPortField(newMem, wMap.getOrElse(w, w), f)
+          val clk = oldDriver("clk")
+
+          // Pack sources of write command inputs into WithValid object -> different for readwriter
+          val cmdSrc = if (wMap.contains(w)) {
+            val en = AND(oldDriver("en"), oldDriver("wmode"))
+            WithValid(en, Seq(oldDriver("addr"), oldDriver("wmask"), oldDriver("wdata")))
+          } else {
+            WithValid(oldDriver("en"), Seq(oldDriver("addr"), oldDriver("mask"), oldDriver("data")))
+          }
+
+          // Pipeline write command, connect to memory
+          val cmdSink = WithValid(newField("en"), Seq(newField("addr"), newField("mask"), newField("data")))
+          val (cmdPiped, cmdDecls, cmdConns) =
+            pipelineWithValid(ns)(clk, wCmdDelay, cmdSrc, nameTemplate = Some(cmdSink))
+          val cmdPortConns = connect(cmdSink, cmdPiped) :+ connect(newField("clk"), clk)
+
+          // Return all statements; they're separated so connects can go after all declarations
+          SplitStatements(cmdDecls, cmdConns ++ cmdPortConns)
+      }
+
+      newConns ++= (readStmts ++ writeStmts).flatMap(_.conns)
+      Block(newMem +: (readStmts ++ writeStmts).flatMap(_.decls))
+    case sx: Connect if kind(sx.loc) == MemKind => EmptyStmt // Filter old mem connections
+    case sx => sx.map(swapMemRefs)
+  }
+
+  val transformed = m match {
+    case mod: Module =>
+      findMemConns(mod.body)
+      mod.copy(body = Block(transform(mod.body) +: newConns.toSeq))
+    case mod => mod
+  }
+}
+
+object VerilogMemDelays extends firrtl.passes.Pass {
+
+  override def prerequisites = firrtl.stage.Forms.LowForm :+ Dependency(firrtl.passes.RemoveValidIf)
+
+  override val optionalPrerequisiteOf =
+    Seq(Dependency[VerilogEmitter], Dependency[SystemVerilogEmitter])
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case _: transforms.ConstantPropagation | firrtl.passes.ResolveFlows => true
+    case _ => false
+  }
+
+  def transform(m: DefModule): DefModule = (new MemDelayAndReadwriteTransformer(m)).transformed
+  def run(c:       Circuit):   Circuit = c.copy(modules = c.modules.map(transform))
+}

--- a/sim/midas/src/main/scala/midas/passes/fame/ImplementThreadedSyncReadMems.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/ImplementThreadedSyncReadMems.scala
@@ -1,0 +1,164 @@
+// See LICENSE for license details.
+
+package midas.passes.fame
+
+import firrtl._
+import firrtl.ir._
+import firrtl.Utils.BoolType
+import firrtl.passes.MemPortUtils._
+
+import firrtl.Mappers._
+
+import collection.mutable
+
+/*
+ * The multithreaders add custom IR nodes to represent threaded sync-read mems.
+ * This pass finds them, replaces them with blackbox instances, and implements the blackboxes.
+ */
+
+object ThreadedSyncReadMem {
+  def apply(nThreads: BigInt, proto: DefMemory): ThreadedSyncReadMem = {
+    ThreadedSyncReadMem(nThreads, proto.info, proto.name, proto.dataType, proto.depth,
+      proto.readers, proto.writers, proto.readwriters, proto.readUnderWrite)
+  }
+  def tIdxName: String = "tidx"
+}
+
+case class ThreadedSyncReadMem(
+  nThreads: BigInt,
+  info: Info,
+  name: String,
+  dataType: Type,
+  depth: BigInt,
+  readers: Seq[String],
+  writers: Seq[String],
+  readwriters: Seq[String],
+  readUnderWrite: ReadUnderWrite.Value) extends Statement with IsDeclaration {
+
+  def flatImpl(desiredName: String): DefMemory = {
+    DefMemory(info, desiredName, dataType, nThreads * depth, 1, 1, readers, writers, readwriters, readUnderWrite)
+  }
+
+  def tpe: BundleType = memType(flatImpl(""))
+
+  def serialize = ???
+  def mapStmt(f: Statement => Statement): Statement = this
+  def mapExpr(f: Expression => Expression): Statement = this
+  def mapType(f: Type => Type): Statement = this.copy(dataType = f(dataType))
+  def mapString(f: String => String): Statement = this.copy(name = f(name))
+  def mapInfo(f: Info => Info): Statement = this.copy(info = f(info))
+  def foreachExpr(f: Expression => Unit): Unit = ()
+  def foreachStmt(f: Statement => Unit): Unit = ()
+  def foreachType(f: Type => Unit): Unit = f(dataType)
+  def foreachString(f: String => Unit): Unit = f(name)
+  def foreachInfo(f: Info => Unit): Unit = f(info)
+}
+
+object ImplementThreadedSyncReadMems extends Transform {
+  def inputForm = HighForm
+  def outputForm = HighForm
+
+  private def implement(tMem: ThreadedSyncReadMem, moduleName: String): Module = {
+    val info = FAME5Info.info
+    val tIdxMax = UIntLiteral(tMem.nThreads-1)
+    val rdataPipeDepth = if (tMem.nThreads < 4) 0 else 1
+
+    val hostClockPort = Port(info, WrapTop.hostClockName, Input, ClockType)
+
+    val accessors = tMem.readers ++ tMem.writers ++ tMem.readwriters
+    val ports = hostClockPort +: tMem.tpe.fields.map {
+      case Field(name, Flip, tpe) => Port(info, name, Input, tpe)
+    }
+
+    val ns = Namespace(ports.map(p => p.name))
+
+    def wsf(e: Expression, f: String): WSubField = WSubField(e, f)
+    def wssf(e: Expression, f0: String, f1: String): WSubField = WSubField(wsf(e, f0), f1)
+
+    def hostRegNext(name: String, expr: Expression): (Block, WRef) = {
+      val reg = DefRegister(info, name, expr.tpe, WRef(hostClockPort), UIntLiteral(0), WRef(name))
+      val conn = Connect(info, WRef(reg), expr)
+      (Block(reg, conn), WRef(reg))
+    }
+
+    def pipeline(depth: Int, expr: WRef): (Block, Expression) = {
+      (1 to depth).foldLeft[(Block, WRef)]((Block(Nil), expr)) {
+        case ((prevBlock, prev), idx) =>
+          val (currentBlock, current) = hostRegNext(ns.newName(s"${expr.name}_p${idx}"), prev)
+          (Block(prevBlock.stmts ++: currentBlock.stmts), current)
+      }
+    }
+
+    // Useful expressions: tidx is carried in the bottom of input addr (part of interface definition)
+    val targetClock = wsf(WRef(accessors.head), "clk")
+    val tLocalAddrWidth = BigInt((tMem.depth - 1).bitLength)
+    val targetClockCounterName = ns.newName("edgeCount")
+
+    // Name the memories used to store read data
+    val rdMemNames = tMem.readers.map(r => r -> ns.newName(s"${r}_datas")).toMap
+    val rwdMemNames = tMem.readwriters.map(rw => rw -> ns.newName(s"${rw}_rdatas")).toMap
+
+    // Now all the statements
+    val tIdx = DefNode(info, ns.newName("thread"), DoPrim(PrimOps.Tail, Seq(wsf(WRef(accessors.head), "addr")), Seq(tLocalAddrWidth), tIdxMax.tpe))
+    val mem = tMem.flatImpl(ns.newName("mem"))
+    val targetClockCounter = DefRegister(info, targetClockCounterName, BoolType, targetClock, UIntLiteral(0), WRef(targetClockCounterName))
+    val counterUpdate = Connect(info, WRef(targetClockCounter), Negate(WRef(targetClockCounter)))
+
+    val (counterTracker, counterTrackerRef) = hostRegNext(ns.newName("edgeCountTracker"), WRef(targetClockCounter))
+    val edgeStatus = DefNode(info, ns.newName("edgeStatus"), Xor(counterTrackerRef, WRef(targetClockCounter)))
+
+    val (tIdxPipe, tIdxPipedRef) = pipeline(rdataPipeDepth + 1, WRef(tIdx))
+    val (edgeStatusPipe, edgeStatusPipedRef) = pipeline(rdataPipeDepth, WRef(edgeStatus))
+
+    val rdMems = rdMemNames.map { case (k, v) => DefMemory(info, v, mem.dataType, tMem.nThreads, 1, 0, Seq("r"), Seq("w"), Nil) }
+    val rwdMems = rwdMemNames.map { case (k, v) => DefMemory(info, v, mem.dataType, tMem.nThreads, 1, 0, Seq("r"), Seq("w"), Nil) }
+
+    val defaultConns = accessors.map(p => Connect(info, wsf(WRef(mem), p), WRef(p)))
+
+    val dataOutLogic = (rdMemNames ++ rwdMemNames).flatMap {
+      case (topPName, doutMemName) =>
+        val doutName = if (rdMemNames.contains(topPName)) "data" else "rdata"
+        val doutMemRef = WRef(doutMemName)
+        val tmpNodeName = ns.newName(s"${topPName}_${doutName}_node")
+
+        val doutNode = DefNode(info, tmpNodeName, wssf(WRef(mem), topPName, doutName))
+        val (doutPipe, doutPipedRef) = pipeline(rdataPipeDepth, WRef(tmpNodeName, tMem.dataType, NodeKind, SourceFlow))
+        Seq(doutNode,
+            doutPipe,
+            Connect(info, wssf(doutMemRef, "r", "clk"), WRef(hostClockPort)),
+            Connect(info, wssf(doutMemRef, "r", "addr"), WRef(tIdx)),
+            Connect(info, wssf(doutMemRef, "r", "en"), UIntLiteral(1)),
+            Connect(info, wsf(WRef(topPName), doutName), wssf(doutMemRef, "r", "data")),
+            Connect(info, wssf(doutMemRef, "w", "clk"), WRef(hostClockPort)),
+            Connect(info, wssf(doutMemRef, "w", "addr"), tIdxPipedRef),
+            Connect(info, wssf(doutMemRef, "w", "en"), edgeStatusPipedRef),
+            Connect(info, wssf(doutMemRef, "w", "mask"), UIntLiteral(1)),
+            Connect(info, wssf(doutMemRef, "w", "data"), doutPipedRef))
+    }
+
+    val ctrlStmts = Seq(tIdx, targetClockCounter, counterUpdate, counterTracker, edgeStatus, tIdxPipe, edgeStatusPipe)
+    val body = Block(Seq(mem) ++ ctrlStmts ++ rdMems ++ rwdMems ++ defaultConns ++ dataOutLogic)
+
+    Module(info, moduleName, ports, body)
+  }
+
+  private def onStmt(ns: Namespace, implementations: mutable.Map[ThreadedSyncReadMem, Module])(stmt: Statement): Statement = {
+    stmt match {
+      case tMem: ThreadedSyncReadMem =>
+        val impl = implementations.getOrElseUpdate(tMem.copy(name = ""), implement(tMem, ns.newName("ThreadedMem")))
+        WDefInstance(tMem.name, impl.name)
+      case s => s.map(onStmt(ns, implementations)(_))
+    }
+  }
+
+  override def execute(state: CircuitState): CircuitState = {
+    val moduleNS = Namespace(state.circuit)
+    val tMemImplementations = new mutable.LinkedHashMap[ThreadedSyncReadMem, Module]
+    val modulesX = state.circuit.modules.map {
+      case m: Module => m.copy(body = onStmt(moduleNS, tMemImplementations)(m.body))
+      case m => m
+    }
+    val tMemMods = tMemImplementations.map { case (k, v) => v }
+    state.copy(circuit = state.circuit.copy(modules = modulesX ++ tMemMods))
+  }
+}

--- a/sim/midas/src/main/scala/midas/passes/fame/ImplementThreadedSyncReadMems.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/ImplementThreadedSyncReadMems.scala
@@ -92,7 +92,6 @@ object ImplementThreadedSyncReadMems extends Transform {
 
     // Useful expressions: tidx is carried in the bottom of input addr (part of interface definition)
     val targetClock = wsf(WRef(accessors.head), "clk")
-    val tLocalAddrWidth = BigInt((tMem.depth - 1).bitLength)
     val targetClockCounterName = ns.newName("edgeCount")
 
     // Name the memories used to store read data
@@ -100,7 +99,7 @@ object ImplementThreadedSyncReadMems extends Transform {
     val rwdMemNames = tMem.readwriters.map(rw => rw -> ns.newName(s"${rw}_rdatas")).toMap
 
     // Now all the statements
-    val tIdx = DefNode(info, ns.newName("thread"), DoPrim(PrimOps.Tail, Seq(wsf(WRef(accessors.head), "addr")), Seq(tLocalAddrWidth), tIdxMax.tpe))
+    val tIdx = DefNode(info, ns.newName("thread"), DoPrim(PrimOps.Head, Seq(wsf(WRef(accessors.head), "addr")), Seq(bitWidth(tIdxMax.tpe)), tIdxMax.tpe))
     val mem = tMem.flatImpl(ns.newName("mem"))
     val targetClockCounter = DefRegister(info, targetClockCounterName, BoolType, targetClock, UIntLiteral(0), WRef(targetClockCounterName))
     val counterUpdate = Connect(info, WRef(targetClockCounter), Negate(WRef(targetClockCounter)))

--- a/sim/midas/src/main/scala/midas/passes/fame/ImplementThreadedSyncReadMems.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/ImplementThreadedSyncReadMems.scala
@@ -54,10 +54,7 @@ case class ThreadedSyncReadMem(
   def foreachInfo(f: Info => Unit): Unit = f(info)
 }
 
-object ImplementThreadedSyncReadMems extends Transform {
-  def inputForm = HighForm
-  def outputForm = HighForm
-
+object ImplementThreadedSyncReadMems {
   private def implement(tMem: ThreadedSyncReadMem, moduleName: String): Module = {
     val info = FAME5Info.info
     val tIdxMax = UIntLiteral(tMem.nThreads-1)
@@ -156,14 +153,14 @@ object ImplementThreadedSyncReadMems extends Transform {
     }
   }
 
-  override def execute(state: CircuitState): CircuitState = {
-    val moduleNS = Namespace(state.circuit)
+  def apply(circuit: Circuit): Circuit = {
+    val moduleNS = Namespace(circuit)
     val tMemImplementations = new mutable.LinkedHashMap[ThreadedSyncReadMem, Module]
-    val modulesX = state.circuit.modules.map {
+    val modulesX = circuit.modules.map {
       case m: Module => m.copy(body = onStmt(moduleNS, tMemImplementations)(m.body))
       case m => m
     }
     val tMemMods = tMemImplementations.map { case (k, v) => v }
-    state.copy(circuit = state.circuit.copy(modules = modulesX ++ tMemMods))
+    circuit.copy(modules = modulesX ++ tMemMods)
   }
 }

--- a/sim/midas/src/main/scala/midas/passes/fame/MultiThreadFAME5Models.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/MultiThreadFAME5Models.scala
@@ -218,6 +218,8 @@ object MultiThreadFAME5Models extends Transform {
 
     // TODO: Renames!
 
-    state.copy(circuit = state.circuit.copy(modules = transformedModules))
+    val threadedCircuit = state.circuit.copy(modules = transformedModules)
+    val withMemImpls = ImplementThreadedSyncReadMems(threadedCircuit)
+    state.copy(circuit = withMemImpls)
   }
 }

--- a/sim/midas/src/main/scala/midas/passes/fame/MultiThreader.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/MultiThreader.scala
@@ -103,7 +103,7 @@ object MultiThreader {
   }
 
   def transformAddr(counter: DefRegister, expr: Expression): Expression = {
-    DoPrim(PrimOps.Cat, Seq(expr, WRef(counter)), Nil, UnknownType)
+    DoPrim(PrimOps.Cat, Seq(WRef(counter), expr), Nil, UnknownType)
   }
 
   def updateReg(reg: DefRegister, slotName: String): DefRegister = {

--- a/sim/midas/src/main/scala/midas/passes/fame/MuxingMultithreader.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/MuxingMultithreader.scala
@@ -59,19 +59,20 @@ object MuxingMultiThreader {
       regWriteAsMemWrite(info, name, tpe, onExprRHS(rhs))
     case Connect(_, lhs, _) if (kind(lhs) == RegKind) =>
       throw CustomTransformException(new IllegalArgumentException(s"Cannot handle complex register assignment to ${lhs}"))
+    case mem: DefMemory if (mem.readLatency == 1 && mem.writeLatency == 1) =>
+      Block(ThreadedSyncReadMem(nThreads, mem),
+            Connect(FAME5Info.info, WSubField(WRef(mem.name), WrapTop.hostClockName), WRef(WrapTop.hostClockName)))
     case mem: DefMemory =>
-      require(mem.readLatency == 0, "Memories must be transformed with VerilogMemDelays before multithreading")
-      require(mem.readLatency == 0, "Memories must have one-cycle write latency")
+      require(mem.readLatency == 0, "Memories must either by combinational read or handled as ThreadedSyncReadMems")
+      require(mem.writeLatency == 1, "Memories must have one-cycle write latency")
       require(nThreads.bitCount == 1, "Models may only be threaded by pow2 threads for now")
       mem.copy(depth = mem.depth * nThreads)
     case s => s.map(onStmt(newResets, nThreads, tIdx)).map(onExprRHS)
   }
 
   def apply(threadedModuleNames: Map[String, String])(module: Module, n: BigInt): Module = {
-    // TODO: this is ugly and uses copied code instead of bumping FIRRTL
     // Simplify all memories first
-    val loweredMod = (new memlib.MemDelayAndReadwriteTransformer(module)).transformed.asInstanceOf[Module]
-    val ns = Namespace(loweredMod)
+    val ns = Namespace(module)
 
     val hostClock = WRef(WrapTop.hostClockName)
     val hostReset = WRef(WrapTop.hostResetName)
@@ -89,7 +90,7 @@ object MuxingMultiThreader {
 
     // Resets transformed to conditional stores to threading RAMs
     val newResets = new ArrayBuffer[Statement]
-    val threaded = onStmt(newResets, n, tIdxRef)(loweredMod.body)
+    val threaded = onStmt(newResets, n, tIdxRef)(module.body)
 
     // Uses only threaded instances
     val (iDecls, threadedImpl) = SeparateInstanceDecls(threaded)

--- a/sim/midas/src/main/scala/midas/passes/fame/MuxingMultithreader.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/MuxingMultithreader.scala
@@ -54,7 +54,7 @@ object MuxingMultiThreader {
       }
       Block(Seq(mem, rClockConn, rEnConn, rAddrConn, wClockConn, wEnDefault, wMaskConn, wAddrConn))
     case Connect(info, lhs @ WSubField(p: WSubField, "addr", _, _), rhs) if kind(lhs) == MemKind =>
-      Connect(FAME5Info.info ++ info, lhs, DoPrim(PrimOps.Cat, Seq(onExprRHS(rhs), tIdx), Nil, UnknownType))
+      Connect(FAME5Info.info ++ info, lhs, DoPrim(PrimOps.Cat, Seq(tIdx, onExprRHS(rhs)), Nil, UnknownType))
     case Connect(info, WRef(name, tpe, RegKind, _), rhs) =>
       regWriteAsMemWrite(info, name, tpe, onExprRHS(rhs))
     case Connect(_, lhs, _) if (kind(lhs) == RegKind) =>
@@ -65,7 +65,6 @@ object MuxingMultiThreader {
     case mem: DefMemory =>
       require(mem.readLatency == 0, "Memories must either by combinational read or handled as ThreadedSyncReadMems")
       require(mem.writeLatency == 1, "Memories must have one-cycle write latency")
-      require(nThreads.bitCount == 1, "Models may only be threaded by pow2 threads for now")
       mem.copy(depth = mem.depth * nThreads)
     case s => s.map(onStmt(newResets, nThreads, tIdx)).map(onExprRHS)
   }

--- a/sim/midas/src/main/scala/midas/passes/fame/RTLUtils.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/RTLUtils.scala
@@ -69,6 +69,10 @@ object Xor extends BinaryBooleanOp {
   val op = PrimOps.Xor
 }
 
+object Eq extends BinaryBooleanOp {
+  val op = PrimOps.Eq
+}
+
 object Neq extends BinaryBooleanOp {
   val op = PrimOps.Neq
 }

--- a/sim/midas/src/main/scala/midas/passes/xilinx/package.scala
+++ b/sim/midas/src/main/scala/midas/passes/xilinx/package.scala
@@ -20,9 +20,16 @@ package object xilinx {
     }
   }
 
+  object FPGAFriendlyMems extends Transform with NoAnalysisPass {
+    val transformer = StatementTransformer {
+      case mem: DefMemory if (mem.readLatency == 1 && mem.readUnderWrite == ReadUnderWrite.Undefined) =>
+        mem.copy(readUnderWrite = ReadUnderWrite.Old)
+    }
+  }
+
   object HostSpecialization extends SeqTransform {
     val inputForm = LowForm
     val outputForm = LowForm
-    val transforms = Seq(DefineBUFGCE, ReplaceAbstractClockGates)
+    val transforms = Seq(DefineBUFGCE, ReplaceAbstractClockGates, FPGAFriendlyMems)
   }
 }

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
@@ -36,7 +36,7 @@ class GoldenGateCompilerPhase extends Phase with ConfigLookup {
       Forms.LowForm).execute(loweredTarget)
 
     // Lower and emit simulator RTL and run user-requested host-transforms
-    new Compiler(Dependency[firrtl.VerilogEmitter] +: p(HostTransforms),Forms.LowForm)
+    new Compiler(Dependency(midas.passes.VerilogMemDelays) +: Dependency[firrtl.VerilogEmitter] +: p(HostTransforms),Forms.LowForm)
       .execute(simulator)
       .annotations
   }


### PR DESCRIPTION
Currently, synchronous-read memories get processed with `VerilogMemDelays` before FAME5 multi-threading, which leads to inconsistent BRAM inference and generally worse QoR. This PR fixes that by generating specialized implementations of natively multi-threaded synchronous-read memories. These implementations generally use RAM resources more effectively than the baseline unoptimized simulators.

This also copies in the fix to `VerilogMemDelays` from freechipsproject/firrtl#1908. This fix can be reverted when the FIRRTL upstream changes make it to FireSim, but since that will take a while, it's good to get this bugfix in.