### PR TITLE
Have FireSim build recipes use Chipyard configs rather than FireChip configs

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -80,7 +80,6 @@ deploytriplet=None
 # Multiclock Temporary Example:ncept Quad-core, Rocket-based recipes
 [firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimMulticlockRocketConfig
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.DividedClockRocketConfig
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -13,14 +13,14 @@
 # Quad-core, Rocket-based recipes
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_FireSimQuadRocketConfig
+TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.QuadRocketConfig
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimQuadRocketConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.QuadRocketConfig
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -29,14 +29,14 @@ deploytriplet=None
 # Single-core, BOOM-based recipes
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_FireSimLargeBoomConfig
+TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
 PLATFORM_CONFIG=F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimLargeBoomConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
 PLATFORM_CONFIG=F70MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -45,7 +45,7 @@ deploytriplet=None
 # Single-core, Ariane-based recipes
 [firesim-ariane-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimArianeConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.ArianeConfig
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -54,7 +54,7 @@ deploytriplet=None
 # Single-core, Rocket-based recipes with Gemmini
 [firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimGemminiRocketConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
 PLATFORM_CONFIG=F110MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -63,7 +63,7 @@ deploytriplet=None
 # RAM Optimizations enabled by adding _MCRams PLATFORM_CONFIG string
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimLargeBoomConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
 PLATFORM_CONFIG=MCRams_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -81,6 +81,7 @@ deploytriplet=None
 [firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_FireSimMulticlockRocketConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.DividedClockRocketConfig
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
@@ -93,5 +94,3 @@ TARGET_CONFIG=NoConfig
 PLATFORM_CONFIG=DefaultF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
-

--- a/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
@@ -14,7 +14,7 @@ case object DramOrganizationKey extends Field[DramOrganizationParams]
 
 // Instantiates an AXI4 memory model that executes (1 / clockDivision) of the frequency
 // of the RTL transformed model (Rocket Chip)
-class WithDefaultMemModel() extends Config((site, here, up) => {
+class WithDefaultMemModel extends Config((site, here, up) => {
   case LlcKey => None
   // Only used if a DRAM model is requested
   case DramOrganizationKey => DramOrganizationParams(maxBanks = 8, maxRanks = 4, dramSize = BigInt(1) << 34)
@@ -99,10 +99,10 @@ class FCFS16GBQuadRankLLC4MB extends Config(
   new FCFS16GBQuadRank)
 
 // DDR3 - First-Ready FCFS models
-class FRFCFS16GBQuadRank() extends Config(
+class FRFCFS16GBQuadRank extends Config(
   new WithFuncModelLimits(32,32) ++
   new WithDDR3FRFCFS(8, 8) ++
-  new WithDefaultMemModel()
+  new WithDefaultMemModel
 )
 class FRFCFS16GBQuadRankLLC4MB extends Config(
   new WithLLCModel(4096, 8) ++

--- a/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
@@ -14,7 +14,7 @@ case object DramOrganizationKey extends Field[DramOrganizationParams]
 
 // Instantiates an AXI4 memory model that executes (1 / clockDivision) of the frequency
 // of the RTL transformed model (Rocket Chip)
-class WithDefaultMemModel(clockDivision: Int = 1) extends Config((site, here, up) => {
+class WithDefaultMemModel() extends Config((site, here, up) => {
   case LlcKey => None
   // Only used if a DRAM model is requested
   case DramOrganizationKey => DramOrganizationParams(maxBanks = 8, maxRanks = 4, dramSize = BigInt(1) << 34)
@@ -26,9 +26,7 @@ class WithDefaultMemModel(clockDivision: Int = 1) extends Config((site, here, up
     llcKey = site(LlcKey))
 
   case MemModelKey => new LatencyPipeConfig(site(BaseParamsKey))
-}) {
-  require(clockDivision == 1, "Endpoint clock-division temporarily removed until FireSim 1.8.0")
-}
+})
 
 
 /*******************************************************************************
@@ -94,12 +92,6 @@ class LBP32R32WLLC4MB extends Config(
   new WithFuncModelLimits(32,32) ++
   new WithDefaultMemModel)
 
-// An LBP that runs at 1/3 the frequency of the cores + uncore
-// This is 1067 MHz for default core frequency of 3.2 GHz
-class LBP32R32W3Div extends Config(
-  new WithFuncModelLimits(32,32) ++
-  new WithDefaultMemModel(3))
-
 // DDR3 - FCFS models.
 class FCFS16GBQuadRank extends Config(new WithDDR3FIFOMAS(8) ++ new WithDefaultMemModel)
 class FCFS16GBQuadRankLLC4MB extends Config(
@@ -107,17 +99,12 @@ class FCFS16GBQuadRankLLC4MB extends Config(
   new FCFS16GBQuadRank)
 
 // DDR3 - First-Ready FCFS models
-class FRFCFS16GBQuadRank(clockDiv: Int = 1) extends Config(
+class FRFCFS16GBQuadRank() extends Config(
   new WithFuncModelLimits(32,32) ++
   new WithDDR3FRFCFS(8, 8) ++
-  new WithDefaultMemModel(clockDiv)
+  new WithDefaultMemModel()
 )
 class FRFCFS16GBQuadRankLLC4MB extends Config(
   new WithLLCModel(4096, 8) ++
   new FRFCFS16GBQuadRank
-)
-
-class FRFCFS16GBQuadRankLLC4MB3Div extends Config(
-  new WithLLCModel(4096, 8) ++
-  new FRFCFS16GBQuadRank(3)
 )

--- a/sim/midas/src/main/cc/unittest/Makefrag
+++ b/sim/midas/src/main/cc/unittest/Makefrag
@@ -31,7 +31,7 @@ $(GEN_DIR)/$(DESIGN).fir $(GEN_DIR)/$(DESIGN).behav_srams.v: $(scala_srcs)
 		--target-dir $(GEN_DIR) \
 		--name $(DESIGN) \
 		--top-module freechips.rocketchip.unittest.TestHarness \
-		--legacy-configs midas.unittest.$(CONFIG)"
+		--legacy-configs midas.unittest:$(CONFIG)"
 	touch $(GEN_DIR)/$(DESIGN).behav_srams.v
 
 $(GEN_DIR)/$(DESIGN).v: $(GEN_DIR)/$(DESIGN).fir

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -44,7 +44,7 @@ $(FIRRTL_FILE) $(ANNO_FILE): $(chisel_srcs) $(FIRRTL_JAR) $(SCALA_BUILDTOOL_DEPS
 		--target-dir $(GENERATED_DIR) \
 		--name $(long_name) \
 		--top-module $(DESIGN_PACKAGE).$(DESIGN) \
-		--legacy-configs $(TARGET_CONFIG_PACKAGE).$(TARGET_CONFIG))
+		--legacy-configs $(TARGET_CONFIG_PACKAGE):$(TARGET_CONFIG))
 
 ##########################
 # Driver Sources & Flags #

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -45,7 +45,7 @@ $(FIRRTL_FILE) $(ANNO_FILE): $(SCALA_SOURCES) $(FIRRTL_JAR) $(SCALA_BUILDTOOL_DE
 		--target-dir $(GENERATED_DIR) \
 		--name $(long_name) \
 		--top-module $(DESIGN_PACKAGE).$(DESIGN) \
-		--legacy-configs $(TARGET_CONFIG_PACKAGE).$(TARGET_CONFIG))
+		--legacy-configs $(TARGET_CONFIG_PACKAGE):$(TARGET_CONFIG))
 
 # DOC include start: Bridge Build System Changes
 ##########################

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -50,7 +50,7 @@ $(FIRRTL_FILE) $(ANNO_FILE): $(chisel_srcs) $(FIRRTL_JAR) $(SCALA_BUILDTOOL_DEPS
 		--target-dir $(GENERATED_DIR) \
 		--name $(long_name) \
 		--top-module $(DESIGN_PACKAGE).$(DESIGN) \
-		--legacy-configs $(TARGET_CONFIG_PACKAGE).$(TARGET_CONFIG))
+		--legacy-configs $(TARGET_CONFIG_PACKAGE):$(TARGET_CONFIG))
 	# Remove once runtime conf generation is generalized, and something is always emitted
 	touch $(GENERATED_DIR)/$(CONF_NAME)
 


### PR DESCRIPTION
Have FireSim build recipes use shared Chipyard configs rather than custom FireChip configs. This required updating the Chipyard phase to enable config strings to accept config fragments from several different packages.
Goes together with Chipyard PR 695 https://github.com/ucb-bar/chipyard/pull/695

Waiting for initial approval before I re-generate AGFIs