### PR TITLE
Label all threading targets as FAME models when threading is enabled

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
@@ -64,6 +64,7 @@ private[midas] class MidasTransforms extends Transform {
       ChannelClockInfoAnalysis,
       UpdateBridgeClockInfo,
       fame.WrapTop,
+      fame.LabelMultiThreadedInstances,
       new ResolveAndCheck,
       new EmitFirrtl("post-wrap-top.fir")) ++
     optionalTargetTransforms ++

--- a/sim/midas/src/main/scala/midas/passes/fame/LabelMultiThreadedInstances.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/LabelMultiThreadedInstances.scala
@@ -1,0 +1,31 @@
+// See LICENSE for license details.
+
+package midas.passes.fame
+
+import firrtl._
+
+// This pass labels all instances that are annotated as potential targets for threading as FAME models
+object LabelMultiThreadedInstances extends Transform {
+  def inputForm = HighForm
+  def outputForm = HighForm
+
+  override def execute(state: CircuitState): CircuitState = {
+    val p = state.annotations.collectFirst({ case midas.stage.phases.ConfigParametersAnnotation(p)  => p }).get
+    val enableMultiThreading = p(midas.EnableModelMultiThreading)
+    val fameModelAnnos = new collection.mutable.LinkedHashSet[midas.targetutils.FirrtlFAMEModelAnnotation]
+    val updatedAnnos = state.annotations.flatMap {
+      case fma: midas.targetutils.FirrtlFAMEModelAnnotation =>
+        fameModelAnnos += fma
+        None
+      case f5a @ midas.targetutils.FirrtlEnableModelMultiThreadingAnnotation(it) =>
+        if (enableMultiThreading) {
+          fameModelAnnos += midas.targetutils.FirrtlFAMEModelAnnotation(it)
+          Some(f5a)
+        } else {
+          None
+        }
+      case anno => Some(anno)
+    }
+    state.copy(annotations = AnnotationSeq(updatedAnnos ++ fameModelAnnos))
+  }
+}

--- a/sim/midas/src/main/scala/midas/passes/fame/MultiThreadFAME5Models.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/MultiThreadFAME5Models.scala
@@ -141,8 +141,9 @@ object MultiThreadFAME5Models extends Transform {
     // Populate keys from annotations, values from traversing statements
     val fame5RawInstances = new mutable.LinkedHashMap[OfModule, mutable.LinkedHashSet[Instance]]
     state.annotations.foreach {
-      case FirrtlEnableModelMultiThreadingAnnotation(ModuleTarget(_, m)) =>
-        fame5RawInstances(OfModule(m)) = new mutable.LinkedHashSet[Instance]
+      case FirrtlEnableModelMultiThreadingAnnotation(it) =>
+        // TODO: why not use instance name from here?
+        fame5RawInstances(OfModule(it.ofModule)) = new mutable.LinkedHashSet[Instance]
       case _ =>
     }
 

--- a/sim/midas/targetutils/src/main/scala/midas/annotations.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/annotations.scala
@@ -122,7 +122,8 @@ case class FirrtlFAMEModelAnnotation(
   */
 case class EnableModelMultiThreadingAnnotation(target: BaseModule) extends chisel3.experimental.ChiselAnnotation {
   def toFirrtl: FirrtlEnableModelMultiThreadingAnnotation = {
-    FirrtlEnableModelMultiThreadingAnnotation(target.toNamed.toTarget)
+    val parent = ModuleTarget(target.toNamed.circuit.name, target.parentModName)
+    FirrtlEnableModelMultiThreadingAnnotation(parent.instOf(target.instanceName, target.name))
   }
 }
 
@@ -130,9 +131,9 @@ case class EnableModelMultiThreadingAnnotation(target: BaseModule) extends chise
   * This specifies that the module should be automatically multi-threaded (FIRRTL annotation).
   */
 case class FirrtlEnableModelMultiThreadingAnnotation(
-  target: ModuleTarget) extends SingleTargetAnnotation[ModuleTarget] with FAMEAnnotation {
+  target: InstanceTarget) extends SingleTargetAnnotation[InstanceTarget] with FAMEAnnotation {
   def targets = Seq(target)
-  def duplicate(n: ModuleTarget) = this.copy(n)
+  def duplicate(n: InstanceTarget) = this.copy(n)
 }
 
 /**

--- a/sim/src/main/scala/midasexamples/MultiReg.scala
+++ b/sim/src/main/scala/midasexamples/MultiReg.scala
@@ -29,7 +29,6 @@ class MultiRegDUT extends Module {
   (io.pipeIOs zip pipes).foreach {
     case (pio, p) =>
       p.io <> pio
-      annotate(FAMEModelAnnotation(p))
       annotate(EnableModelMultiThreadingAnnotation(p))
   }
 }

--- a/sim/src/main/scala/midasexamples/MultiRegfile.scala
+++ b/sim/src/main/scala/midasexamples/MultiRegfile.scala
@@ -31,7 +31,6 @@ class MultiRegfileDUT extends Module {
   rfs.zip(io.accesses).foreach {
     case (rf, rfio) =>
       rf.io <> rfio
-      annotate(FAMEModelAnnotation(rf))
       annotate(EnableModelMultiThreadingAnnotation(rf))
   }
 }

--- a/sim/src/main/scala/midasexamples/MultiSRAM.scala
+++ b/sim/src/main/scala/midasexamples/MultiSRAM.scala
@@ -37,7 +37,6 @@ class MultiSRAMDUT extends Module {
   rfs.zip(io.accesses).foreach {
     case (rf, rfio) =>
       rf.io <> rfio
-      annotate(FAMEModelAnnotation(rf))
       annotate(EnableModelMultiThreadingAnnotation(rf))
   }
 }

--- a/sim/src/main/scala/midasexamples/NestedModels.scala
+++ b/sim/src/main/scala/midasexamples/NestedModels.scala
@@ -40,8 +40,6 @@ class NestedModelsDUT extends Module {
   })
   val midA = Module(new Mid)
   val midB = Module(new Mid)
-  annotate(FAMEModelAnnotation(midA))
-  annotate(FAMEModelAnnotation(midB))
   annotate(EnableModelMultiThreadingAnnotation(midA))
   annotate(EnableModelMultiThreadingAnnotation(midB))
   midA.io <> io.a

--- a/sim/src/main/scala/midasexamples/TwoAdders.scala
+++ b/sim/src/main/scala/midasexamples/TwoAdders.scala
@@ -44,14 +44,12 @@ class TwoAddersDUT extends Module {
   })
 
   val a0 = Module(new DoublePipeAdder)
-  annotate(FAMEModelAnnotation(a0))
   annotate(EnableModelMultiThreadingAnnotation(a0))
   a0.io.x := io.i0
   a0.io.y := io.i1
   io.o0 := a0.io.z
 
   val a1 = Module(new DoublePipeAdder)
-  annotate(FAMEModelAnnotation(a1))
   annotate(EnableModelMultiThreadingAnnotation(a1))
   a1.io.x := io.i2
   a1.io.y := io.i3


### PR DESCRIPTION
This removes the need to put both a `EnableModelMultiThreadingAnnotation` and a `FAMEModelAnnotation` on a target module for multi-threading to work (if enabled in the platform config).