### PR TITLE
Rename Ariane to CVA6

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -42,10 +42,10 @@ instancetype=z1d.2xlarge
 deploytriplet=None
 
 
-# Single-core, Ariane-based recipes
-[firesim-ariane-singlecore-no-nic-l2-llc4mb-ddr3]
+# Single-core, CVA6-based recipes
+[firesim-cva6-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
-TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.ArianeConfig
+TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -108,8 +108,8 @@ TARGET_LD_FLAGS := -L$(RISCV)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DI
 # Setup Extra Verilator Compile Flags #
 #######################################
 
-## default flags added for ariane
-ARIANE_VERILATOR_FLAGS = \
+## default flags added for cva6
+CVA6_VERILATOR_FLAGS = \
 	--unroll-count 256 \
 	-Werror-PINMISSING \
 	-Werror-IMPLICIT \
@@ -123,13 +123,13 @@ ARIANE_VERILATOR_FLAGS = \
 	-Wno-style \
 	-Wall
 
-# normal flags used for midas builds (that are incompatible with ariane)
+# normal flags used for midas builds (that are incompatible with cva6)
 DEFAULT_MIDAS_VERILATOR_FLAGS = \
 	--assert
 
 # AJG: this must be evaluated after verilog generation to work (hence the =)
 EXTRA_VERILATOR_FLAGS = \
-	$(shell if ! grep -iq "module.*ariane" $(VERILOG); then echo "$(DEFAULT_MIDAS_VERILATOR_FLAGS)"; else echo "$(ARIANE_VERILATOR_FLAGS)"; fi)
+	$(shell if ! grep -iq "module.*cva6" $(VERILOG); then echo "$(DEFAULT_MIDAS_VERILATOR_FLAGS)"; else echo "$(CVA6_VERILATOR_FLAGS)"; fi)
 
 ################################################################
 # SW RTL Simulation Args -- for MIDAS- & FPGA-level Simulation #


### PR DESCRIPTION
This renames Ariane to CVA6 matching the following Chipyard PR: https://github.com/ucb-bar/chipyard/pull/710