### PR TITLE
Update to Chisel 3.4

### DIFF
--- a/sim/midas/src/main/scala/midas/core/SimWrapper.scala
+++ b/sim/midas/src/main/scala/midas/core/SimWrapper.scala
@@ -16,15 +16,15 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.{Direction, chiselName, ChiselAnnotation, annotate}
 import chisel3.experimental.DataMirror.directionOf
-import firrtl.annotations.{SingleTargetAnnotation, ReferenceTarget}
+import firrtl.annotations.{SingleTargetAnnotation, ReferenceTarget, IsModule}
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.{ArrayBuffer}
 
 case object SimWrapperKey extends Field[SimWrapperConfig]
 
-private[midas] case class TargetBoxAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
-  def duplicate(rt: ReferenceTarget): TargetBoxAnnotation = TargetBoxAnnotation(rt)
+private[midas] case class TargetBoxAnnotation(target: IsModule) extends SingleTargetAnnotation[IsModule] {
+  def duplicate(rt: IsModule): TargetBoxAnnotation = TargetBoxAnnotation(rt)
 }
 
 class SimReadyValidRecord(es: Seq[(String, ReadyValidIO[Data])]) extends Record {
@@ -249,7 +249,7 @@ class SimWrapper(config: SimWrapperConfig)(implicit val p: Parameters) extends M
 
   // Indicates SimulationMapping which module we want to replace with the simulator
   annotate(new ChiselAnnotation { def toFirrtl =
-    TargetBoxAnnotation(outer.toNamed.toTarget.ref(target.instanceName))
+    TargetBoxAnnotation(target.toAbsoluteTarget)
   })
 
   target.io.hostReset := reset.toBool

--- a/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala
@@ -224,7 +224,7 @@ class LLCModel(cfg: BaseConfig)(implicit p: Parameters) extends NastiModule()(p)
 
   val fill_empty_way = !hit_valid && empty_valid
 
-  val lsfr = LFSR16(true.B)
+  val lsfr = Chisel.LFSR16(true.B)
   val evict_way_sel = UIntToOH(lsfr(llcKey.ways.maxBits - 1, 0) & ((1.U << io.settings.wayBits) - 1.U))
   val evict_way_is_dirty = (VecInit(s1_metadata.map(_.dirty)).asUInt & evict_way_sel).orR
   val evict_way_tag = Mux1H(evict_way_sel, s1_metadata.map(_.tag))

--- a/sim/midas/src/main/scala/midas/passes/AssertPass.scala
+++ b/sim/midas/src/main/scala/midas/passes/AssertPass.scala
@@ -49,8 +49,7 @@ private[passes] class AssertPass extends firrtl.Transform {
         val idx = asserts(mname).size
         val name = namespace newName s"assert_$idx"
         val clockName = clk match {
-          case Reference(name, _) => name
-          case WRef(name, _, _, _) => name
+          case Reference(name, _, _, _) => name
           case o => throw new RuntimeException(s"$clk")
         }
         asserts(mname)(en.serialize) = (idx, name, clockName)


### PR DESCRIPTION
These are the changes I needed to make when updating FireSim to work with Chisel 3.4 and FIRRTL 1.4.  I'm going to point to this branch in a ChipYard PR that will also point to the version of RC and barstools that I know to be capable of running Chisel->GoldenGate->Verilog without blowing up (and was passing midas-level `run-asm-tests` but that isn't being regressed yet).

NOTE: I also need to pass `--no-dce` when running GoldenGate because I'm hitting a case where DCE seems to be removing a dont_touch'd AutoCounter node.