### PR TITLE
cannot import name docevents

### DIFF
--- a/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
+++ b/docs/Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
@@ -116,6 +116,7 @@ Again on the ``t2.nano`` instance, do the following:
 
     sudo yum -y install python-pip
     sudo pip install boto3
+    sudo pip install --upgrade awscli
     wget https://raw.githubusercontent.com/firesim/firesim/master/scripts/aws-setup.py
     python aws-setup.py
 


### PR DESCRIPTION
The 
```
yum install python-pip
pip install boto3
```
sequence wouldn't let me run successfully aws-setup. It turns out that the developers of the boto package did something (described here in detail: [https://github.com/boto/boto3/issues/2596](https://github.com/boto/boto3/issues/2596)) that requires the awscli package to be upgraded via pip.