### PR TITLE
Bump AMI string

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -11,7 +11,7 @@ from fabric.api import local, hide
 rootLogger = logging.getLogger()
 
 # this needs to be updated whenever the FPGA Dev AMI changes
-f1_ami_name = "FPGA Developer AMI - 1.6.0-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-0b1edf08d56c2da5c.4"
+f1_ami_name = "FPGA Developer AMI - 1.6.1-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-01d5f32a3d517960b.4"
 
 def aws_resource_names():
     """ Get names for various aws resources the manager relies on. For example:


### PR DESCRIPTION
Bumps the AWS AMI string to match with the new AMI used for FireSim (1.6.1).