### PR TITLE
fix compile warnings: Midas Bits

### DIFF
--- a/sim/midas/src/main/scala/midas/models/dram/DramCommon.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/DramCommon.scala
@@ -546,7 +546,7 @@ class RankStateTracker(key: DramOrganizationParams) extends Module with HasDRAMM
   val bankTrackers = Seq.fill(key.maxBanks)(Module(new BankStateTracker(key)).io)
   io.rank.banks.zip(bankTrackers) foreach { case (out, bank) => out := bank.out }
 
-  bankTrackers.zip(io.cmdBankOH.toBools) foreach { case (bank, cmdUsesThisBank)  =>
+  bankTrackers.zip(io.cmdBankOH.asBools) foreach { case (bank, cmdUsesThisBank)  =>
     bank.timings := io.timings
     bank.selectedCmd := io.selectedCmd
     bank.cmdUsesThisBank := cmdUsesThisBank && io.cmdUsesThisRank

--- a/sim/midas/src/main/scala/midas/models/dram/FIFOMASModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FIFOMASModel.scala
@@ -121,7 +121,7 @@ class FIFOMASModel(cfg: FIFOMASConfig)(implicit p: Parameters) extends TimingMod
     }
   }
 
-  rankStateTrackers.zip(UIntToOH(cmdRank).toBools) foreach { case (state, cmdUsesThisRank)  =>
+  rankStateTrackers.zip(UIntToOH(cmdRank).asBools) foreach { case (state, cmdUsesThisRank)  =>
     state.io.selectedCmd := selectedCmd
     state.io.cmdBankOH := cmdBankOH
     state.io.cmdRow := cmdRow
@@ -159,7 +159,7 @@ class FIFOMASModel(cfg: FIFOMASConfig)(implicit p: Parameters) extends TimingMod
   cmdMonitor.io.row := cmdRow
   cmdMonitor.io.autoPRE := casAutoPRE
 
-  val powerStats = (rankStateTrackers).zip(UIntToOH(cmdRank).toBools) map {
+  val powerStats = (rankStateTrackers).zip(UIntToOH(cmdRank).asBools) map {
     case (rankState, cmdUsesThisRank) =>
       val powerMonitor = Module(new RankPowerMonitor(cfg.dramKey))
       powerMonitor.io.selectedCmd := selectedCmd

--- a/sim/midas/src/main/scala/midas/models/dram/FRFCFSModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FRFCFSModel.scala
@@ -242,7 +242,7 @@ class FirstReadyFCFSModel(cfg: FirstReadyFCFSConfig)(implicit p: Parameters) ext
     bankHasReadyEntries(Cat(newReference.bits.rankAddr, newReference.bits.bankAddr)) := true.B
   }
 
-  rankStateTrackers.zip(UIntToOH(cmdRank).toBools) foreach { case (state, cmdUsesThisRank)  =>
+  rankStateTrackers.zip(UIntToOH(cmdRank).asBools) foreach { case (state, cmdUsesThisRank)  =>
     state.io.selectedCmd := selectedCmd
     state.io.cmdBankOH := cmdBankOH
     state.io.cmdRow := cmdRow
@@ -277,7 +277,7 @@ class FirstReadyFCFSModel(cfg: FirstReadyFCFSConfig)(implicit p: Parameters) ext
   cmdMonitor.io.row := cmdRow
   cmdMonitor.io.autoPRE := casAutoPRE
 
-  val powerStats = (rankStateTrackers).zip(UIntToOH(cmdRank).toBools) map {
+  val powerStats = (rankStateTrackers).zip(UIntToOH(cmdRank).asBools) map {
     case (rankState, cmdUsesThisRank) =>
       val powerMonitor = Module(new RankPowerMonitor(cfg.dramKey))
       powerMonitor.io.selectedCmd := selectedCmd

--- a/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala
@@ -164,7 +164,7 @@ class LLCModel(cfg: BaseConfig)(implicit p: Parameters) extends NastiModule()(p)
   d_array_busy.io.set.bits := DontCare
   d_array_busy.io.decr := false.B
 
-  val mshr_mask_vec = UIntToOH1(io.settings.activeMSHRs, llcKey.mshrs.max).toBools
+  val mshr_mask_vec = UIntToOH1(io.settings.activeMSHRs, llcKey.mshrs.max).asBools
   val mshrs =  RegInit(VecInit(Seq.fill(llcKey.mshrs.max)(MSHR(llcKey))))
   // Enable only active MSHRs as requested in the runtime configuration
   mshrs.zipWithIndex.foreach({ case (m, idx) => m.enabled := mshr_mask_vec(idx) })
@@ -233,7 +233,7 @@ class LLCModel(cfg: BaseConfig)(implicit p: Parameters) extends NastiModule()(p)
   val evict_dirty_way  = do_evict && evict_way_is_dirty
   val dirty_line_addr  = io.settings.regenPhysicalAddress(s1_set_addr, evict_way_tag)
 
-  val selected_way_OH = Mux(hit_valid, hit_way_sel, Mux(empty_valid, empty_way_sel, evict_way_sel)).toBools
+  val selected_way_OH = Mux(hit_valid, hit_way_sel, Mux(empty_valid, empty_way_sel, evict_way_sel)).asBools
 
   val md_update = s1_metadata.zip(selected_way_OH) map { case (md, sel) =>
     val next = WireInit(md)

--- a/sim/midas/src/main/scala/midas/models/dram/Util.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/Util.scala
@@ -65,7 +65,7 @@ class ProgrammableSubAddr(
   // Used to produce a bit vector of enables from a mask
   def maskToOH(): UInt = {
     val decodings = Seq.tabulate(maskBits)({ i => ((1 << (1 << (i + 1))) - 1).U})
-    MuxCase(1.U, (mask.toBools.zip(decodings)).reverse)
+    MuxCase(1.U, (mask.asBools.zip(decodings)).reverse)
   }
 
   val registers = Seq(
@@ -154,7 +154,7 @@ class DynamicLatencyPipe[T <: Data] (
 
   when (do_enq) {
     latencies(enq_ptr.value) := io.tCycle + io.latency
-    pendingRegisters(enq_ptr.value) := io.latency != 1.U
+    pendingRegisters(enq_ptr.value) := io.latency =/= 1.U
   }
 
   io.deq.valid := !empty && done(deq_ptr.value)
@@ -238,7 +238,7 @@ class CollapsingBuffer[T <: Data](gen: T, depth: Int) extends Module {
     }
   }
 
-  val lastEntry = UIntToOH(io.programmableDepth).toBools.take(depth).reverse
+  val lastEntry = UIntToOH(io.programmableDepth).asBools.take(depth).reverse
   val entries = Seq.fill(depth)(
     RegInit({val w = Wire(Valid(gen.cloneType)); w.valid := false.B; w.bits := DontCare; w}))
   io.entries := entries
@@ -492,7 +492,7 @@ class HostLatencyHistogram (
   when (io.cycleCountEnable) { cycle := cycle + 1.U }
 
   // When the host accepts an AW/AR enq the current cycle
-  (queues map { _.io.enq }).zip(UIntToOH(io.reqId.bits).toBools).foreach({ case (enq, sel) =>
+  (queues map { _.io.enq }).zip(UIntToOH(io.reqId.bits).asBools).foreach({ case (enq, sel) =>
      enq.valid := io.reqId.valid && sel
      enq.bits := cycle
      assert(!(enq.valid && !enq.ready), "Multiple requests issued to same ID")
@@ -500,7 +500,7 @@ class HostLatencyHistogram (
 
   val deqAddrOH = UIntToOH(io.respId.bits)
   val reqCycle = Mux1H(deqAddrOH, (queues map { _.io.deq.bits }))
-  (queues map { _.io.deq }).zip(deqAddrOH.toBools).foreach({ case (deq, sel) =>
+  (queues map { _.io.deq }).zip(deqAddrOH.asBools).foreach({ case (deq, sel) =>
     deq.ready := io.respId.valid && sel
     assert(deq.valid || !deq.ready, "Received an unexpected response")
   })


### PR DESCRIPTION
**Type of change**: paying off technical debt

**Impact**: no functional change

**What was changed**
fix compile warnings:
```
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/DramCommon.scala:548:33: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   bankTrackers.zip(io.cmdBankOH.toBools) foreach { case (bank, cmdUsesThisBank)  =>
[warn]                                 ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/FIFOMASModel.scala:124:43: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   rankStateTrackers.zip(UIntToOH(cmdRank).toBools) foreach { case (state, cmdUsesThisRank)  =>
[warn]                                           ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/FIFOMASModel.scala:162:62: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   val powerStats = (rankStateTrackers).zip(UIntToOH(cmdRank).toBools) map {
[warn]                                                              ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/FRFCFSModel.scala:245:43: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   rankStateTrackers.zip(UIntToOH(cmdRank).toBools) foreach { case (state, cmdUsesThisRank)  =>
[warn]                                           ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/FRFCFSModel.scala:280:62: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   val powerStats = (rankStateTrackers).zip(UIntToOH(cmdRank).toBools) map {
[warn]                                                              ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala:167:76: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   val mshr_mask_vec = UIntToOH1(io.settings.activeMSHRs, llcKey.mshrs.max).toBools
[warn]                                                                            ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala:236:101: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   val selected_way_OH = Mux(hit_valid, hit_way_sel, Mux(empty_valid, empty_way_sel, evict_way_sel)).toBools
[warn]                                                                                                     ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/Util.scala:68:24: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]     MuxCase(1.U, (mask.toBools.zip(decodings)).reverse)
[warn]                        ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/Util.scala:157:51: method != in class UInt is deprecated (since 3.0): Use '=/=', which avoids potential precedence problems
[warn]     pendingRegisters(enq_ptr.value) := io.latency != 1.U
[warn]                                                   ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/Util.scala:241:50: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   val lastEntry = UIntToOH(io.programmableDepth).toBools.take(depth).reverse
[warn]                                                  ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/Util.scala:494:57: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   (queues map { _.io.enq }).zip(UIntToOH(io.reqId.bits).toBools).foreach({ case (enq, sel) =>
[warn]                                                         ^
[warn] /firesim/sim/midas/src/main/scala/midas/models/dram/Util.scala:502:43: method do_toBools in class Bits is deprecated (since 3.2): Use asBools instead
[warn]   (queues map { _.io.deq }).zip(deqAddrOH.toBools).foreach({ case (deq, sel) =>
[warn]                                           ^
```