### PR TITLE
bump chipyard for rc chisel firrtl 3.4.1.x

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,27 +10,32 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0db1aebdbcdd84100
+agfi=agfi-07a58170fd418c6dc
+deploytripletoverride=None
+customruntimeconfig=None
+
+[firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
+agfi=agfi-07f91ee816a00a758
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-09a60aafe779cce44
+agfi=agfi-01be89add09290c16
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-016fd119937b75d31
+agfi=agfi-026b8446b58e41566
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
-agfi=agfi-04a21c2bc4ba68906
+agfi=agfi-0898811103d833964
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-0284e09b2f39a5b49
+agfi=agfi-060edc638f564f602
 deploytripletoverride=None
 customruntimeconfig=None
 


### PR DESCRIPTION
Haven't found any compile-time changes needed inside firesim for bumping RC in ucb-bar/chipyard#742.  The CI looks like it is running alright locally.  Opening a pr with the chipyard bump so that the CI will run cleanly in the cloud as well.