### PR TITLE
provide vcs -top to avoid spurious toplevel in hierarchy (#618)

### DIFF
--- a/sim/midas/src/main/cc/rtlsim/Makefrag-vcs
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-vcs
@@ -18,6 +18,7 @@
 VCS ?= vcs -full64
 override VCS_FLAGS := -quiet -timescale=1ns/1ps +v2k +rad +vcs+initreg+random +vcs+lic+wait \
 	-notice -line +lint=all,noVCDE,noONGS,noUI -quiet -debug_pp +no_notifier -cpp $(CXX) \
+	-top emul \
 	-Mdir=$(GEN_DIR)/$(DESIGN)-debug.csrc \
 	+vc+list \
 	-CFLAGS "$(CXXFLAGS) $(CFLAGS) -D_GNU_SOURCE -DVCS -I$(VCS_HOME)/include" \


### PR DESCRIPTION
From pg 4-69 of https://spdocs.synopsys.com/dow_retrieve/R-2020.09/vg/VCS/PDFs/vcs.pdf

VCS has the -top compile-time option for specifying the configuration that describes the
top-level configuration or module of the design. For example:vcs -top top_cfg ...If you have
coded your design to have more than one top-level module, you can enter more than one -top
option, or you can append arguments to the option using the plus delimiter. For example:-top
top_cfg+test+Using the -top option tells VCS not to create extraneous top-level modules, that
is, one that you do not specify.

fixes #618 