### PR TITLE
Make midas.passes.DedupModules respect dedup-version flags

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/Dedup.scala
+++ b/sim/midas/src/main/scala/midas/passes/Dedup.scala
@@ -17,11 +17,6 @@ import firrtl.options.{HasShellOptions, PreservesAll, ShellOption}
 import scala.collection.mutable
 
 
-/** A component, e.g. register etc. Must be declared only once under the TopAnnotation */
-case class NoDedupAnnotation(target: ModuleName) extends SingleTargetAnnotation[ModuleName] {
-  def duplicate(n: ModuleName): NoDedupAnnotation = NoDedupAnnotation(n)
-}
-
 /** If this [[firrtl.annotations.Annotation Annotation]] exists in an [[firrtl.AnnotationSeq AnnotationSeq]],
   * then the [[firrtl.transforms.DedupModules]] transform will *NOT* be run on the circuit.
   *  - set with '--no-dedup'
@@ -52,11 +47,11 @@ class DedupModules extends Transform with DependencyAPIMigration with PreservesA
     * @return A transformed Firrtl AST
     */
   def execute(state: CircuitState): CircuitState = {
-    if (state.annotations.contains(NoCircuitDedupAnnotation)) {
+    if (state.annotations.contains(NoCircuitDedupClassicAnnotation)) {
       state
     } else {
       // Don't try deduping the main module of the circuit
-      val noDedups = state.circuit.main +: state.annotations.collect { case NoDedupAnnotation(ModuleName(m, c)) => m }
+      val noDedups = state.circuit.main +: state.annotations.collect { case NoDedupAnnotation(ModuleTarget(c, m)) => m }
       val (newC, renameMap) = run(state.circuit, noDedups, state.annotations)
       state.copy(circuit = newC, renames = Some(renameMap))
     }


### PR DESCRIPTION
Currently, `midas.passes.DedupModules` actually checks for the mainline `NoCircuitDedupAnnotation`, not the new `NoCircuitDedupClassicAnnotation`, so the default flags end up disabling all deduplication with no way to selectively enable "Dedup Classic".

This fixes that issue and makes both versions respect the same mainline `NoDedupAnnotation` on a given module.