### PR TITLE
Fix Two GG-Compile Time Errors

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -37,7 +37,7 @@ deploytriplet=None
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=F70MHz_BaseF1Config
+PLATFORM_CONFIG=F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,32 +10,27 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-07a6234b949180f82
-deploytripletoverride=None
-customruntimeconfig=None
-
-[firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-03513bfb04b58e576
+agfi=agfi-0db1aebdbcdd84100
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0e0438d20d6e6a772
+agfi=agfi-09a60aafe779cce44
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0eb2813f9b2caafe8
+agfi=agfi-016fd119937b75d31
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
-agfi=agfi-0081875d70576f3b9
+agfi=agfi-04a21c2bc4ba68906
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-015ca015ed4636e69
+agfi=agfi-0284e09b2f39a5b49
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/midas/src/main/scala/midas/passes/AutoCounterCoverTransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/AutoCounterCoverTransform.scala
@@ -31,9 +31,6 @@ class FireSimPropertyLibrary extends BasePropertyLibrary {
   def generateProperty(prop_param: BasePropertyParameters)(implicit sourceInfo: SourceInfo) {
     //requireIsHardware(prop_param.cond, "condition covered for counter is not hardware!")
     if (!(prop_param.cond.isLit) && chisel3.experimental.DataMirror.internal.isSynthesizable(prop_param.cond)) {
-      dontTouch(prop_param.cond)
-      dontTouch(chisel3.Module.reset)
-      dontTouch(chisel3.Module.clock)
       annotate(new ChiselAnnotation {
         val implicitClock = chisel3.Module.clock
         val implicitReset = chisel3.Module.reset

--- a/sim/midas/src/main/scala/midas/passes/fame/PromoteSubmodule.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/PromoteSubmodule.scala
@@ -38,7 +38,7 @@ class PromoteSubmodule extends Transform {
          * Otherwise, the parent (and possibly grandparent) would potentially
          * need to be replicated into versions with and without the promoted child.
          */
-        assert(instTarget.isLocal)
+        assert(instTarget.isLocal, s"InstanceTarget ${instTarget} must be local")
         (instTarget.module, instTarget.instance)
     }
     val annotatedInstanceSet = annotatedInstances.toSet


### PR DESCRIPTION
Fixes two bugs that break default target elaboration on dev, this should enable the RC bump to proceed forward.

- Pulls in a update to DedupModules that fixes a loss of connectivity when using Chisel bulk connects 

- As a workaround, removes now-unneeded `DontTouchAnnotations` emitted by the AutoCounter cover implementation. These were being emitted into modules that were later inlined. I suspect they should be renamed to point to nodes in the parent but, for still unknown reasons, weren't. This wasn't a problem previously because, until 5c890ead6, we were never running `InlineInstances`.  

It might be worthwhile to regenerate AGFIs for this change. Alternatively it can be folded into the RC bump. 