### PR TITLE
 #695 must mixin WithAutoILA to platform config to populate ILA

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -14,14 +14,14 @@
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.QuadRocketConfig
-PLATFORM_CONFIG=F90MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.QuadRocketConfig
-PLATFORM_CONFIG=F90MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -30,14 +30,14 @@ deploytriplet=None
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=F65MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=F65MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -46,7 +46,7 @@ deploytriplet=None
 [firesim-cva6-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
-PLATFORM_CONFIG=F90MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -55,7 +55,7 @@ deploytriplet=None
 [firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
-PLATFORM_CONFIG=F110MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F110MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -64,7 +64,7 @@ deploytriplet=None
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=MCRams_F90MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_MCRams_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -73,7 +73,7 @@ deploytriplet=None
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_SupernodeFireSimRocketConfig
-PLATFORM_CONFIG=F85MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F85MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -81,7 +81,7 @@ deploytriplet=None
 [firesim-rocket-singlecore-no-nic-l2-llc4mb-ddr3-half-freq-uncore]
 DESIGN=FireSim
 TARGET_CONFIG=FireSimMulticlockRocketConfig
-PLATFORM_CONFIG=F90MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 

--- a/sim/firesim-lib/src/main/scala/configs/CompilerConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/CompilerConfigs.scala
@@ -69,6 +69,11 @@ class WithILATopWiringTransform extends Config((site, here, up) => {
   case HostTransforms => Dependency[firesim.passes.ILATopWiringTransform] +: up(HostTransforms, site)
 })
 
+// Tells ILATopWiringTransform to actually populate the ILA
+class WithAutoILA extends Config((site, here, up) => {
+  case midas.EnableAutoILA => true
+})
+
 // Implements the AutoCounter performace counters features
 class WithAutoCounter extends Config((site, here, up) => {
   case midas.EnableAutoCounter => true

--- a/sim/firesim-lib/src/main/scala/passes/ILATopWiring.scala
+++ b/sim/firesim-lib/src/main/scala/passes/ILATopWiring.scala
@@ -3,6 +3,7 @@
 
 package firesim.passes
 
+import midas.EnableAutoILA
 import midas.targetutils.FirrtlFpgaDebugAnnotation
 import midas.stage.phases.ConfigParametersAnnotation
 
@@ -141,8 +142,10 @@ class ILATopWiringTransform extends Transform with DependencyAPIMigration {
   }
 
   def execute(state: CircuitState): CircuitState = {
+    val p = state.annotations.collectFirst({ case ConfigParametersAnnotation(p)  => p }).get
+    val enableTransform = p(EnableAutoILA)
     val ilaannos = state.annotations.collect {
-      case a @ (_: FirrtlFpgaDebugAnnotation) => a
+      case a @ (_: FirrtlFpgaDebugAnnotation) if enableTransform => a
     }
 
     //Take debug annotation and make them into TopWiring annotations
@@ -150,7 +153,6 @@ class ILATopWiringTransform extends Transform with DependencyAPIMigration {
       case p => p.map { case FirrtlFpgaDebugAnnotation(target) => TopWiringAnnotation(target, s"ila_")  }
     }
 
-    val p = state.annotations.collectFirst({ case ConfigParametersAnnotation(p)  => p }).get
     val dir = state.annotations.collectFirst({ case TargetDirAnnotation(targetDir) => new File(targetDir) }).get
 
     val dataDepth = p(ILADepthKey)

--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -19,6 +19,9 @@ case object Platform extends Field[(Parameters) => PlatformShim]
 case object SynthAsserts extends Field[Boolean]
 case object SynthPrints extends Field[Boolean]
 
+// When False FpgaDebug() annotations are ignored
+case object EnableAutoILA extends Field[Boolean](false)
+
 // Auto Counter Switches
 case object EnableAutoCounter extends Field[Boolean](false)
 /**


### PR DESCRIPTION
Addresses part of #695 by adding a new `WithAutoILA` PLATFORM_CONFIG mixin that is required to enable the AutoILA population.  This will enable us to keep interesting `FpgaDebug()` annotations in our design or to add default annotations in FireSim IP.