### PR TITLE
Remove unused import from UARTBridge.scala

### DIFF
--- a/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala
@@ -8,7 +8,7 @@ import chisel3.util._
 import chisel3.experimental.{DataMirror, Direction}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem.PeripheryBusKey
-import sifive.blocks.devices.uart.{UARTPortIO, PeripheryUARTKey, UARTParams}
+import sifive.blocks.devices.uart.{UARTPortIO, UARTParams}
 
 //Note: This file is heavily commented as it serves as a bridge walkthrough
 //example in the FireSim docs


### PR DESCRIPTION
The PeripheryUARTKey import is unused in this file.