### PR TITLE
Fix VCS-related breakages in MIDASExamples, SynthUnittests

### DIFF
--- a/sim/midas/src/main/cc/rtlsim/Makefrag-vcs
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-vcs
@@ -18,7 +18,7 @@
 VCS ?= vcs -full64
 override VCS_FLAGS := -quiet -timescale=1ns/1ps +v2k +rad +vcs+initreg+random +vcs+lic+wait \
 	-notice -line +lint=all,noVCDE,noONGS,noUI -quiet -debug_pp +no_notifier -cpp $(CXX) \
-	-top emul \
+	-top $(TB) \
 	-Mdir=$(GEN_DIR)/$(DESIGN)-debug.csrc \
 	+vc+list \
 	-CFLAGS "$(CXXFLAGS) $(CFLAGS) -D_GNU_SOURCE -DVCS -I$(VCS_HOME)/include" \

--- a/sim/midas/src/main/cc/unittest/Makefrag
+++ b/sim/midas/src/main/cc/unittest/Makefrag
@@ -40,6 +40,7 @@ $(GEN_DIR)/$(DESIGN).fir $(GEN_DIR)/$(DESIGN).behav_srams.v: $(scala_srcs)
 $(GEN_DIR)/$(DESIGN).v: $(GEN_DIR)/$(DESIGN).fir
 	cd $(BASE_DIR) && $(SBT) "project $(SBT_PROJECT); \
 		runMain firrtl.stage.FirrtlMain -i $< -o $@ \
+		-td $(GEN_DIR) \
 		-faf $(GEN_DIR)/$(DESIGN).anno.json -X verilog"
 
 emul_v     := $(GEN_DIR)/$(DESIGN).v

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -62,8 +62,8 @@ driver_dir = $(firesim_base_dir)/src/main/cc
 firesim_lib_dir = $(firesim_base_dir)/firesim-lib/src/main/cc/
 DRIVER_H = $(shell find $(driver_dir) -name "*.h")
 DRIVER_CC := $(driver_dir)/midasexamples/Driver.cc \
-			$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))  \
-			$(RISCV)/lib/libfesvr.a \
+		$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))  \
+		$(RISCV)/lib/libfesvr.a
 
 TARGET_CXX_FLAGS := -L$(RISCV)/lib -DDESIGNDRIVERCLASS=$(DESIGN)_t -DDESIGNNAME_$(DESIGN) -I$(driver_dir) -I$(RISCV)/include -I$(driver_dir)/midasexamples -g
 TARGET_LD_FLAGS :=

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -65,7 +65,7 @@ DRIVER_CC := $(driver_dir)/midasexamples/Driver.cc \
 		$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))  \
 		$(RISCV)/lib/libfesvr.a
 
-TARGET_CXX_FLAGS := -L$(RISCV)/lib -DDESIGNDRIVERCLASS=$(DESIGN)_t -DDESIGNNAME_$(DESIGN) -I$(driver_dir) -I$(RISCV)/include -I$(driver_dir)/midasexamples -g
+TARGET_CXX_FLAGS := -DDESIGNDRIVERCLASS=$(DESIGN)_t -DDESIGNNAME_$(DESIGN) -I$(driver_dir) -I$(RISCV)/include -I$(driver_dir)/midasexamples -g
 TARGET_LD_FLAGS :=
 
 ##########################

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -62,9 +62,10 @@ driver_dir = $(firesim_base_dir)/src/main/cc
 firesim_lib_dir = $(firesim_base_dir)/firesim-lib/src/main/cc/
 DRIVER_H = $(shell find $(driver_dir) -name "*.h")
 DRIVER_CC := $(driver_dir)/midasexamples/Driver.cc \
-             $(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/*)))  \
+			$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))  \
+			$(RISCV)/lib/libfesvr.a \
 
-TARGET_CXX_FLAGS := -DDESIGNDRIVERCLASS=$(DESIGN)_t -DDESIGNNAME_$(DESIGN) -I$(driver_dir) -I$(firesim_lib_dir) -I$(driver_dir)/midasexamples -g
+TARGET_CXX_FLAGS := -L$(RISCV)/lib -DDESIGNDRIVERCLASS=$(DESIGN)_t -DDESIGNNAME_$(DESIGN) -I$(driver_dir) -I$(RISCV)/include -I$(driver_dir)/midasexamples -g
 TARGET_LD_FLAGS :=
 
 ##########################


### PR DESCRIPTION
Fixes three breakages: 
- ML sim uses the threading library in fesvr (yes.), so we need to include that in compilations for ML sim
- Black box verilog for unittests was getting dumped into `sim/` because no target-dir was being provided
- The vcs makefrag is used in the unittests, and there the top-level module is different