### PR TITLE
[printf] Support %c format specifiers

### DIFF
--- a/sim/midas/src/main/cc/bridges/synthesized_prints.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.cc
@@ -157,7 +157,7 @@ void synthesized_prints_t::print_format(const char* fmt, print_vars_t* vars, pri
     if (*fmt == '%' && fmt[1] != '%') {
       mpz_t* value = vars->data[k];
       char* v = NULL;
-      if (fmt[1] == 's') {
+      if (fmt[1] == 's' || fmt[1] == 'c') {
         size_t size;
         v = (char*)mpz_export(NULL, &size, 1, sizeof(char), 0, 0, *value);
         for (size_t j = 0 ; j < size ; j++) printstream->put(v[j]);

--- a/sim/src/main/scala/midasexamples/PrintfModule.scala
+++ b/sim/src/main/scala/midasexamples/PrintfModule.scala
@@ -40,6 +40,10 @@ class PrintfModuleDUT(printfPrefix: String = "SYNTHESIZED_PRINT ") extends Modul
   childInst.cycle := cycle
 
   printf(SynthesizePrintf("thi$!sn+taS/\neName", s"${printfPrefix}CYCLE: %d constantArgument: %x\n", cycle, 1.U(8.W)))
+  // Check character-type format specifier; restrict to printable range to play
+  // nice with our ScalaTest utilities
+  val ch = Mux(cycle(7,0) > 32.U && cycle(7,0) < 127.U, cycle(7,0), 32.U(8.W))
+  printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d Char: %c\n", cycle, ch))
 }
 
 class PrintfModuleChild(printfPrefix: String) extends MultiIOModule {

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -216,7 +216,8 @@ class MulticlockPrintF1Test extends TutorialSuite("MulticlockPrintfModule",
   diffSynthesizedLog("synthprinttest.out1",
     stdoutPrefix = "SYNTHESIZED_PRINT_HALFRATE ",
     synthPrefix = "SYNTHESIZED_PRINT_HALFRATE ",
-    synthLinesToDrop = 4) // Corresponds to a single cycle of extra output
+    // Corresponds to a single cycle of extra output.
+    synthLinesToDrop = 5)
 }
 
 class MulticlockAutoCounterF1Test extends TutorialSuite("MulticlockAutoCounterModule",

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -172,7 +172,7 @@ class PrintfCycleBoundsTestBase(startCycle: Int, endCycle: Int) extends Tutorial
       s"+print-start=${startCycle}",
       s"+print-end=${endCycle}"
     )) {
-  checkPrintCycles("synthprinttest.out0", startCycle, endCycle, linesPerCycle = 4)
+  checkPrintCycles("synthprinttest.out0", startCycle, endCycle, linesPerCycle = 5)
 }
 
 class PrintfCycleBoundsF1Test extends PrintfCycleBoundsTestBase(startCycle = 172, endCycle = 9377)


### PR DESCRIPTION
See: https://groups.google.com/g/firesim/c/jSDHYbiSpuQ and #592 

It seems %N and %n are handled by chisel and do not show up in emitted format strings.