### PR TITLE
Test FMR of threaded midasexamples

### DIFF
--- a/sim/src/main/cc/midasexamples/Driver.cc
+++ b/sim/src/main/cc/midasexamples/Driver.cc
@@ -63,8 +63,12 @@
 #include "Regfile.h"
 #elif defined DESIGNNAME_MultiRegfile
 #include "MultiRegfile.h"
+#elif defined DESIGNNAME_MultiRegfileFMR
+#include "MultiRegfileFMR.h"
 #elif defined DESIGNNAME_MultiSRAM
 #include "MultiSRAM.h"
+#elif defined DESIGNNAME_MultiSRAMFMR
+#include "MultiSRAMFMR.h"
 #elif defined DESIGNNAME_NestedModels
 #include "NestedModels.h"
 #elif defined DESIGNNAME_MultiReg

--- a/sim/src/main/cc/midasexamples/MultiRegfileFMR.h
+++ b/sim/src/main/cc/midasexamples/MultiRegfileFMR.h
@@ -1,0 +1,18 @@
+// See LICENSE for license details.
+
+#include "simif.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <utility>
+
+class MultiRegfileFMR_t: virtual simif_t
+{
+ public:
+  MultiRegfileFMR_t(int argc, char** argv) {}
+  void run() {
+    target_reset();
+    step(10000);
+  }
+};

--- a/sim/src/main/cc/midasexamples/MultiSRAMFMR.h
+++ b/sim/src/main/cc/midasexamples/MultiSRAMFMR.h
@@ -1,0 +1,7 @@
+#include "MultiRegfileFMR.h"
+
+class MultiSRAMFMR_t: public MultiRegfileFMR_t
+{
+ public:
+  MultiSRAMFMR_t(int argc, char** argv) : MultiRegfileFMR_t(argc, argv) {}
+};

--- a/sim/src/main/scala/midasexamples/MultiRegfile.scala
+++ b/sim/src/main/scala/midasexamples/MultiRegfile.scala
@@ -22,15 +22,11 @@ class RegfileInner extends Module {
   }
 }
 
-object MultiRegfile {
-  val nCopies = 5
-}
-
-class MultiRegfileDUT extends Module {
+class MultiRegfileDUT(nCopies: Int) extends Module {
   val io = IO(new Bundle {
-    val accesses = Vec(MultiRegfile.nCopies, new RegfileIO)
+    val accesses = Vec(nCopies, new RegfileIO)
   })
-  val rfs = Seq.fill(MultiRegfile.nCopies)(Module(new RegfileInner))
+  val rfs = Seq.fill(nCopies)(Module(new RegfileInner))
   rfs.zip(io.accesses).foreach {
     case (rf, rfio) =>
       rf.io <> rfio
@@ -38,4 +34,10 @@ class MultiRegfileDUT extends Module {
   }
 }
 
-class MultiRegfile(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiRegfileDUT)
+object MultiRegfile {
+  val nCopiesToTest = 5
+  val nCopiesToTime = 17
+}
+
+class MultiRegfile(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiRegfileDUT(MultiRegfile.nCopiesToTest))
+class MultiRegfileFMR(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiRegfileDUT(MultiRegfile.nCopiesToTime))

--- a/sim/src/main/scala/midasexamples/MultiSRAM.scala
+++ b/sim/src/main/scala/midasexamples/MultiSRAM.scala
@@ -28,11 +28,11 @@ class SRAMInner extends Module {
   }
 }
 
-class MultiSRAMDUT extends Module {
+class MultiSRAMDUT(nCopies: Int) extends Module {
   val io = IO(new Bundle {
-    val accesses = Vec(MultiRegfile.nCopies, new RegfileIO)
+    val accesses = Vec(nCopies, new RegfileIO)
   })
-  val rfs = Seq.fill(MultiRegfile.nCopies)(Module(new SRAMInner))
+  val rfs = Seq.fill(nCopies)(Module(new SRAMInner))
   rfs.zip(io.accesses).foreach {
     case (rf, rfio) =>
       rf.io <> rfio
@@ -40,4 +40,5 @@ class MultiSRAMDUT extends Module {
   }
 }
 
-class MultiSRAM(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiSRAMDUT)
+class MultiSRAM(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiSRAMDUT(MultiRegfile.nCopiesToTest))
+class MultiSRAMFMR(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiSRAMDUT(MultiRegfile.nCopiesToTime))

--- a/sim/src/main/scala/midasexamples/MultiSRAM.scala
+++ b/sim/src/main/scala/midasexamples/MultiSRAM.scala
@@ -10,6 +10,10 @@ import freechips.rocketchip.config.Parameters
 import midas.widgets.PeekPokeBridge
 import midas.targetutils._
 
+/** A module that wraps a multi-ported, synchronous-read memory.
+  *
+  * @see [[RegfileInner]] for an analogous module with an asynchronous-read memory
+  */
 class SRAMInner extends Module {
   val io = IO(new RegfileIO)
   val mem = SyncReadMem(21, UInt(64.W))
@@ -28,6 +32,11 @@ class SRAMInner extends Module {
   }
 }
 
+/** A DUT to demonstrate threading of set of identical [[SRAMInner]] instances. This
+  * helps test the behavior of the threading optimization with synchronous-read memories.
+  *
+  * @see [[MultiRegfileDUT]] for an analogous target using` optimizable memories
+  */
 class MultiSRAMDUT(nCopies: Int) extends Module {
   val io = IO(new Bundle {
     val accesses = Vec(nCopies, new RegfileIO)
@@ -40,5 +49,21 @@ class MultiSRAMDUT(nCopies: Int) extends Module {
   }
 }
 
+/** A top-level target module that instantiates a small number of inner [[SRAMInner]] modules. This is used as part of
+  * [[MultiSRAMF1Test]] to test for correct behavior with a directed random peek-poke test. If the module is threaded,
+  * this can help ensure the correct behavior of the threading optimization. However, it does not directly test whether
+  * threading is successfully applied, and a simulator that unexpectedly fails to be threaded may indeed behave correctly.
+  *
+  * @see [[MultiSRAMFMR]] for a test that helps ensure threading is actually applied
+  * @see [[MultiRegfile]] for an analogous test that contains optimizable memories
+  */
 class MultiSRAM(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiSRAMDUT(MultiRegfile.nCopiesToTest))
+
+/** A top-level target module that instantiates a large number of inner [[SRAMInner]] modules. This is used as part of
+  * [[MultiSRAMFMRF1Test]] to test whether the threading optimization is actually applied. By letting a simulator run
+  * freely for many cycles, the observed FPGA-cycle-to-model-cycle ratio (FMR) can be compared to the expected slowdown
+  * from multi-threading N instances.
+  *
+  * @see [[MultiRegfileFMR]] for an analogous test that contains optimizable memories
+  */
 class MultiSRAMFMR(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new MultiSRAMDUT(MultiRegfile.nCopiesToTime))

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -230,8 +230,14 @@ class TwoAddersF1Test extends TutorialSuite("TwoAdders")
 class RegfileF1Test extends TutorialSuite("Regfile")
 
 class MultiRegfileF1Test extends TutorialSuite("MultiRegfile")
+class MultiRegfileFMRF1Test extends TutorialSuite("MultiRegfileFMR") {
+  // TODO(albert-magyar): add expectedFMR once threading works for this test on dev again
+}
 
 class MultiSRAMF1Test extends TutorialSuite("MultiSRAM")
+class MultiSRAMFMRF1Test extends TutorialSuite("MultiSRAMFMR") {
+  expectedFMR(MultiRegfile.nCopiesToTime) // No comb paths -> 1:1
+}
 
 class NestedModelsF1Test extends TutorialSuite("NestedModels")
 


### PR DESCRIPTION
This adds a test to make sure that a threaded midasexamples design has the expected FMR -- i.e., if it is as slow as would be expected for the degree of threading. This is a decent "smoke test" of whether threading is working as intended.

There is a TODO for the design that mixes threading and multi-cycle RAM models, as this seems to not be threading as intended in recent commits to dev.