### PR TITLE
FPGA Dev. AMI 1.10 Bump

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -11,7 +11,7 @@ from fabric.api import local, hide
 rootLogger = logging.getLogger()
 
 # this needs to be updated whenever the FPGA Dev AMI changes
-f1_ami_name = "FPGA Developer AMI - 1.6.1-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-01d5f32a3d517960b.4"
+f1_ami_name = "FPGA Developer AMI - 1.10.0-40257ab5-6688-4c95-97d1-e251a40fd1fc"
 
 def aws_resource_names():
     """ Get names for various aws resources the manager relies on. For example:

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -47,22 +47,23 @@ sudo yum -y install graphviz python-devel
 # used for CI
 sudo yum -y install expect
 
-python3 -m pip install -U pip setuptools
-python3 -m pip install fabric==1.14.0
-python3 -m pip install boto3==1.6.2
-python3 -m pip install colorama==0.3.7
-python3 -m pip install argcomplete==1.9.3
-python3 -m pip install graphviz==0.8.3
+# last working pip version before deprecation
+sudo pip2 install --upgrade pip==20.3.4
+sudo pip2 install fabric==1.14.0
+sudo pip2 install boto3==1.6.2
+sudo pip2 install colorama==0.3.7
+sudo pip2 install argcomplete==1.9.3
+sudo pip2 install graphviz==0.8.3
 # for some of our workload plotting scripts
-python3 -m pip install --upgrade --ignore-installed pyparsing
-python3 -m pip install numpy==1.16.6
-python3 -m pip install kiwisolver==1.1.0
-python3 -m pip install matplotlib==2.2.2
-python3 -m pip install pandas==0.22.0
+sudo pip2 install --upgrade --ignore-installed pyparsing
+sudo pip2 install numpy==1.16.6
+sudo pip2 install kiwisolver==1.1.0
+sudo pip2 install matplotlib==2.2.2
+sudo pip2 install pandas==0.22.0
 # new awscli on 1.6.0 AMI is broken with our versions of boto3
-python3 -m pip install awscli==1.15.76
+sudo pip2 install awscli==1.15.76
 
-activate-global-python-argcomplete --user
+sudo activate-global-python-argcomplete
 
 } 2>&1 | tee /home/centos/machine-launchstatus.log
 

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -47,22 +47,22 @@ sudo yum -y install graphviz python-devel
 # used for CI
 sudo yum -y install expect
 
-# these need to match what's in deploy/requirements.txt
-sudo pip2 install fabric==1.14.0
-sudo pip2 install boto3==1.6.2
-sudo pip2 install colorama==0.3.7
-sudo pip2 install argcomplete==1.9.3
-sudo pip2 install graphviz==0.8.3
+python3 -m pip install -U pip setuptools
+python3 -m pip install fabric==1.14.0
+python3 -m pip install boto3==1.6.2
+python3 -m pip install colorama==0.3.7
+python3 -m pip install argcomplete==1.9.3
+python3 -m pip install graphviz==0.8.3
 # for some of our workload plotting scripts
-sudo pip2 install --upgrade --ignore-installed pyparsing
-sudo pip2 install numpy==1.16.6
-sudo pip2 install kiwisolver==1.1.0
-sudo pip2 install matplotlib==2.2.2
-sudo pip2 install pandas==0.22.0
+python3 -m pip install --upgrade --ignore-installed pyparsing
+python3 -m pip install numpy==1.16.6
+python3 -m pip install kiwisolver==1.1.0
+python3 -m pip install matplotlib==2.2.2
+python3 -m pip install pandas==0.22.0
 # new awscli on 1.6.0 AMI is broken with our versions of boto3
-sudo pip2 install awscli==1.15.76
+python3 -m pip install awscli==1.15.76
 
-sudo activate-global-python-argcomplete
+activate-global-python-argcomplete --user
 
 } 2>&1 | tee /home/centos/machine-launchstatus.log
 


### PR DESCRIPTION
Related PRs: https://github.com/firesim/aws-fpga-firesim/pull/36

This PR updates AWS-FPGA so that FireSim can support the FPGA Developer AMI 1.10.X which contains Vivado 2020.2. To test this you need to use the FPGA Developer AMI 1.10.X (instead of 1.6.X) and you need to use the `machine-launch-script.sh` changes to properly check out all dependencies.

Things to check:
- [ ] All default AFI's work
- [ ] GG optimizations work (MCRams, MT)
- [ ] ILA works