### PR TITLE
refactor GoldenGateStage with DependencyAPI.

### DIFF
--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
@@ -2,20 +2,27 @@
 
 package midas.stage
 
-import midas.{TargetTransforms, HostTransforms}
-import midas.passes.{MidasTransforms}
-import midas.stage.phases.{CreateParametersInstancePhase, ConfigParametersAnnotation}
-
-import firrtl.{CircuitState, AnnotationSeq}
-import firrtl.annotations.{Annotation}
-import firrtl.options.{Phase, Dependency}
+import midas.{HostTransforms, TargetTransforms}
+import midas.passes.MidasTransforms
+import midas.stage.phases.{ConfigParametersAnnotation, CreateParametersInstancePhase}
+import firrtl.{AnnotationSeq, CircuitState}
+import firrtl.options.{Dependency, Phase}
 import firrtl.passes.memlib.{InferReadWrite, InferReadWriteAnnotation}
-import firrtl.stage.{Forms, FirrtlCircuitAnnotation}
+import firrtl.stage.phases.{AddCircuit, AddDefaults, AddImplicitEmitter, AddImplicitOutputFile, Checks}
+import firrtl.stage.{FirrtlCircuitAnnotation, Forms}
 import firrtl.stage.transforms.Compiler
 
 class GoldenGateCompilerPhase extends Phase with ConfigLookup {
 
-  override val prerequisites = Seq(Dependency[CreateParametersInstancePhase])
+  override val prerequisites = Seq(
+    Dependency[AddDefaults],
+    Dependency[AddImplicitEmitter],
+    Dependency[Checks],
+    Dependency[AddCircuit],
+    Dependency[AddImplicitOutputFile],
+    Dependency[CreateParametersInstancePhase]
+  )
+
   override val optionalPrerequisiteOf = Seq(Dependency[firrtl.stage.phases.WriteEmitted])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateStage.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateStage.scala
@@ -3,30 +3,41 @@
 package midas.stage
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
+import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.options.Viewer.view
+import firrtl.stage.phases.CatchExceptions
 
-import java.io.{StringWriter, PrintWriter}
+import java.io.{PrintWriter, StringWriter}
 
-class GoldenGateStage extends Stage with PreservesAll[Phase] {
+
+class GoldenGatePhase
+    extends PhaseManager(
+      targets = Seq(
+        Dependency[midas.stage.GoldenGateCompilerPhase],
+        Dependency[firrtl.stage.phases.WriteEmitted]
+      )
+    ) {
+
+  override def invalidates(a: Phase) = false
+
+  override val wrappers = Seq(CatchExceptions(_: Phase), DeletedWrapper(_: Phase))
+}
+
+class GoldenGateStage extends Stage {
+  lazy val phase = new GoldenGatePhase
+
+  override def prerequisites = phase.prerequisites
+
+  override def optionalPrerequisites = phase.optionalPrerequisites
+
+  override def optionalPrerequisiteOf = phase.optionalPrerequisiteOf
+
+  override def invalidates(a: Phase): Boolean = phase.invalidates(a)
+
   val shell: Shell = new Shell("goldengate") with GoldenGateCli
 
-  private val phases: Seq[Phase] =
-    Seq(
-        new firrtl.options.phases.GetIncludes,
-        new midas.stage.phases.CreateParametersInstancePhase,
-        new firrtl.stage.phases.AddDefaults,
-        new firrtl.stage.phases.AddImplicitEmitter,
-        new firrtl.stage.phases.Checks,
-        new firrtl.stage.phases.AddCircuit,
-        new firrtl.stage.phases.AddImplicitOutputFile,
-        new midas.stage.GoldenGateCompilerPhase,
-        new firrtl.stage.phases.WriteEmitted )
-      .map(DeletedWrapper(_))
-
-
-  def run(annotations: AnnotationSeq): AnnotationSeq = phases.foldLeft(annotations)((a, f) => f.transform(a))
+  def run(annotations: AnnotationSeq): AnnotationSeq = phase.transform(annotations)
 }
 
 object GoldenGateMain extends StageMain(new GoldenGateStage)


### PR DESCRIPTION
This refactor adds
```
    Dependency[AddDefaults],
    Dependency[AddImplicitEmitter],
    Dependency[Checks],
    Dependency[AddCircuit],
    Dependency[AddImplicitOutputFile],
    Dependency[CreateParametersInstancePhase]
```
to `GoldenGateCompilerPhase.prerequisites` and use `PhaseManager` to use dependency API to manage `GoldenGateCompilerPhase` dependency.