### PR TITLE
Arbiter Instead of DualQueue to Prevent Write Starvation

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -48,6 +48,8 @@ sudo yum -y install graphviz python-devel
 sudo yum -y install expect
 
 # these need to match what's in deploy/requirements.txt
+# last working pip version before deprecation
+sudo pip2 install --upgrade pip==20.3.4
 sudo pip2 install fabric==1.14.0
 sudo pip2 install boto3==1.6.2
 sudo pip2 install colorama==0.3.7


### PR DESCRIPTION
DualQueue can result in starvation of write request, and specifically cache eviction requests which can generate incredible tail latencies (12000 cycles in one case...).
Using a single queue and an arbiter should alleviate some of the complexity and edge cases of DualQueue.