### PR TITLE
Check sns topic permission at start of buildafi and warn user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,14 @@ commands:
             source env.sh
             make -C sim scaladoc
 
+  run-manager-pytest:
+    description: "Runs all manager pytests"
+    steps:
+      - run:
+          command: |
+            source env.sh
+            cd deploy && python -m pytest
+
   push-scaladoc-to-ghpages:
     description: "Pushes scaladoc to ghphage branch"
     steps:
@@ -119,6 +127,7 @@ jobs:
       - run-scala-test:
           test-name: "CIGroupA"
       - build-scala-doc
+      - run-manager-pytest
 
   run-test-groupB:
     executor: main-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+orbs:
+  aws-cli: circleci/aws-cli@1.0.0
 executors:
   main-env:
     docker:
@@ -117,6 +119,7 @@ commands:
       - checkout
       - machinelaunchscript
       - buildsetup
+      - aws-cli/setup
       - scala-build
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-orbs:
-  aws-cli: circleci/aws-cli@1.0.0
 executors:
   main-env:
     docker:
@@ -119,7 +117,6 @@ commands:
       - checkout
       - machinelaunchscript
       - buildsetup
-      - aws-cli/setup
       - scala-build
 
 jobs:

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -359,9 +359,11 @@ def get_snsname_arn():
     except client.exceptions.ClientError as err:
         if 'AuthorizationError' in repr(err): 
             rootLogger.critical("You don't have permissions to perform \"Topic Creation \". Required to send you email notifications. Please contact your IT administrator")
-            rootLogger.critical(err)
+
         else:
             rootLogger.critical("Unknown exception is encountered while trying to perform \"Topic Creation\"")
+
+        rootLogger.critical(err)
         assert False
         
     return response['TopicArn']

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -344,8 +344,8 @@ def auto_create_bucket(userbucketname):
             rootLogger.critical(repr(exc))
             assert False
 
-def subscribe_to_firesim_topic(email):
-    """ Subscribe a user to their FireSim SNS topic for notifications. """
+def create_topic():
+    """ Send a FireSim SNS Email notification. """
     client = boto3.client('sns')
 
     aws_resource_names_dict = aws_resource_names()
@@ -355,8 +355,13 @@ def subscribe_to_firesim_topic(email):
     response = client.create_topic(
         Name=snsname
     )
-    arn = response['TopicArn']
+    return response
 
+def subscribe_to_firesim_topic(email):
+    """ Subscribe a user to their FireSim SNS topic for notifications. """
+
+    arn_dict = create_topic()
+    arn = arn_dict['TopicArn']
     response = client.subscribe(
         TopicArn=arn,
         Protocol='email',
@@ -371,18 +376,9 @@ receive any notifications until you click the confirmation link.""".format(email
     rootLogger.info(message)
 
 def send_firesim_notification(subject, body):
-    """ Send a FireSim SNS Email notification. """
-    client = boto3.client('sns')
 
-    aws_resource_names_dict = aws_resource_names()
-    snsname = aws_resource_names_dict['snsname']
-
-    # this will either create the topic, if it doesn't exist, or just get the arn
-    response = client.create_topic(
-        Name=snsname
-    )
-
-    arn = response['TopicArn']
+    arn_dict = create_topic()
+    arn = arn_dict['TopicArn']
 
     response = client.publish(
         TopicArn=arn,

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -390,7 +390,6 @@ receive any notifications until you click the confirmation link.""".format(email
         else:
             rootLogger.warning("Unknown exception is encountered while trying subscribe notifications")
         rootLogger.warning(err)
-    rootLogger.info("Proceeding..")
 
 
 def send_firesim_notification(subject, body):
@@ -409,11 +408,10 @@ def send_firesim_notification(subject, body):
         )
     except client.exceptions.ClientError as err:
         if 'AuthorizationError' in repr(err): 
-            rootLogger.warning("You don't have permissions to subscribe to firesim notifications")
+            rootLogger.warning("You don't have permissions to publish to firesim notifications")
         else:
             rootLogger.warning("Unknown exception is encountered while trying publish notifications")
         rootLogger.warning(err)
-    rootLogger.info("Proceeding..")
 
 
 if __name__ == '__main__':

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -119,6 +119,16 @@ def buildafi(globalbuildconf):
 
     auto_create_bucket(globalbuildconf.s3_bucketname)
 
+    client = boto3.client('sns')
+
+    aws_resource_names_dict = aws_resource_names()
+    snsname = aws_resource_names_dict['snsname']
+
+    # this will either create the topic, if it doesn't exist, or just get the arn
+    client.create_topic(
+        Name=snsname
+    )
+
     def terminate_instances_handler(sig, frame):
         """ Handler that prompts to terminate build instances if you press ctrl-c. """
         rootLogger.info("You pressed ctrl-c, so builds have been killed.")

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -118,12 +118,9 @@ def buildafi(globalbuildconf):
             run("uname -a")
 
     auto_create_bucket(globalbuildconf.s3_bucketname)
+
     #check to see email notifications can be subscribed
-    try:
-        create_topic() 
-    except :
-        rootLogger.critical("You don't have permissions to perform \"Topic Creation \". Required to send you email notifications. Please contact you IT administrator")
-        exit(1)
+    get_snsname_arn()
 
     def terminate_instances_handler(sig, frame):
         """ Handler that prompts to terminate build instances if you press ctrl-c. """

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -118,16 +118,12 @@ def buildafi(globalbuildconf):
             run("uname -a")
 
     auto_create_bucket(globalbuildconf.s3_bucketname)
-
-    client = boto3.client('sns')
-
-    aws_resource_names_dict = aws_resource_names()
-    snsname = aws_resource_names_dict['snsname']
-
-    # this will either create the topic, if it doesn't exist, or just get the arn
-    client.create_topic(
-        Name=snsname
-    )
+    #check to see email notifications can be subscribed
+    try:
+        create_topic() 
+    except :
+        rootLogger.critical("You don't have permissions to perform \"Topic Creation \". Required to send you email notifications. Please contact you IT administrator")
+        exit(1)
 
     def terminate_instances_handler(sig, frame):
         """ Handler that prompts to terminate build instances if you press ctrl-c. """

--- a/deploy/pytest.ini
+++ b/deploy/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# without this, pytest will find run_test.py files in workloads/ and get confused
+testpaths = tests

--- a/deploy/tests/README.md
+++ b/deploy/tests/README.md
@@ -1,0 +1,6 @@
+This directory contains Python unit tests for the firesim
+manager code.
+
+To run them:
+* make sure you have the latest deps from scripts/machine-launch-script.sh
+* cd deploy && pytest

--- a/deploy/tests/awstools/test_awstools.py
+++ b/deploy/tests/awstools/test_awstools.py
@@ -67,8 +67,9 @@ class TestSNS(object):
         # since firesim manager code doesn't take clients as method parameters
         # now we mock boto3.client to return our stubbed client
         with patch.object(boto3._get_default_session(), 'client', return_value=client) as mock_session:
-            with pytest.raises(AssertionError):
-                get_snsname_arn()
+            get_snsname_arn()
+
+            stub.assert_no_pending_responses()
 
             # TODO we could mock rootLogger.critical to capture it's calls and args and validate that we're seeing the correct "nice" message
 

--- a/deploy/tests/awstools/test_awstools.py
+++ b/deploy/tests/awstools/test_awstools.py
@@ -21,7 +21,7 @@ class TestSNS(object):
 
     # When we're testing awstools.get_snsname_arn(), we don't also want to be
     # testing awstools.aws_resource_names(). mainly because we're subjugating
-    # the boto3.client factory and also because we want to be able to run these
+    # the boto3.client factory (in the second test below) and also because we want to be able to run these
     # tests while not on a AWS EC2 host and aws_resource_names() assumes that it
     # can lookup the AWS instance-id via 169.254.169.254 API
     @patch('awstools.awstools.aws_resource_names', return_value={'snsname': 'Testing'})

--- a/deploy/tests/awstools/test_awstools.py
+++ b/deploy/tests/awstools/test_awstools.py
@@ -1,0 +1,79 @@
+from __future__ import print_function
+from pprint import pprint
+
+# Do NOT import any firesim code being tested that might open connections to AWS here.
+# Import the firesim code to be tested inside the test functions so that the moto
+# mocks are registered before any possible boto connections are created
+import boto3
+from botocore.stub import Stubber
+from moto import mock_sns
+
+from mock import patch
+import pytest
+from pytest import raises
+
+# In case you put any package-level tests, make sure they use the test credentials too
+pytestmark = pytest.mark.usefixtures("aws_test_credentials")
+
+@pytest.mark.usefixtures("aws_test_credentials")
+class TestSNS(object):
+    """Test functions in awstools that work with SNS"""
+
+    # When we're testing awstools.get_snsname_arn(), we don't also want to be
+    # testing awstools.aws_resource_names(). mainly because we're subjugating
+    # the boto3.client factory and also because we want to be able to run these
+    # tests while not on a AWS EC2 host and aws_resource_names() assumes that it
+    # can lookup the AWS instance-id via 169.254.169.254 API
+    @patch('awstools.awstools.aws_resource_names', return_value={'snsname': 'Testing'})
+    # register the moto backend for sns
+    @mock_sns
+    def test_get_snsname_arn_sanity(self, aws_res_mock):
+        """Simple call returns properly formed ARN"""
+        # local imports of code-under-test ensure moto has mocks
+        # registered before any possible calls out to AWS
+        from awstools.awstools import get_snsname_arn
+
+        arn = get_snsname_arn()
+
+        client = boto3.client('sns')
+        response = client.get_topic_attributes(TopicArn=arn)
+
+        # output will normally be captured and suppressed but printed
+        # iff the test fails. So, leaving in something that dumps the response
+        # can be useful. See https://docs.pytest.org/en/4.6.x/capture.html
+        pprint(response)
+        assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+        assert response['Attributes']['TopicArn'] == arn
+
+        # check that our mock of aws_resource_names was used
+        aws_res_mock.assert_called_once()
+
+
+    @patch('awstools.awstools.aws_resource_names', return_value={'snsname': 'Testing'})
+    @mock_sns
+    def test_get_snsname_arn_auth_exception_handling(self, aws_res_mock):
+        """AuthorizationError is intercepted and re-raised as AssertionError"""
+        # local imports of code-under-test ensure moto has mocks
+        # registered before any possible calls out to AWS
+        from awstools.awstools import get_snsname_arn
+
+        # create a mock SNS client that returns what we tell it to
+        client = boto3.client('sns')
+        stub = Stubber(client)
+        stub.add_client_error('create_topic', service_error_code='AuthorizationError')
+        stub.activate()
+
+
+        # since firesim manager code doesn't take clients as method parameters
+        # now we mock boto3.client to return our stubbed client
+        with patch.object(boto3._get_default_session(), 'client', return_value=client) as mock_session:
+            with pytest.raises(AssertionError):
+                get_snsname_arn()
+
+            # TODO we could mock rootLogger.critical to capture it's calls and args and validate that we're seeing the correct "nice" message
+
+            # make sure get_snsname_arn() actually called out to get a sns
+            # client, otherwise we aren't testing what we think we are
+            mock_session.assert_called_once_with('sns')
+
+        aws_res_mock.assert_called_once()

--- a/deploy/tests/awstools/test_awstools.py
+++ b/deploy/tests/awstools/test_awstools.py
@@ -67,9 +67,10 @@ class TestSNS(object):
         # since firesim manager code doesn't take clients as method parameters
         # now we mock boto3.client to return our stubbed client
         with patch.object(boto3._get_default_session(), 'client', return_value=client) as mock_session:
-            get_snsname_arn()
+            topic_arn = get_snsname_arn()
 
             stub.assert_no_pending_responses()
+            assert topic_arn == None
 
             # TODO we could mock rootLogger.critical to capture it's calls and args and validate that we're seeing the correct "nice" message
 

--- a/deploy/tests/conftest.py
+++ b/deploy/tests/conftest.py
@@ -20,3 +20,6 @@ def aws_test_credentials():
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
     os.environ['AWS_SECURITY_TOKEN'] = 'testing'
     os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    # Provide a default region, since one may not already be configured (true of CI)
+    # This was an arbitrary selection
+    os.environ['AWS_DEFAULT_REGION'] = 'us-west-2'

--- a/deploy/tests/conftest.py
+++ b/deploy/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from pprint import pprint
+import os
+
+# fixtures defined in this file will be available to all tests. see
+# https://docs.pytest.org/en/4.6.x/example/simple.html#package-directory-level-fixtures-setups
+
+@pytest.fixture
+def aws_test_credentials():
+    """Mocked AWS Credentials for moto."""
+    # see https://github.com/spulec/moto/blob/8281367dcea520d8971d88fbea1a8bbe552c4a3d/README.md#example-on-pytest-usage
+    # ** You must use this on every test. **
+    #
+    # moto mock must be established before boto makes calls.  In the event that someone forgets to
+    # mock the appropriate apis or more likely APIs used by a function called in a test change without
+    # updating the test, these environment variables will prevent boto from being able to use
+    # real credentials to make real calls to AWS.
+    # see: https://github.com/spulec/moto/blob/8281367dcea520d8971d88fbea1a8bbe552c4a3d/README.md#very-important----recommended-usage
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -63,6 +63,11 @@ sudo pip2 install matplotlib==2.2.2
 sudo pip2 install pandas==0.22.0
 # new awscli on 1.6.0 AMI is broken with our versions of boto3
 sudo pip2 install awscli==1.15.76
+# pip2 should install pytest 4.6.X as it's the last py2 release. see:
+# https://pytest.org/en/latest/py27-py34-deprecation.html#what-this-means-for-general-users
+sudo pip2 install pytest
+# moto 1.3.1 is newest version that will work with boto3 1.6.2
+sudo pip2 install moto==1.3.1
 
 sudo activate-global-python-argcomplete
 


### PR DESCRIPTION
Rather than exiting with a unhandled exception when SNS-related permissions failures happen at the end of `buildafi`, check whether the topic exists (or can be created) early in `buildafi` and warn the user that the script will be unable to send email (and log the details of the exception) but continue to finish `buildafi` because failure in sending the notification probably should not be a fatal error for the manager.

This PR also introduces `pytest` driven unit tests for the firesim manager.  The tests make use of `moto` to mock the backend of `boto` and prevent tests from actually calling out to AWS API's.  They also utilize `unittest.mock` and `botocore.stub.Stubber` to inject desired testing stimulus to the code under test.