### PR TITLE
simif_f1_t::fpga_setup prints AGFI ID at simulation init time

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -4,6 +4,8 @@ FROM centos:centos7.6.1810
 RUN yum -y install sudo epel-release
 # aws fpga dev ami comes with this: pip2
 RUN yum -y install python-pip
+# Match the version on the dev ami
+RUN pip2 install --upgrade pip==18.0
 # Provide a baseline of version for circle CI to use.
 # If Circle CI uses its native version to initialize the repo, future submodule
 # initializations with the machine-launch installed version of git produce very

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   main-env:
     docker:
-      - image: firesim/firesim-ci:v1.0
+      - image: firesim/firesim-ci:v1.1
         user: "centos"
     environment:
         JVM_MEMORY: 3500M # Default JVM maximum heap limit

--- a/sim/midas/src/main/cc/simif_f1.cc
+++ b/sim/midas/src/main/cc/simif_f1.cc
@@ -80,6 +80,10 @@ void simif_f1_t::fpga_setup(int slot_id) {
         check_rc(rc, "AFI in Slot is not in READY state !");
     }
 
+    fprintf(stderr, "AFI ID for Slot %2u: %s\n",
+	    slot_id,
+	    (!info.ids.afi_id[0]) ? "none" : info.ids.afi_id);
+
     fprintf(stderr, "AFI PCI  Vendor ID: 0x%x, Device ID 0x%x\n",
         info.spec.map[FPGA_APP_PF].vendor_id,
         info.spec.map[FPGA_APP_PF].device_id);
@@ -95,6 +99,10 @@ void simif_f1_t::fpga_setup(int slot_id) {
         /* get local image description, contains status, vendor id, and device id. */
         rc = fpga_mgmt_describe_local_image(slot_id, &info,0);
         check_rc(rc, "Unable to get AFI information from slot");
+
+	fprintf(stderr, "AFI ID for Slot %2u: %s\n",
+		slot_id,
+		(!info.ids.afi_id[0]) ? "none" : info.ids.afi_id);
 
         fprintf(stderr, "AFI PCI  Vendor ID: 0x%x, Device ID 0x%x\n",
             info.spec.map[FPGA_APP_PF].vendor_id,


### PR DESCRIPTION
This will make it so that the uartlog will contain the loaded AGFI ID
at the beginning.  Before this addition, one needed to trace the breadcrumbs through
firesim manager logfiles to get to the infrasetup output.  Should make it
easier to audit and reproduce results.