### PR TITLE
[DO NOT MERGE] Local FireSim Mockup

### DIFF
--- a/deploy/buildtools/buildafi.py
+++ b/deploy/buildtools/buildafi.py
@@ -6,8 +6,6 @@ import string
 import logging
 import os
 
-from fabric.api import *
-from fabric.contrib.console import confirm
 from fabric.contrib.project import rsync_project
 from awstools.afitools import *
 from awstools.awstools import send_firesim_notification
@@ -15,243 +13,289 @@ from util.streamlogger import StreamLogger, InfoStreamLogger
 
 rootLogger = logging.getLogger()
 
-def get_deploy_dir():
-    """ Must use local here. determine where the firesim/deploy dir is """
-    with StreamLogger('stdout'), StreamLogger('stderr'):
-        deploydir = local("pwd", capture=True)
-    return deploydir
+class GlobalAwsBuildConfig:
+    def __init__(self, args, global_build_configfile):
+        # parse afibuild section
+        self.s3_bucketname = \
+            global_build_configfile.get('afibuild', 's3bucketname')
 
-def replace_rtl(conf, buildconfig):
-    """ Run chisel/firrtl/fame-1, produce verilog for fpga build.
+        aws_resource_names_dict = aws_resource_names()
+        if aws_resource_names_dict['s3bucketname'] is not None:
+            # in tutorial mode, special s3 bucket name
+            self.s3_bucketname = aws_resource_names_dict['s3bucketname']
 
-    THIS ALWAYS RUNS LOCALLY"""
-    builddir = buildconfig.get_build_dir_name()
-    fpgabuilddir = "hdk/cl/developer_designs/cl_" + buildconfig.get_chisel_triplet()
-    ddir = get_deploy_dir()
+        self.build_instance_market = \
+                global_build_configfile.get('afibuild', 'buildinstancemarket')
+        self.spot_interruption_behavior = \
+            global_build_configfile.get('afibuild', 'spotinterruptionbehavior')
+        self.spot_max_price = \
+                    global_build_configfile.get('afibuild', 'spotmaxprice')
+        self.post_build_hook = global_build_configfile.get('afibuild', 'postbuildhook')
 
-    rootLogger.info("Running replace-rtl to generate verilog for " + str(buildconfig.get_chisel_triplet()))
+        # parse agfistoshare
+        self.agfistoshare = [x[0] for x in global_build_configfile.items('agfistoshare')]
 
-    with prefix('cd ' + ddir + '/../'), \
-         prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
-         prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
-         prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
-         prefix('source sourceme-f1-manager.sh'), \
-         prefix('export CL_DIR={}/../platforms/f1/aws-fpga/{}'.format(ddir, fpgabuilddir)), \
-         prefix('cd sim/'), \
-         InfoStreamLogger('stdout'), \
-         InfoStreamLogger('stderr'):
-        run(buildconfig.make_recipe("replace-rtl"))
-        run("""mkdir -p {}/results-build/{}/""".format(ddir, builddir))
-        run("""cp $CL_DIR/design/cl_firesim_generated.sv {}/results-build/{}/cl_firesim_generated.sv""".format(ddir, builddir))
+        # parse sharewithaccounts
+        self.acctids_to_sharewith = [x[1] for x in global_build_configfile.items('sharewithaccounts')]
 
-    # build the fpga driver that corresponds with this version of the RTL
-    with prefix('cd ' + ddir + '/../'), \
-         prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
-         prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
-         prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
-         prefix('source sourceme-f1-manager.sh'), \
-         prefix('cd sim/'), \
-         StreamLogger('stdout'), \
-         StreamLogger('stderr'):
-        run(buildconfig.make_recipe("f1"))
+    def launch_build_instances(self):
+        # get access to the runfarmprefix, which we will apply to build
+        # instances too now.
+        aws_resource_names_dict = aws_resource_names()
+        # just duplicate the runfarmprefix for now. This can be None,
+        # in which case we give an empty build farm prefix
+        build_farm_prefix = aws_resource_names_dict['runfarmprefix']
 
-@parallel
-def aws_build(global_build_config, bypass=False):
-    """ Run Vivado, convert tar -> AGFI/AFI. Then terminate the instance at the end.
-    conf = buildconfig dicitonary
-    bypass: since this function takes a long time, bypass just returns for
-    testing purposes when set to True. """
-    if bypass:
-        ### This is duplicated from the end of the function.
-        buildconfig = global_build_config.get_build_by_ip(env.host_string)
-        buildconfig.terminate_build_instance(buildconfig)
-        return
+        for build in self.builds_list:
+            build.launch_build_instance(self.build_instance_market,
+                                        self.spot_interruption_behavior,
+                                        self.spot_max_price,
+                                        build_farm_prefix)
 
-    # The default error-handling procedure. Send an email and teardown instance
-    def on_build_failure():
-        message_title = "FireSim FPGA Build Failed"
+    def wait_build_instances(self):
+        instances = [build.get_launched_instance_object() for build in self.builds_list]
+        wait_on_instance_launches(instances)
 
-        message_body = "Your FPGA build failed for triplet: " + buildconfig.get_chisel_triplet()
-        message_body += ".\nInspect the log output from IP address " + env.host_string + " for more information."
+    def terminate_all_build_instances(self):
+        for build in self.builds_list:
+            build.terminate_build_instance()
 
-        send_firesim_notification(message_title, message_body)
+    def host_platform_init(self):
+        auto_create_bucket(self.s3_bucketname)
 
-        rootLogger.info(message_title)
-        rootLogger.info(message_body)
+    def replace_rtl(self, buildconf):
+        """ Run chisel/firrtl/fame-1, produce verilog for fpga build.
+        THIS ALWAYS RUNS LOCALLY."""
+
+        builddir = buildconf.get_build_dir_name()
+        ddir = self.get_deploy_dir()
+        fpgabuilddir = "hdk/cl/developer_designs/cl_" + buildconf.get_chisel_triplet()
+
+        with prefix('cd ' + ddir + '/../'), \
+            prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+            prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+            prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
+            prefix('source sourceme-f1-manager.sh'), \
+            prefix('export CL_DIR={}/../platforms/f1/aws-fpga/{}'.format(ddir, fpgabuilddir)), \
+            prefix('cd sim/'), \
+            InfoStreamLogger('stdout'), \
+            InfoStreamLogger('stderr'):
+            run(buildconf.make_recipe("replace-rtl"))
+            run("""mkdir -p {}/results-build/{}/""".format(ddir, builddir))
+            run("""cp $CL_DIR/design/cl_firesim_generated.sv {}/results-build/{}/cl_firesim_generated.sv""".format(ddir, builddir))
+
+        # build the fpga driver that corresponds with this version of the RTL
+        with prefix('cd ' + ddir + '/../'), \
+            prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+            prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+            prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
+            prefix('source sourceme-f1-manager.sh'), \
+            prefix('cd sim/'), \
+            StreamLogger('stdout'), \
+            StreamLogger('stderr'):
+            run(buildconf.make_recipe("f1"))
+
+    def fpga_build(self, global_build_config, bypass=False):
+        """ Run Vivado, convert tar -> AGFI/AFI. Then terminate the instance at the end.
+        global_build_config = buildconf dicitonary
+        bypass: since this function takes a long time, bypass just returns for
+        testing purposes when set to True. """
+
+        # The default error-handling procedure. Send an email and teardown instance
+        def on_build_failure():
+            message_title = "FireSim FPGA Build Failed"
+
+            message_body = "Your FPGA build failed for triplet: " + buildconf.get_chisel_triplet()
+            message_body += ".\nInspect the log output from IP address " + env.host_string + " for more information."
+
+            send_firesim_notification(message_title, message_body)
+
+            rootLogger.info(message_title)
+            rootLogger.info(message_body)
+            rootLogger.info("Terminating the build instance now.")
+            buildconf.terminate_build_instance()
+
+        rootLogger.info("Running process to build AGFI from verilog.")
+
+        # First, Produce dcp/tar for design. Runs on remote machines, out of
+        # /home/centos/firesim-build/ """
+        ddir = get_deploy_dir()
+        buildconf = global_build_config.get_build_by_ip(env.host_string)
+        builddir = buildconf.get_build_dir_name()
+        # local AWS build directory; might have config-specific changes to fpga flow
+        fpgabuilddir = "hdk/cl/developer_designs/cl_" + buildconf.get_chisel_triplet()
+        remotefpgabuilddir = "hdk/cl/developer_designs/cl_firesim"
+
+        if bypass:
+            buildconf.terminate_build_instance(buildconf)
+            return
+
+        # first, copy aws-fpga to the build instance. it will live in
+        # firesim-build/platforms/f1/
+        with StreamLogger('stdout'), StreamLogger('stderr'):
+            run('mkdir -p /home/centos/firesim-build/platforms/f1/')
+        # do the rsync, but ignore any checkpoints that might exist on this machine
+        # (in case builds were run locally)
+        # extra_opts -l preserves symlinks
+        with StreamLogger('stdout'), StreamLogger('stderr'):
+            rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga",
+                        remote_dir='/home/centos/firesim-build/platforms/f1/',
+                        ssh_opts="-o StrictHostKeyChecking=no",
+                        exclude="hdk/cl/developer_designs/cl_*",
+                        extra_opts="-l", capture=True)
+            rootLogger.debug(rsync_cap)
+            rootLogger.debug(rsync_cap.stderr)
+            rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga/{}/*".format(fpgabuilddir),
+                        remote_dir='/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir,
+                        exclude='build/checkpoints',
+                        ssh_opts="-o StrictHostKeyChecking=no",
+                        extra_opts="-l", capture=True)
+            rootLogger.debug(rsync_cap)
+            rootLogger.debug(rsync_cap.stderr)
+
+        # run the Vivado build
+        vivado_result = 0
+        with prefix('cd /home/centos/firesim-build/platforms/f1/aws-fpga'), \
+            prefix('source hdk_setup.sh'), \
+            prefix('export CL_DIR=/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir), \
+            prefix('cd $CL_DIR/build/scripts/'), InfoStreamLogger('stdout'), InfoStreamLogger('stderr'), \
+            settings(warn_only=True):
+            vivado_result = run('./aws_build_dcp_from_cl.sh -foreground').return_code
+
+        # rsync in the reverse direction to get build results
+        with StreamLogger('stdout'), StreamLogger('stderr'):
+            rsync_cap = rsync_project(local_dir="""{}/results-build/{}/""".format(ddir, builddir),
+                        remote_dir='/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir,
+                        ssh_opts="-o StrictHostKeyChecking=no", upload=False, extra_opts="-l",
+                        capture=True)
+            rootLogger.debug(rsync_cap)
+            rootLogger.debug(rsync_cap.stderr)
+
+        if vivado_result != 0:
+            on_build_failure()
+            return
+
+        if not aws_create_afi(global_build_config, buildconf):
+            on_build_failure()
+            return
+
         rootLogger.info("Terminating the build instance now.")
-        buildconfig.terminate_build_instance()
+        buildconf.terminate_build_instance()
+
+    def get_deploy_dir(self):
+        """ Must use local here. determine where the firesim/deploy dir is """
+        with StreamLogger('stdout'), StreamLogger('stderr'):
+            deploydir = local("pwd", capture=True)
+        return deploydir
+
+    def aws_create_afi(self, buildconf):
+        """
+        Convert the tarball created by Vivado build into an Amazon Global FPGA Image (AGFI)
+
+        :return: None on error
+        """
+        ## next, do tar -> AGFI
+        ## This is done on the local copy
+
+        ddir = get_deploy_dir()
+        results_builddir = buildconf.get_build_dir_name()
+
+        afi = None
+        agfi = None
+        s3bucket = global_build_config.s3_bucketname
+        afiname = buildconf.name
+
+        # construct the "tags" we store in the AGFI description
+        tag_buildtriplet = buildconf.get_chisel_triplet()
+        tag_deploytriplet = tag_buildtriplet
+        if buildconf.deploytriplet != "None":
+            tag_deploytriplet = buildconf.deploytriplet
+
+        # the asserts are left over from when we tried to do this with tags
+        # - technically I don't know how long these descriptions are allowed to be,
+        # but it's at least 256*3, so I'll leave these here for now as sanity
+        # checks.
+        assert len(tag_buildtriplet) <= 255, "ERR: aws does not support tags longer than 256 chars for buildtriplet"
+        assert len(tag_deploytriplet) <= 255, "ERR: aws does not support tags longer than 256 chars for deploytriplet"
+
+        with StreamLogger('stdout'), StreamLogger('stderr'):
+            is_dirty_str = local("if [[ $(git status --porcelain) ]]; then echo '-dirty'; fi", capture=True)
+            hash = local("git rev-parse HEAD", capture=True)
+        tag_fsimcommit = hash + is_dirty_str
+
+        assert len(tag_fsimcommit) <= 255, "ERR: aws does not support tags longer than 256 chars for fsimcommit"
+
+        # construct the serialized description from these tags.
+        description = firesim_tags_to_description(tag_buildtriplet, tag_deploytriplet, tag_fsimcommit)
+
+        # if we're unlucky, multiple vivado builds may launch at the same time. so we
+        # append the build node IP + a random string to diff them in s3
+        global_append = "-" + str(env.host_string) + "-" + ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(10)) + ".tar"
+
+        with lcd("""{}/results-build/{}/cl_firesim/build/checkpoints/to_aws/""".format(ddir, builddir)), StreamLogger('stdout'), StreamLogger('stderr'):
+            files = local('ls *.tar', capture=True)
+            rootLogger.debug(files)
+            rootLogger.debug(files.stderr)
+            tarfile = files.split()[-1]
+            s3_tarfile = tarfile + global_append
+            localcap = local('aws s3 cp ' + tarfile + ' s3://' + s3bucket + '/dcp/' + s3_tarfile, capture=True)
+            rootLogger.debug(localcap)
+            rootLogger.debug(localcap.stderr)
+            agfi_afi_ids = local("""aws ec2 create-fpga-image --input-storage-location Bucket={},Key={} --logs-storage-location Bucket={},Key={} --name "{}" --description "{}" """.format(s3bucket, "dcp/" + s3_tarfile, s3bucket, "logs/", afiname, description), capture=True)
+            rootLogger.debug(agfi_afi_ids)
+            rootLogger.debug(agfi_afi_ids.stderr)
+            rootLogger.debug("create-fpge-image result: " + str(agfi_afi_ids))
+            ids_as_dict = json.loads(agfi_afi_ids)
+            agfi = ids_as_dict["FpgaImageGlobalId"]
+            afi = ids_as_dict["FpgaImageId"]
+            rootLogger.info("Resulting AGFI: " + str(agfi))
+            rootLogger.info("Resulting AFI: " + str(afi))
+
+        rootLogger.info("Waiting for create-fpga-image completion.")
+        results_build_dir = """{}/results-build/{}/""".format(ddir, builddir)
+        checkstate = "pending"
+        with lcd(results_build_dir), StreamLogger('stdout'), StreamLogger('stderr'):
+            while checkstate == "pending":
+                imagestate = local("""aws ec2 describe-fpga-images --fpga-image-id {} | tee AGFI_INFO""".format(afi), capture=True)
+                state_as_dict = json.loads(imagestate)
+                checkstate = state_as_dict["FpgaImages"][0]["State"]["Code"]
+                rootLogger.info("Current state: " + str(checkstate))
+                time.sleep(10)
 
 
-    rootLogger.info("Running process to build AGFI from verilog.")
+        if checkstate == "available":
+            # copy the image to all regions for the current user
+            copy_afi_to_all_regions(afi)
 
-    # First, Produce dcp/tar for design. Runs on remote machines, out of
-    # /home/centos/firesim-build/ """
-    ddir = get_deploy_dir()
-    buildconfig = global_build_config.get_build_by_ip(env.host_string)
-    builddir = buildconfig.get_build_dir_name()
-    # local AWS build directory; might have config-specific changes to fpga flow
-    fpgabuilddir = "hdk/cl/developer_designs/cl_" + buildconfig.get_chisel_triplet()
-    remotefpgabuilddir = "hdk/cl/developer_designs/cl_firesim"
+            message_title = "FireSim FPGA Build Completed"
+            agfi_entry = "[" + afiname + "]\nagfi=" + agfi + "\ndeploytripletoverride=None\ncustomruntimeconfig=None\n\n"
+            message_body = "Your AGFI has been created!\nAdd\n" + agfi_entry + "\nto your config_hwdb.ini to use this hardware configuration."
 
-    # first, copy aws-fpga to the build instance. it will live in
-    # firesim-build/platforms/f1/
-    with StreamLogger('stdout'), StreamLogger('stderr'):
-        run('mkdir -p /home/centos/firesim-build/platforms/f1/')
-    # do the rsync, but ignore any checkpoints that might exist on this machine
-    # (in case builds were run locally)
-    # extra_opts -l preserves symlinks
-    with StreamLogger('stdout'), StreamLogger('stderr'):
-        rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga",
-                      remote_dir='/home/centos/firesim-build/platforms/f1/',
-                      ssh_opts="-o StrictHostKeyChecking=no",
-                      exclude="hdk/cl/developer_designs/cl_*",
-                      extra_opts="-l", capture=True)
-        rootLogger.debug(rsync_cap)
-        rootLogger.debug(rsync_cap.stderr)
-        rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga/{}/*".format(fpgabuilddir),
-                      remote_dir='/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir,
-                      exclude='build/checkpoints',
-                      ssh_opts="-o StrictHostKeyChecking=no",
-                      extra_opts="-l", capture=True)
-        rootLogger.debug(rsync_cap)
-        rootLogger.debug(rsync_cap.stderr)
+            send_firesim_notification(message_title, message_body)
 
-    # run the Vivado build
-    vivado_result = 0
-    with prefix('cd /home/centos/firesim-build/platforms/f1/aws-fpga'), \
-         prefix('source hdk_setup.sh'), \
-         prefix('export CL_DIR=/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir), \
-         prefix('cd $CL_DIR/build/scripts/'), InfoStreamLogger('stdout'), InfoStreamLogger('stderr'), \
-         settings(warn_only=True):
-        vivado_result = run('./aws_build_dcp_from_cl.sh -foreground').return_code
+            rootLogger.info(message_title)
+            rootLogger.info(message_body)
 
-    # rsync in the reverse direction to get build results
-    with StreamLogger('stdout'), StreamLogger('stderr'):
-        rsync_cap = rsync_project(local_dir="""{}/results-build/{}/""".format(ddir, builddir),
-                      remote_dir='/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir,
-                      ssh_opts="-o StrictHostKeyChecking=no", upload=False, extra_opts="-l",
-                      capture=True)
-        rootLogger.debug(rsync_cap)
-        rootLogger.debug(rsync_cap.stderr)
+            # for convenience when generating a bunch of images. you can just
+            # cat all the files in this directory after your builds finish to get
+            # all the entries to copy into config_hwdb.ini
+            hwdb_entry_file_location = """{}/built-hwdb-entries/""".format(ddir)
+            local("mkdir -p " + hwdb_entry_file_location)
+            with open(hwdb_entry_file_location + "/" + afiname, "w") as outputfile:
+                outputfile.write(agfi_entry)
 
-    if vivado_result != 0:
-        on_build_failure()
-        return
+            if global_build_config.post_build_hook:
+                with StreamLogger('stdout'), StreamLogger('stderr'):
+                    localcap = local("""{} {}""".format(global_build_config.post_build_hook,
+                                                        results_build_dir,
+                                                        capture=True))
+                    rootLogger.debug("[localhost] " + str(localcap))
+                    rootLogger.debug("[localhost] " + str(localcap.stderr))
 
-    if not aws_create_afi(global_build_config, buildconfig):
-        on_build_failure()
-        return
+            rootLogger.info("Build complete! AFI ready. See {}.".format(pjoin(hwdb_entry_file_location,afiname)))
+            return True
+        else:
+            return
 
-
-    rootLogger.info("Terminating the build instance now.")
-    buildconfig.terminate_build_instance()
-
-
-def aws_create_afi(global_build_config, buildconfig):
-    """
-    Convert the tarball created by Vivado build into an Amazon Global FPGA Image (AGFI)
-
-    :return: None on error
-    """
-    ## next, do tar -> AGFI
-    ## This is done on the local copy
-
-    ddir = get_deploy_dir()
-    results_builddir = buildconfig.get_build_dir_name()
-
-    afi = None
-    agfi = None
-    s3bucket = global_build_config.s3_bucketname
-    afiname = buildconfig.name
-
-    # construct the "tags" we store in the AGFI description
-    tag_buildtriplet = buildconfig.get_chisel_triplet()
-    tag_deploytriplet = tag_buildtriplet
-    if buildconfig.deploytriplet != "None":
-        tag_deploytriplet = buildconfig.deploytriplet
-
-    # the asserts are left over from when we tried to do this with tags
-    # - technically I don't know how long these descriptions are allowed to be,
-    # but it's at least 256*3, so I'll leave these here for now as sanity
-    # checks.
-    assert len(tag_buildtriplet) <= 255, "ERR: aws does not support tags longer than 256 chars for buildtriplet"
-    assert len(tag_deploytriplet) <= 255, "ERR: aws does not support tags longer than 256 chars for deploytriplet"
-
-    with StreamLogger('stdout'), StreamLogger('stderr'):
-        is_dirty_str = local("if [[ $(git status --porcelain) ]]; then echo '-dirty'; fi", capture=True)
-        hash = local("git rev-parse HEAD", capture=True)
-    tag_fsimcommit = hash + is_dirty_str
-
-    assert len(tag_fsimcommit) <= 255, "ERR: aws does not support tags longer than 256 chars for fsimcommit"
-
-    # construct the serialized description from these tags.
-    description = firesim_tags_to_description(tag_buildtriplet, tag_deploytriplet, tag_fsimcommit)
-
-    # if we're unlucky, multiple vivado builds may launch at the same time. so we
-    # append the build node IP + a random string to diff them in s3
-    global_append = "-" + str(env.host_string) + "-" + ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(10)) + ".tar"
-
-    with lcd("""{}/results-build/{}/cl_firesim/build/checkpoints/to_aws/""".format(ddir, builddir)), StreamLogger('stdout'), StreamLogger('stderr'):
-        files = local('ls *.tar', capture=True)
-        rootLogger.debug(files)
-        rootLogger.debug(files.stderr)
-        tarfile = files.split()[-1]
-        s3_tarfile = tarfile + global_append
-        localcap = local('aws s3 cp ' + tarfile + ' s3://' + s3bucket + '/dcp/' + s3_tarfile, capture=True)
-        rootLogger.debug(localcap)
-        rootLogger.debug(localcap.stderr)
-        agfi_afi_ids = local("""aws ec2 create-fpga-image --input-storage-location Bucket={},Key={} --logs-storage-location Bucket={},Key={} --name "{}" --description "{}" """.format(s3bucket, "dcp/" + s3_tarfile, s3bucket, "logs/", afiname, description), capture=True)
-        rootLogger.debug(agfi_afi_ids)
-        rootLogger.debug(agfi_afi_ids.stderr)
-        rootLogger.debug("create-fpge-image result: " + str(agfi_afi_ids))
-        ids_as_dict = json.loads(agfi_afi_ids)
-        agfi = ids_as_dict["FpgaImageGlobalId"]
-        afi = ids_as_dict["FpgaImageId"]
-        rootLogger.info("Resulting AGFI: " + str(agfi))
-        rootLogger.info("Resulting AFI: " + str(afi))
-
-    rootLogger.info("Waiting for create-fpga-image completion.")
-    results_build_dir = """{}/results-build/{}/""".format(ddir, builddir)
-    checkstate = "pending"
-    with lcd(results_build_dir), StreamLogger('stdout'), StreamLogger('stderr'):
-        while checkstate == "pending":
-            imagestate = local("""aws ec2 describe-fpga-images --fpga-image-id {} | tee AGFI_INFO""".format(afi), capture=True)
-            state_as_dict = json.loads(imagestate)
-            checkstate = state_as_dict["FpgaImages"][0]["State"]["Code"]
-            rootLogger.info("Current state: " + str(checkstate))
-            time.sleep(10)
-
-
-    if checkstate == "available":
-        # copy the image to all regions for the current user
-        copy_afi_to_all_regions(afi)
-
-        message_title = "FireSim FPGA Build Completed"
-        agfi_entry = "[" + afiname + "]\nagfi=" + agfi + "\ndeploytripletoverride=None\ncustomruntimeconfig=None\n\n"
-        message_body = "Your AGFI has been created!\nAdd\n" + agfi_entry + "\nto your config_hwdb.ini to use this hardware configuration."
-
-        send_firesim_notification(message_title, message_body)
-
-        rootLogger.info(message_title)
-        rootLogger.info(message_body)
-
-        # for convenience when generating a bunch of images. you can just
-        # cat all the files in this directory after your builds finish to get
-        # all the entries to copy into config_hwdb.ini
-        hwdb_entry_file_location = """{}/built-hwdb-entries/""".format(ddir)
-        local("mkdir -p " + hwdb_entry_file_location)
-        with open(hwdb_entry_file_location + "/" + afiname, "w") as outputfile:
-            outputfile.write(agfi_entry)
-
-        if global_build_config.post_build_hook:
-            with StreamLogger('stdout'), StreamLogger('stderr'):
-                localcap = local("""{} {}""".format(global_build_config.post_build_hook,
-                                                    results_build_dir,
-                                                    capture=True))
-                rootLogger.debug("[localhost] " + str(localcap))
-                rootLogger.debug("[localhost] " + str(localcap.stderr))
-
-        rootLogger.info("Build complete! AFI ready. See {}.".format(pjoin(hwdb_entry_file_location,afiname)))
-        return True
-    else:
-        return
+    def __str__(self):
+        return pprint.pformat(vars(self))

--- a/deploy/buildtools/buildglobal.py
+++ b/deploy/buildtools/buildglobal.py
@@ -1,0 +1,105 @@
+""" This converts the build configuration files into something usable by the
+manager """
+
+from time import strftime, gmtime
+import ConfigParser
+import pprint
+from fabric.api import *
+import logging
+
+from runtools.runtime_config import RuntimeHWDB
+from buildtools.buildconfig import BuildConfig
+from buildtools.buildlocal import GlobalLocalBuildConfig
+from buildtools.buildafi import GlobalAwsBuildConfig
+
+rootLogger = logging.getLogger()
+
+class GlobalBuildConfig:
+    """ Configuration class for builds. This is the "global" configfile,
+    i.e. sample_config_build.ini
+    """
+
+    def __init__(self, args):
+        if args.launchtime:
+            launch_time = args.launchtime
+        else:
+            launch_time = strftime("%Y-%m-%d--%H-%M-%S", gmtime())
+
+        self.args = args
+
+        global_build_configfile = ConfigParser.ConfigParser(allow_no_value=True)
+        # make option names case sensitive
+        global_build_configfile.optionxform = str
+        global_build_configfile.read(args.buildconfigfile)
+
+        builds_to_run_list = map(lambda x: x[0], global_build_configfile.items('builds'))
+
+        build_recipes_configfile = ConfigParser.ConfigParser(allow_no_value=True)
+        # make option names case sensitive
+        build_recipes_configfile.optionxform = str
+        build_recipes_configfile.read(args.buildrecipesconfigfile)
+
+        self.builds_list = []
+        for build_name in builds_to_run_list:
+            self.builds_list.append(BuildConfig(
+                build_name,
+                dict(build_recipes_configfile.items(build_name)),
+                launch_time))
+
+        self.hwdb = RuntimeHWDB(args.hwdbconfigfile)
+
+        # setup the particular host_platform
+        self.host_platform = global_build_configfile.get('buildfarmconfig', 'hostplatform')
+        if self.host_platform == "aws":
+            self.host_platform_config = GlobalAwsBuildConfig(args, global_build_configfile)
+        elif self.host_platform == "local":
+            self.host_platform_config = GlobalLocalBuildConfig(args, global_build_configfile, self.builds_list)
+        else:
+            sys.exit('Invalid host platform: {}'.format(host_platform))
+
+    def launch_build_instances(self):
+        """ Launch an instance for the builds we want to do """
+        self.host_platform_config.launch_build_instances()
+
+    def wait_build_instances(self):
+        """ Block until all build instances are launched """
+        self.host_platform_config.wait_build_instances()
+
+    def terminate_all_build_instances(self):
+        """ Terminate all build instances that are launched """
+        self.host_platform_config.terminate_all_build_instances()
+
+    def host_platform_init(self):
+        """ Specific init before running RTL builds """
+        self.host_platform_config.init()
+
+    def replace_rtl(self, buildconf):
+        """ Run chisel/firrtl/fame-1, produce verilog for fpga build.
+        THIS ALWAYS RUNS LOCALLY."""
+        rootLogger.info('Running replace-rtl to generate verilog for {}'.format(buildconf.get_chisel_triplet()))
+        self.host_platform_config.replace_rtl(buildconf)
+
+    @parallel
+    def fpga_build(self, bypass=False):
+        """ Run specific steps for building FPGA image. """
+        self.host_platform_config.fpga_build(self)
+        return
+
+    def get_build_by_ip(self, nodeip):
+        """ For a particular private IP (aka instance), return the BuildConfig
+        that it's supposed to be running. """
+        for build in self.builds_list:
+            if build.get_build_instance_private_ip() == nodeip:
+                return build
+        return None
+
+    def get_build_instance_ips(self):
+        """ Return a list of all the build instance IPs, i.e. hosts to pass to
+        fabric. """
+        return map(lambda x: x.get_build_instance_private_ip(), self.builds_list)
+
+    def get_builds_list(self):
+        return self.builds_list
+
+    def __str__(self):
+        return pprint.pformat(vars(self))

--- a/deploy/buildtools/buildlocal.py
+++ b/deploy/buildtools/buildlocal.py
@@ -1,0 +1,80 @@
+from __future__ import with_statement
+import logging
+import os
+import sys
+
+from fabric.api import *
+from util.streamlogger import StreamLogger, InfoStreamLogger
+
+rootLogger = logging.getLogger()
+
+class GlobalLocalBuildConfig:
+    def __init__(self, args, global_build_configfile, build_recipes_list):
+        self.local_ip_list = map(lambda x: x[0], global_build_configfile.items('localips'))
+        self.fpga_type = global_build_configfile.get('local', 'fpgatype')
+
+        if len(self.local_ip_list) != len(build_recipes_list):
+            sys.exit('Not enough IP addresses to assign to each build. {} IPs < {} builds.'.format(
+                len(self.local_ip_list),
+                len(build_recipes_list)))
+
+        for item in zip(build_recipes_list, self.local_ip_list):
+            item[0].set_build_instance_private_ip(item[1])
+
+    def launch_build_instances(self):
+        return
+
+    def wait_build_instances(self):
+        return
+
+    def terminate_all_build_instances(self):
+        return
+
+    def host_platform_init(self):
+        return
+
+    def replace_rtl(self, buildconf):
+        """ Run chisel/firrtl/fame-1, produce verilog for fpga build.
+        THIS ALWAYS RUNS LOCALLY."""
+
+        builddir = buildconf.get_build_dir_name()
+        ddir = self.get_deploy_dir()
+
+        # build the rtl
+        with prefix('cd ' + ddir + '/../'), \
+            prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+            prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+            prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
+            prefix('source sourceme-f1-manager.sh'), \
+            prefix('cd sim/'), \
+            InfoStreamLogger('stdout'), \
+            InfoStreamLogger('stderr'):
+            run(buildconf.make_recipe("replace-rtl"))
+            run("""mkdir -p {}/results-build/{}/""".format(ddir, builddir))
+
+        # build the fpga driver (RTL, C++) that corresponds with this version of the RTL
+        # TODO: Verify later
+        print("Building FPGA driver RTL and C++")
+        #with prefix('cd ' + ddir + '/../'), \
+        #    prefix('export RISCV={}'.format(os.getenv('RISCV', ""))), \
+        #    prefix('export PATH={}'.format(os.getenv('PATH', ""))), \
+        #    prefix('export LD_LIBRARY_PATH={}'.format(os.getenv('LD_LIBRARY_PATH', ""))), \
+        #    prefix('source sourceme-f1-manager.sh'), \
+        #    prefix('cd sim/'), \
+        #    StreamLogger('stdout'), \
+        #    StreamLogger('stderr'):
+        #    run(buildconfig.make_recipe(conf.fpga_type))
+
+    def fpga_build(self, global_build_config, bypass=False):
+        """ Run specific steps for building FPGA image. """
+        print("Not there yet")
+        return
+
+    def get_deploy_dir(self):
+        """ Must use local here. determine where the firesim/deploy dir is """
+        with StreamLogger('stdout'), StreamLogger('stderr'):
+            deploydir = local("pwd", capture=True)
+        return deploydir
+
+    def __str__(self):
+        return pprint.pformat(vars(self))

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -22,14 +22,14 @@ from awstools.afitools import *
 
 # firesim buildtools
 from buildtools.buildafi import *
-from buildtools.buildconfig import GlobalBuildConfig
+from buildtools.buildglobal import GlobalBuildConfig
 
 from util.streamlogger import StreamLogger
 
 ## below are tasks that users can call
 ## to add a task, add it here and to the choices array
 
-def managerinit():
+def managerinit(args):
     """ Setup local FireSim manager components. """
 
     def valid_aws_configure_creds():
@@ -51,19 +51,20 @@ def managerinit():
             return False
         return True
 
-    valid_creds = valid_aws_configure_creds()
-    while not valid_creds:
-        # only run aws configure if we cannot already find valid creds
-        # this loops calling valid_aws_configure_creds until
-        rootLogger.info("Running aws configure. You must specify your AWS account info here to use the FireSim Manager.")
-        # DO NOT wrap this local call with StreamLogger, we don't want creds to get
-        # stored in the log
-        local("aws configure")
-
-        # check again
+    if not args.localrun:
         valid_creds = valid_aws_configure_creds()
-        if not valid_creds:
-            rootLogger.info("Invalid AWS credentials. Try again.")
+        while not valid_creds:
+            # only run aws configure if we cannot already find valid creds
+            # this loops calling valid_aws_configure_creds until
+            rootLogger.info("Running aws configure. You must specify your AWS account info here to use the FireSim Manager.")
+            # DO NOT wrap this local call with StreamLogger, we don't want creds to get
+            # stored in the log
+            local("aws configure")
+
+            # check again
+            valid_creds = valid_aws_configure_creds()
+            if not valid_creds:
+                rootLogger.info("Invalid AWS credentials. Try again.")
 
     rootLogger.info("Backing up initial config files, if they exist.")
     config_files = ["build", "build_recipes", "hwdb", "runtime"]
@@ -79,15 +80,18 @@ def managerinit():
             m = local("""cp sample-backup-configs/sample_config_{}.ini config_{}.ini""".format(conf_file, conf_file), capture=True)
             rootLogger.debug(m)
             rootLogger.debug(m.stderr)
-            m = local("""sed -i 's/AWSUSERNAME/{}/g' config_{}.ini""".format(get_aws_userid(), conf_file), capture=True)
-            rootLogger.debug(m)
-            rootLogger.debug(m.stderr)
+            if not args.localrun:
+                m = local("""sed -i 's/AWSUSERNAME/{}/g' config_{}.ini""".format(get_aws_userid(), conf_file), capture=True)
+                rootLogger.debug(m)
+                rootLogger.debug(m.stderr)
 
-    useremail = raw_input("If you are a new user, supply your email address [abc@xyz.abc] for email notifications (leave blank if you do not want email notifications): ")
-    if useremail != "":
-        subscribe_to_firesim_topic(useremail)
-    else:
-        rootLogger.info("You did not supply an email address. No notifications will be sent.")
+    if not args.localrun:
+        useremail = raw_input("If you are a new user, supply your email address [abc@xyz.abc] for email notifications (leave blank if you do not want email notifications): ")
+        if useremail != "":
+            subscribe_to_firesim_topic(useremail)
+        else:
+            rootLogger.info("You did not supply an email address. No notifications will be sent.")
+
     rootLogger.info("FireSim Manager setup completed.")
 
 def infrasetup(runtime_conf):
@@ -117,8 +121,6 @@ def buildafi(globalbuildconf):
         with StreamLogger('stdout'), StreamLogger('stderr'):
             run("uname -a")
 
-    auto_create_bucket(globalbuildconf.s3_bucketname)
-
     def terminate_instances_handler(sig, frame):
         """ Handler that prompts to terminate build instances if you press ctrl-c. """
         rootLogger.info("You pressed ctrl-c, so builds have been killed.")
@@ -130,10 +132,15 @@ def buildafi(globalbuildconf):
             rootLogger.info("Termination skipped. There may still be build instances running.")
         sys.exit(0)
 
-    signal.signal(signal.SIGINT, terminate_instances_handler)
 
+    if globalbuildconf.host_platform == "aws":
+        signal.signal(signal.SIGINT, terminate_instances_handler)
+        auto_create_bucket(globalbuildconf.s3_bucketname)
+
+    # runs serially on the localhost
     for buildconf in globalbuildconf.get_builds_list():
-        execute(replace_rtl, globalbuildconf, buildconf, hosts=['localhost'])
+        #globalbuildconf.replace_rtl(buildconf)
+        execute(globalbuildconf.replace_rtl, buildconf, hosts=['localhost'])
 
     # local items (replace_rtl) need to be called in a loop, for each config
     # remote items will map themselves
@@ -146,8 +153,7 @@ def buildafi(globalbuildconf):
     execute(instance_liveness, hosts=globalbuildconf.get_build_instance_ips())
 
     # run builds, then terminate instances
-    execute(aws_build, globalbuildconf, hosts=globalbuildconf.get_build_instance_ips())
-
+    execute(globalbuildconf.fpga_build, hosts=globalbuildconf.get_build_instance_ips())
 
 def tar2afi(globalbuildconf):
     """
@@ -259,6 +265,7 @@ def construct_firesim_argparser():
                         help='For terminaterunfarm, force termination without prompting user for confirmation. Defaults to False')
     parser.add_argument('-t', '--launchtime', type=str,
                         help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildafi')
+    parser.add_argument('-l', '--localrun', action='store_true', help='Do things locally')
 
     argcomplete.autocomplete(parser)
     return parser.parse_args()
@@ -281,7 +288,7 @@ def main(args):
 
     # tasks that have a special config/dispatch setup
     if args.task == 'managerinit':
-        managerinit()
+        managerinit(args)
 
     if args.task in ['buildafi', 'shareagfi', 'tar2afi']:
         buildconfig = GlobalBuildConfig(args)

--- a/deploy/sample-backup-configs/sample_config_build.ini
+++ b/deploy/sample-backup-configs/sample_config_build.ini
@@ -1,6 +1,21 @@
 # BUILDTIME/AGFI management configuration for the FireSim Simulation Manager
 # See docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst for documentation of all of these params.
 
+[buildfarmconfig]
+# build platform (options are "aws" or "local")
+hostplatform=aws
+
+# enabled if hostplatform=local
+[localips]
+# list of ip addresses that you can build on (requires you to have access to those build instances)
+# note you cannot have multiple of the same ip addresses i.e. localhost, localhost
+# ips can be listed in username@hostname:port syntax
+localhost
+
+[local]
+# type of fpga supported (options are "xilinx-u250")
+fpgatype=xilinx-u250
+
 [afibuild]
 
 s3bucketname=firesim-AWSUSERNAME


### PR DESCRIPTION
This is an initial sketch on how to run `buildafi` locally and have it do specific logic to one FPGA. This hopefully will transition into a later Local FireSim full PR.

Things to think about / ask:
- Why not just use `local` for the `replace_rtl` step? Why use `execute` with `run`?
- Right now I'm using `managerinit` + `--localrun` to only copy files over and not do any other AWS stuff... better way to do this?
- Clean up the class hierarchy / abstract more things away.
- Ctrl-C when running the `replace_rtl` step doesn't cancel the RTL build.