### PR TITLE
[simif] Hide SEED output unless explicitly set

### DIFF
--- a/sim/midas/src/main/cc/simif.cc
+++ b/sim/midas/src/main/cc/simif.cc
@@ -18,7 +18,6 @@ simif_t::simif_t() {
   pass = true;
   t = 0;
   fail_t = 0;
-  seed = time(NULL); // FIXME: better initail seed?
   SIMULATIONMASTER_0_substruct_create;
   this->master_mmio_addrs = SIMULATIONMASTER_0_substruct;
   LOADMEMWIDGET_0_substruct_create;
@@ -44,11 +43,11 @@ void simif_t::init(int argc, char** argv, bool log) {
     }
     if (arg.find("+seed=") == 0) {
       seed = strtoll(arg.c_str() + 6, NULL, 10);
+      user_provided_seed = true;
       fprintf(stderr, "Using custom SEED: %ld\n", seed);
     }
   }
   gen.seed(seed);
-  fprintf(stderr, "random min: 0x%llx, random max: 0x%llx\n", gen.min(), gen.max());
   if (!fastloadmem && !loadmem.empty()) {
     load_mem(loadmem.c_str());
   }
@@ -81,7 +80,9 @@ int simif_t::finish() {
   record_end_times();
   fprintf(stderr, "[%s] %s Test", pass ? "PASS" : "FAIL", TARGET_NAME);
   if (!pass) { fprintf(stdout, " at cycle %llu", fail_t); }
-  fprintf(stderr, "SEED: %ld\n", seed);
+  if (this->user_provided_seed) {
+      fprintf(stderr, "User-provided SEED: %ld\n", seed);
+  }
   this->print_simulation_performance_summary();
 
   return pass ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -32,9 +32,19 @@ class simif_t
     bool pass;
     uint64_t t;
     uint64_t fail_t;
-    // random numbers
-    uint64_t seed;
+    // Randomization.
+    // Bridges may use this seed to initalize their own RNG where
+    // necessary, but should be explicit about its effect on target behavior.
+    //
+    // Currently, no bridges or other simulation functions used during an
+    // FPGA-hosted simulation will change target behavior (e.g., assertion
+    // times, instruction traces) as a function of this seed.
+    uint64_t seed = 0;
+    bool user_provided_seed = false;
+
+    // Legacy RNG that backs simif_t::rand_next(), which be removed in a future release.
     std::mt19937_64 gen;
+
     SIMULATIONMASTER_struct * master_mmio_addrs;
     LOADMEMWIDGET_struct * loadmem_mmio_addrs;
     PEEKPOKEBRIDGEMODULE_struct * defaultiowidget_mmio_addrs;


### PR DESCRIPTION
The SEED is not used anywhere that will affect the target, so mask it's output until we start using it / reimplement it in a safer way. simif_t::rand_next is used in a few places, so i'll remove it and simif_t::gen() when i factor out the peek-poke widget from simif as well. 

