### PR TITLE
[TracerV] Support Heterogenous Mixes of Cores 

### DIFF
--- a/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
@@ -64,7 +64,7 @@ class TracerVBridge(insnWidths: TracedInstructionWidths, numInsns: Int) extends 
   // a lowered verilog module.
   //
   // See https://github.com/firesim/firesim/issues/729.
-  val defnameSuffix = s"_${numInsns}Wide_" + insnWidths.toString.replaceAll("[(),]", "_")
+  def defnameSuffix = s"_${numInsns}Wide_" + insnWidths.toString.replaceAll("[(),]", "_")
 
   override def desiredName = super.desiredName + defnameSuffix
 }


### PR DESCRIPTION
Previously, FIRRTL CheckHighForm would croak because different tracerV target black boxes would have different port definitions. This works around that problem by giving a parameterized name to each black box based on the widths of it's IO. 

Providing widths as parameters in the black box does not suffice to fix this problem, because the _length_ of the Vec of traced instruction can vary from bridge to bridge. 

Also adds some scaladoc. 

Resolves #729. 