### PR TITLE
Improve Bridge Host IFs

### DIFF
--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -76,7 +76,7 @@ class FPGATop(implicit p: Parameters) extends LazyModule with UnpackedWrapperCon
     "Simulation control bus must be 32-bits wide per AXI4-lite specification")
   lazy val config = p(SimWrapperKey)
   val master = addWidget(new SimulationMaster)
-  val bridgeModuleMap: Map[BridgeIOAnnotation, BridgeModule[_ <: TokenizedRecord]] = bridgeAnnos.map(anno => anno -> addWidget(anno.elaborateWidget)).toMap
+  val bridgeModuleMap: Map[BridgeIOAnnotation, BridgeModule[_ <: Record with HasChannels]] = bridgeAnnos.map(anno => anno -> addWidget(anno.elaborateWidget)).toMap
 
   // Find all bridges that wish to be allocated FPGA DRAM, and group them
   // according to their memoryRegionName. Requested addresses will be unified

--- a/sim/midas/src/main/scala/midas/core/SimUtils.scala
+++ b/sim/midas/src/main/scala/midas/core/SimUtils.scala
@@ -7,6 +7,8 @@ import chisel3.util._
 import chisel3.experimental.{Direction}
 import chisel3.experimental.DataMirror.directionOf
 
+import firrtl.annotations.ReferenceTarget
+
 import scala.collection.mutable.{ArrayBuffer}
 
 // A collection of useful types and methods for moving between target and host-land interfaces
@@ -86,5 +88,12 @@ object SimUtils {
     case b: Record => b.elements.flatMap({ case (_, field) => findClocks(field) }).toSeq
     case v: Vec[_] => v.flatMap(findClocks)
     case o => Seq()
+  }
+
+  // !FIXME! FCCA renamer can't handle flattening of an aggregate target; so do it manually
+  def lowerAggregateIntoLeafTargets(bits: Data): Seq[ReferenceTarget] = {
+    val (ins, outs, _, _) = SimUtils.parsePorts(bits)
+    require (ins.isEmpty || outs.isEmpty, "Aggregate should be uni-directional")
+    (ins ++ outs).map({ case (leafField, _) => leafField.toNamed.toTarget })
   }
 }

--- a/sim/midas/src/main/scala/midas/widgets/Bridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Bridge.scala
@@ -3,16 +3,14 @@
 package midas
 package widgets
 
-import midas.core.{SimWrapperChannels, SimUtils}
-import midas.core.SimUtils.{RVChTuple}
-import midas.passes.fame.{FAMEChannelConnectionAnnotation,DecoupledForwardChannel, PipeChannel, DecoupledReverseChannel, WireChannel}
+import midas.core.{SimWrapperChannels}
 
 import freechips.rocketchip.config.{Parameters, Field}
 
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.{BaseModule, Direction, ChiselAnnotation, annotate}
-import firrtl.annotations.{ReferenceTarget, JsonProtocol, HasSerializationHints}
+import firrtl.annotations.{ReferenceTarget, ModuleTarget, JsonProtocol, HasSerializationHints}
 
 import scala.reflect.runtime.{universe => ru}
 
@@ -26,13 +24,11 @@ import scala.reflect.runtime.{universe => ru}
 // Set in FPGA Top before the BridgeModule is generated
 case object TargetClockInfo extends Field[Option[RationalClock]]
 
-abstract class TokenizedRecord extends Record with HasChannels
-
-abstract class BridgeModule[HostPortType <: TokenizedRecord]()(implicit p: Parameters) extends Widget()(p) {
+abstract class BridgeModule[HostPortType <: Record with HasChannels]()(implicit p: Parameters) extends Widget()(p) {
   def module: BridgeModuleImp[HostPortType]
 }
 
-abstract class BridgeModuleImp[HostPortType <: TokenizedRecord]
+abstract class BridgeModuleImp[HostPortType <: Record with HasChannels]
     (wrapper: BridgeModule[_ <: HostPortType])
     (implicit p: Parameters) extends WidgetImp(wrapper) {
   def hPort: HostPortType
@@ -47,7 +43,7 @@ abstract class BridgeModuleImp[HostPortType <: TokenizedRecord]
 
 }
 
-trait Bridge[HPType <: TokenizedRecord, WidgetType <: BridgeModule[HPType]] {
+trait Bridge[HPType <: Record with HasChannels, WidgetType <: BridgeModule[HPType]] {
   self: BaseModule =>
   def constructorArg: Option[_ <: AnyRef]
   def bridgeIO: HPType
@@ -57,7 +53,7 @@ trait Bridge[HPType <: TokenizedRecord, WidgetType <: BridgeModule[HPType]] {
     // Adapted from https://medium.com/@giposse/scala-reflection-d835832ed13a
     val mirror = ru.runtimeMirror(getClass.getClassLoader)
     val classType = mirror.classSymbol(getClass)
-    // The base class here is Bridge, but it has not yet been parameterized. 
+    // The base class here is Bridge, but it has not yet been parameterized.
     val baseClassType = ru.typeOf[Bridge[_,_]].typeSymbol.asClass
     // Now this will be the type-parameterized form of Bridge
     val baseType = ru.internal.thisType(classType).baseType(baseClassType)
@@ -78,112 +74,17 @@ trait Bridge[HPType <: TokenizedRecord, WidgetType <: BridgeModule[HPType]] {
 }
 
 trait HasChannels {
-  // A template of the target-land port that is channelized in this host-land port
-  protected def targetPortProto: Data
-
-  // Conventional channels corresponding to a single, unidirectioned token stream
-  def outputWireChannels: Seq[(Data, String)]
-  def inputWireChannels: Seq[(Data, String)]
-
-  // Ready-valid channels with bidirectional token streams.
-  // Used to emit special channel annotations to generate MIDAS I-like
-  // simulators that run with FMR=1
-  def outputRVChannels: Seq[RVChTuple]
-  def inputRVChannels: Seq[RVChTuple]
-
-  // Called to emit FCCAs in the target RTL in order to assign the target
-  // port's fields to channels
+  /**
+    *  Called to emit FCCAs in the target RTL in order to assign the target
+    *  port's fields to channels.
+    */
   def generateAnnotations(): Unit
+
+  /**
+    * Returns a list of channel names for which FAMECHannelConnectionAnnotations have been generated
+    */
+  def allChannelNames(): Seq[String]
 
   // Called in FPGATop to connect the instantiated bridge to channel ports on the wrapper
   private[midas] def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, channels: SimWrapperChannels): Unit
-
-  /*
-   * Implementation follows
-   *
-   */
-  private[midas] def getClock(): Clock = {
-    val allTargetClocks = SimUtils.findClocks(targetPortProto)
-    require(allTargetClocks.nonEmpty,
-      s"Target-side bridge interface of ${targetPortProto.getClass} has no clock field.")
-    require(allTargetClocks.size == 1,
-      s"Target-side bridge interface of ${targetPortProto.getClass} has ${allTargetClocks.size} clocks but must define only one.")
-    allTargetClocks.head
-  }
-
-  private[midas] def outputChannelNames(): Seq[String] = outputWireChannels.map(_._2)
-  private[midas] def inputChannelNames(): Seq[String] = inputWireChannels.map(_._2)
-
-  private def getRVChannelNames(channels: Seq[RVChTuple]): Seq[String] =
-    channels.flatMap({ channel =>
-      val (fwd, rev) =  SimUtils.rvChannelNamePair(channel)
-      Seq(fwd, rev)
-    })
-
-  private[midas] def outputRVChannelNames = getRVChannelNames(outputRVChannels)
-  private[midas] def inputRVChannelNames = getRVChannelNames(inputRVChannels)
-
-  private[midas] def allChannelNames(): Seq[String] = inputChannelNames ++ outputChannelNames ++
-    outputRVChannelNames ++ inputRVChannelNames
-
-  // !FIXME! FCCA renamer can't handle flattening of an aggregate target; so do it manually
-  protected def lowerAggregateIntoLeafTargets(bits: Data): Seq[ReferenceTarget] = {
-    val (ins, outs, _, _) = SimUtils.parsePorts(bits)
-    require (ins.isEmpty || outs.isEmpty, "Aggregate should be uni-directional")
-    (ins ++ outs).map({ case (leafField, _) => leafField.toNamed.toTarget })
-  }
-
-  // Create a wire channel annotation
-  protected def generateWireChannelFCCAs(channels: Seq[(Data, String)], bridgeSunk: Boolean = false, latency: Int = 0): Unit = {
-    for ((field, chName) <- channels) {
-      annotate(new ChiselAnnotation { def toFirrtl =
-        if (bridgeSunk) {
-          FAMEChannelConnectionAnnotation.source(chName, PipeChannel(latency), Some(getClock.toNamed.toTarget), Seq(field.toNamed.toTarget))
-        } else {
-          FAMEChannelConnectionAnnotation.sink(chName, PipeChannel(latency), Some(getClock.toNamed.toTarget), Seq(field.toNamed.toTarget))
-        }
-      })
-    }
-  }
-
-  // Create Ready Valid channel annotations assuming bridge-sourced directions
-  protected def generateRVChannelFCCAs(channels: Seq[(ReadyValidIO[Data], String)], bridgeSunk: Boolean = false): Unit = {
-    for ((field, chName) <- channels) yield {
-      // Generate the forward channel annotation
-      val (fwdChName, revChName)  = SimUtils.rvChannelNamePair(chName)
-      annotate(new ChiselAnnotation { def toFirrtl = {
-        val clockTarget = Some(getClock.toNamed.toTarget)
-        val validTarget = field.valid.toNamed.toTarget
-        val readyTarget = field.ready.toNamed.toTarget
-        val leafTargets = Seq(validTarget) ++ lowerAggregateIntoLeafTargets(field.bits)
-        // Bridge is the sink; it applies target backpressure
-        if (bridgeSunk) {
-          FAMEChannelConnectionAnnotation.source(
-            fwdChName,
-            DecoupledForwardChannel.source(validTarget, readyTarget),
-            clockTarget,
-            leafTargets
-          )
-        } else {
-        // Bridge is the source; it asserts target-valid and recieves target-backpressure
-          FAMEChannelConnectionAnnotation.sink(
-            fwdChName,
-            DecoupledForwardChannel.sink(validTarget, readyTarget),
-            clockTarget,
-            leafTargets
-          )
-        }
-      }})
-
-      annotate(new ChiselAnnotation { def toFirrtl = {
-        val clockTarget = Some(getClock.toNamed.toTarget)
-        val readyTarget = Seq(field.ready.toNamed.toTarget)
-        if (bridgeSunk) {
-          FAMEChannelConnectionAnnotation.sink(revChName, DecoupledReverseChannel, clockTarget, readyTarget)
-        } else {
-          FAMEChannelConnectionAnnotation.source(revChName, DecoupledReverseChannel, clockTarget, readyTarget)
-        }
-      }})
-    }
-  }
 }

--- a/sim/midas/src/main/scala/midas/widgets/Bridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Bridge.scala
@@ -81,7 +81,7 @@ trait HasChannels {
   def generateAnnotations(): Unit
 
   /**
-    * Returns a list of channel names for which FAMECHannelConnectionAnnotations have been generated
+    * Returns a list of channel names for which FAMEChannelConnectionAnnotations have been generated
     */
   def allChannelNames(): Seq[String]
 

--- a/sim/midas/src/main/scala/midas/widgets/BridgeAnnotations.scala
+++ b/sim/midas/src/main/scala/midas/widgets/BridgeAnnotations.scala
@@ -78,7 +78,7 @@ case class SerializableBridgeAnnotation[T <: AnyRef](
 case class InMemoryBridgeAnnotation(
     val target: ModuleTarget,
     channelNames: Seq[String],
-    widget: (Parameters) => BridgeModule[_ <: TokenizedRecord]) extends BridgeAnnotation {
+    widget: (Parameters) => BridgeModule[_ <: Record with HasChannels]) extends BridgeAnnotation {
   def duplicate(n: ModuleTarget) = this.copy(target)
   def toIOAnnotation(port: String): BridgeIOAnnotation = {
     val channelMapping = channelNames.map(oldName => oldName -> s"${port}_$oldName")
@@ -115,7 +115,7 @@ private[midas] case class BridgeIOAnnotation(
     val target: ReferenceTarget,
     channelMapping: Map[String, String],
     clockInfo: Option[RationalClock] = None,
-    widget: Option[(Parameters) => BridgeModule[_ <: TokenizedRecord]] = None,
+    widget: Option[(Parameters) => BridgeModule[_ <: Record with HasChannels]] = None,
     widgetClass: Option[String] = None,
     widgetConstructorKey: Option[_ <: AnyRef] = None)
     extends SingleTargetAnnotation[ReferenceTarget] with FAMEAnnotation with HasSerializationHints {
@@ -132,7 +132,7 @@ private[midas] case class BridgeIOAnnotation(
   // Elaborates the BridgeModule using the lambda if it exists
   // Otherwise, uses reflection to find the constructor for the class given by
   // widgetClass, passing it the widgetConstructorKey
-  def elaborateWidget(implicit p: Parameters): BridgeModule[_ <: TokenizedRecord] = {
+  def elaborateWidget(implicit p: Parameters): BridgeModule[_ <: Record with HasChannels] = {
     val px = p alterPartial { case TargetClockInfo => clockInfo }
     widget match {
       case Some(elaborator) => elaborator(px)
@@ -144,7 +144,7 @@ private[midas] case class BridgeIOAnnotation(
             println(s"  With constructor arguments: $key")
             constructor.newInstance(key, px)
           case None => constructor.newInstance(px)
-        }).asInstanceOf[BridgeModule[_ <: TokenizedRecord]]
+        }).asInstanceOf[BridgeModule[_ <: Record with HasChannels]]
     }
   }
 }
@@ -153,7 +153,7 @@ private[midas] case class BridgeIOAnnotation(
 private[midas] object BridgeIOAnnotation {
   // Useful when a pass emits these annotations directly; (they aren't promoted from BridgeAnnotation)
   def apply(target: ReferenceTarget,
-            widget: (Parameters) => BridgeModule[_ <: TokenizedRecord],
+            widget: (Parameters) => BridgeModule[_ <: Record with HasChannels],
             channelNames: Seq[String]): BridgeIOAnnotation =
    BridgeIOAnnotation(target, channelNames.map(p => p -> p).toMap, widget = Some(widget))
 }

--- a/sim/midas/src/main/scala/midas/widgets/ChannelizedHostPort.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ChannelizedHostPort.scala
@@ -4,95 +4,144 @@ package midas.widgets
 
 import midas.core.SimWrapperChannels
 
+import midas.passes.fame.{FAMEChannelInfo, FAMEChannelConnectionAnnotation}
+
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{Direction}
+import chisel3.experimental.{Direction, ChiselAnnotation, annotate}
 import chisel3.experimental.DataMirror.directionOf
+
+import firrtl.annotations.ReferenceTarget
 
 import scala.collection.mutable
 
-abstract class ChannelizedHostPortIO(protected val targetPortProto: Data) extends TokenizedRecord {
-  // Call in port definition to register a field as belonging to a unique channel
-  def InputChannel[T <: Data](field: T) = channel(Direction.Input)(field)
-  def OutputChannel[T <: Data](field: T) = channel(Direction.Output)(field)
+/**
+  * A utility trait for translating chisel references into unidirected FCCAs
+  * This becomes more useful when there are channel types.
+  *
+  */
+sealed trait ChannelMetadata {
+  def clockRT(): Option[ReferenceTarget]
+  def chInfo(): FAMEChannelInfo
+  def fieldRTs(): Seq[ReferenceTarget]
+  def bridgeSunk: Boolean
+  // Channel name is passed as an argument here because it is determined reflexively after the record
+  // is constructed -- it's not avaiable when the metadata instance is created
+  def generateAnnotations(chName: String): Seq[ChiselAnnotation] = {
+    Seq(new ChiselAnnotation { def toFirrtl =
+      if (bridgeSunk) {
+        FAMEChannelConnectionAnnotation.source(chName, chInfo, clockRT, fieldRTs)
+      } else {
+        FAMEChannelConnectionAnnotation.sink(chName, chInfo, clockRT, fieldRTs)
+      }
+    })
+  }
+}
 
-  private val _inputWireChannels = mutable.ArrayBuffer[(Data, ReadyValidIO[Data])]()
-  private val _outputWireChannels = mutable.ArrayBuffer[(Data, ReadyValidIO[Data])]()
-  lazy val fieldToChannelMap = Map((_inputWireChannels ++ _outputWireChannels):_*)
+case class PipeChannelMetadata(field: Data, clock: Clock, bridgeSunk: Boolean, latency: Int = 0) extends ChannelMetadata {
+  def fieldRTs = Seq(field.toTarget)
+  def clockRT = Some(clock.toTarget)
+  def chInfo = midas.passes.fame.PipeChannel(latency)
+}
+
+/**
+  * A host-side bridge interface trait that permits finer-grained control over
+  * channel definition versus [[HostPortIO]]. Required for describing bridges
+  * that are combinationally coupled to the target.
+  *
+  */
+trait ChannelizedHostPortIO extends HasChannels { this: Record =>
+  // All channels in a bridge are "tokenized" on the positive edge of a single
+  // clock. With this, the user provides a reference to a clock, either on the
+  // target-side bridge itself or elsewhere in the target, which will encode
+  // this relationship in emitted channel annotations.
+  def targetClockRef: Clock
+
+  type ChannelType[A <: Data] = DecoupledIO[A]
+  // This is built up with invocations to [[InputChannel]] and [[OutputChannel]]
+  // _1 -> A reference to the target field (directioned if elaborated as part
+  //       of the target-side of the bridge) 
+  // _2 -> The associated host-channel (an actual element in this aggregate, unlike above)
+  // _3 -> Associated metadate which will encode for the FCCA
+  private val channels = mutable.ArrayBuffer[(Data, ChannelType[_ <: Data], ChannelMetadata)]()
+
+  // These will only be called after the record has been finalized.
+  lazy private val fieldToChannelMap = Map((channels.map(t => t._1 -> t._2)):_*)
+  private def reverseElementMap = elements.map({ case (chName, chField) => chField -> chName  }).toMap
 
   private def getLeafDirs(token: Data): Seq[Direction] = token match {
-    case c: Clock => throw new Exception("Tokens cannot contain clock fields")
+    case c: Clock => Seq(directionOf(c))
     case b: Record => b.elements.flatMap({ case (_, e) => getLeafDirs(e)}).toSeq
     case v: Vec[_] => v.flatMap(getLeafDirs)
     case b: Bits => Seq(directionOf(b))
   }
+
+  private def checkFieldDirection(field: Data, bridgeSunk: Boolean): Unit = {
+    val directions = getLeafDirs(field)
+    val isUnidirectional = directions.zip(directions.tail).map({ case (a, b) => a == b }).foldLeft(true)(_ && _)
+    require(isUnidirectional, "Token channels must have a unidirectioned payload")
+    val channelDir = if (bridgeSunk) Direction.Input else Direction.Output
+    require(directions.head == channelDir,
+      s"Direction of target fields ${directions.head} must match direction of requested channel.")
+  }
+
   // Simplifying assumption: if the user wants to aggregate a bunch of wires
   // into a single channel they should aggregate them into a Bundle on their record
-  private def channel[T <: Data](direction: Direction)(field: T): DecoupledIO[T] = {
-    val directions = getLeafDirs(field)
-    val isUnidirectional = directions.zip(directions.tail).map({ case (a, b) => a == b })
-                                                          .foldLeft(true)(_ && _)
-    require(isUnidirectional, "Token channels must have a unidirectioned payload")
-    require(directions.head == direction)
-
-    directions.head match {
-      case Direction.Input => {
-        val ch = Flipped(Decoupled(field.cloneType))
-        _inputWireChannels += (field -> ch)
-        ch
-      }
-      case Direction.Output => {
-        val ch = Decoupled(field.cloneType)
-        _outputWireChannels += (field -> ch)
-        ch
-      }
+  private def channelField[T <: Data](direction: Direction, field: T): ChannelType[T] = {
+    val ch = direction match {
+      case Direction.Input => Flipped(Decoupled(field.cloneType))
+      case Direction.Output => Decoupled(field.cloneType)
+      case _ => throw new Exception("Channel direction must be Input or Output")
     }
+    ch
   }
 
-  private def checkAllFieldsAssignedToChannels(): Unit = {
-    def prefixWith(prefix: String, base: Any): String =
-      if (prefix != "")  s"${prefix}.${base}" else base.toString
-
-    def loop(name: String, field: Data): Seq[(String, Boolean)] = field match {
-      case c: Clock => Seq(name -> true)
-      case b: Record if fieldToChannelMap.isDefinedAt(b) => Seq(name -> true)
-      case b: Record => b.elements.flatMap({ case (n, e) => loop(prefixWith(name, n), e) }).toSeq
-      case v: Vec[_] if fieldToChannelMap.isDefinedAt(v) => Seq(name -> true)
-      case v: Vec[_] => (v.zipWithIndex).flatMap({ case (e, i) => loop(s"${name}_$i", e) })
-      case b: Bits => Seq(name -> fieldToChannelMap.isDefinedAt(b))
-    }
-    val messages = loop("", targetPortProto).collect({ case (name, assigned) if !assigned =>
-      "Field ${name} of bridge IO is not assigned to a channel"})
-    assert(messages.isEmpty, messages.mkString("\n"))
+  /**
+    * Marks an input to the bridge as being a distinct channel. It will become a
+    * bridge-sunk ready-valid interface on this host port definition, with the
+    * target datatype as its payload.
+    *
+    * @param field A field in the target interface that corresponds to a channel.F
+    *
+    */
+  def InputChannel[A <: Data](field: A): ChannelType[A] = {
+    val ch = channelField(Direction.Input, field)
+    channels.append((field, ch, PipeChannelMetadata(field, targetClockRef, bridgeSunk = true)))
+    ch
   }
 
-  def inputWireChannels: Seq[(Data, String)] = {
-    checkAllFieldsAssignedToChannels()
-    val reverseElementMap = elements.map({ case (name, field) => field -> name  }).toMap
-    _inputWireChannels.map({ case (tField, channel) => (tField, reverseElementMap(channel)) })  
+  /**
+    * The reverse of [[ChannelizedHostPortIO.InputChannel]], in that it marks
+    * an output to the bridge as being a distinct channel.
+    *
+    * @param field A field in the target interface that corresponds to a channel.
+    *
+    */
+  def OutputChannel[A <: Data](field: A): ChannelType[A] = {
+    val ch = channelField(Direction.Output, field)
+    channels.append((field, ch, PipeChannelMetadata(field, targetClockRef, bridgeSunk = false)))
+    ch
   }
 
-  def outputWireChannels: Seq[(Data, String)] = {
-    checkAllFieldsAssignedToChannels()
-    val reverseElementMap = elements.map({ case (name, field) => field -> name  }).toMap
-    _outputWireChannels.map({ case (tField, channel) => (tField, reverseElementMap(channel)) })  
-  }
-
-  def inputRVChannels = Seq.empty
-  def outputRVChannels = Seq.empty
-
+  // Implement methods of HasChannels
   def generateAnnotations(): Unit = {
-    generateWireChannelFCCAs(inputWireChannels, bridgeSunk = true)
-    generateWireChannelFCCAs(outputWireChannels, bridgeSunk = false)
+    for ((targetField, channelElement, metadata) <- channels) {
+      checkFieldDirection(targetField, metadata.bridgeSunk)
+      metadata.generateAnnotations(reverseElementMap(channelElement)).map(a => annotate(a))
+    }
   }
 
-  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, channels: SimWrapperChannels): Unit = {
+  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, simWrapper: SimWrapperChannels): Unit = {
     val local2globalName = bridgeAnno.channelMapping.toMap
-    for (localName <- inputChannelNames) {
-      elements(localName) <> channels.wireOutputPortMap(local2globalName(localName))
-    }
-    for (localName <- outputChannelNames) {
-      channels.wireInputPortMap(local2globalName(localName)) <> elements(localName)
+    for ((_, channel, metadata) <- channels) {
+      val localName = reverseElementMap(channel)
+      if (metadata.bridgeSunk) {
+        channel <> simWrapper.wireOutputPortMap(local2globalName(localName))
+      } else {
+        simWrapper.wireInputPortMap(local2globalName(localName)) <> channel
+      }
     }
   }
+
+  def allChannelNames() = channels.map(ch => reverseElementMap(ch._2))
 }

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -114,24 +114,12 @@ object RationalClockBridge {
   * @param numClocks The total number of clocks in the channel (inclusive of the base clock)
   *
   */
-class ClockTokenVector(numClocks: Int) extends TokenizedRecord with ClockBridgeConsts {
-  def targetPortProto(): Vec[Bool] = Vec(numClocks, Bool())
-  val clocks = new DecoupledIO(targetPortProto)
+class ClockTokenVector(numClocks: Int) extends Bundle with HasChannels with ClockBridgeConsts {
+  val clocks = new DecoupledIO(Vec(numClocks, Bool()))
 
-  def outputWireChannels = Seq(clocks -> clockChannelName)
-  def inputWireChannels = Seq()
-  def outputRVChannels = Seq()
-  def inputRVChannels = Seq()
-
-  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, simIo: SimWrapperChannels): Unit = {
-    val local2globalName = bridgeAnno.channelMapping.toMap
-    for (localName <- outputChannelNames) {
-      simIo.clockElement._2 <> elements(localName)
-    }
-  }
-
-  val elements = collection.immutable.ListMap(clockChannelName -> clocks)
-  override def cloneType(): this.type = new ClockTokenVector(numClocks).asInstanceOf[this.type]
+  def allChannelNames = Seq(clockChannelName)
+  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, simIo: SimWrapperChannels): Unit =
+    simIo.clockElement._2 <> clocks
   def generateAnnotations(): Unit = {}
 }
 

--- a/sim/midas/src/test/scala/midas/widgets/ChannelizedHostPortIOSpec.scala
+++ b/sim/midas/src/test/scala/midas/widgets/ChannelizedHostPortIOSpec.scala
@@ -1,0 +1,89 @@
+// See LICENSE for license details.
+
+package goldengate.tests.widgets
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import chisel3._
+import chisel3.stage.ChiselStage
+import chisel3.experimental.BaseModule
+
+import freechips.rocketchip.config.Parameters
+
+import midas.widgets._
+
+// Can't elaborate a top-level that is a blackbox, so wrap it
+class BlackBoxWrapper(mod: => BaseModule) extends MultiIOModule {
+  val testMod = Module(mod)
+}
+
+class ChannelizedHostPortIOSpec extends AnyFlatSpec {
+  // 
+  class BridgeTargetIO extends Bundle {
+    val out = Output(Bool())
+    val in =  Input(Bool())
+    val bidir = new Bundle {
+      val in = Input(Bool())
+      val out = Output(Bool())
+    }
+    val clock = Input(Clock())
+  }
+
+  // With the targetIO above, create a few simple misconfigurations by using
+  // only a subset of the IO
+  class IncorrectInputChannel(proto: BridgeTargetIO) extends Bundle with ChannelizedHostPortIO {
+    def targetClockRef = proto.clock
+    val inCh = InputChannel(proto.out)
+  }
+
+  class IncorrectOutputChannel(proto: BridgeTargetIO) extends Bundle with ChannelizedHostPortIO {
+    def targetClockRef = proto.clock
+    val outCh = OutputChannel(proto.in)
+  }
+
+  class DisallowedBidirChannel(proto: BridgeTargetIO) extends Bundle with ChannelizedHostPortIO {
+    def targetClockRef = proto.clock
+    val bidirCh = OutputChannel(proto.bidir)
+  }
+
+  class CorrectHostPort(proto: BridgeTargetIO) extends Bundle with ChannelizedHostPortIO {
+    def targetClockRef = proto.clock
+    val outCh = OutputChannel(proto.out)
+    val inCh = InputChannel(proto.in)
+    val bidirInCh = InputChannel(proto.bidir.in)
+    val bidirOutCh = OutputChannel(proto.bidir.out)
+  }
+
+  class BridgeMock[T <: Bundle with ChannelizedHostPortIO](gen: (BridgeTargetIO) => T) extends BlackBox {
+    val io = IO(new BridgeTargetIO)
+    val bridgeIO = gen(io)
+    bridgeIO.generateAnnotations()
+  }
+
+  def elaborateBlackBox(mod: =>BaseModule): Unit = ChiselStage.emitChirrtl(new BlackBoxWrapper(mod))
+
+  def checkElaborationRequirement(mod: =>BaseModule): Unit = {
+    assertThrows[java.lang.IllegalArgumentException] {
+      try {
+        elaborateBlackBox(mod)
+      } catch {
+        // Strip away the outer ChiselException and rethrow to get a more precise cause
+        case ce: ChiselException => println(ce.getCause); throw ce.getCause
+      }
+    }
+  }
+
+  "ChannelizedHostPortIO" should "reject outputs incorrectly labelled as input channels" in {
+    checkElaborationRequirement(new BridgeMock( { new IncorrectInputChannel(_) } ))
+  }
+  it should "reject inputs incorreclty labelled as output channels" in {
+    checkElaborationRequirement(new BridgeMock( { new IncorrectOutputChannel(_) } ))
+  }
+  it should "reject channels with bidirectional payloads"  in {
+    checkElaborationRequirement(new BridgeMock( { new DisallowedBidirChannel(_) } ))
+  }
+  it should "elaborate correctly otherwise"  in {
+    elaborateBlackBox(new BridgeMock( { new CorrectHostPort(_) }))
+  }
+}


### PR DESCRIPTION
This pulls in (and simplifies) some changes from my dissertation branch to make it easier to build more advanced bridges:

* Removes a deeply unhygienic, non-private reference to a bound piece of hardware (`targetPortProto`)  from `HasChannels`. It's been pushed into HostPortIO, where it can be made private. `HasChannels` is now as thin as possible. 
* Removes `TokenizedRecord` because it effectively forbids extending `Bundle` with `HasChannels`

With these changes it's possible to succinctly define host interfaces like so: 
```scala
// Target side
class ResetPulseBridgeTargetIO extends Bundle {                                                     
  val clock = Input(Clock())                                                                        
  val reset = Output(Bool())                                                                        
}  

// Host side
 class ResetPulseBridgeHostIO(targetIO: ResetPulseBridgeTargetIO = new ResetPulseBridgeTargetIO)                                         
      extends Bundle with ChannelizedHostPortIO {                                                                                                     
    def targetClockRef = targetIO.clock                                                                                                   
    val reset = OutputChannel(targetIO.reset)                                                                                             
 }    
