### PR TITLE
Introduce a ResetPulseBridge to Remove An Early Deadlock Condition

### DIFF
--- a/sim/midas/src/main/cc/bridges/reset_pulse.cc
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.cc
@@ -1,0 +1,39 @@
+#ifdef RESETPULSEBRIDGEMODULE_struct_guard
+
+#include "reset_pulse.h"
+
+reset_pulse_t::reset_pulse_t(
+  simif_t* sim,
+  std::vector<std::string> &args,
+  RESETPULSEBRIDGEMODULE_struct * mmio_addrs,
+  unsigned int max_pulse_length,
+  unsigned int default_pulse_length,
+  int reset_index):
+    bridge_driver_t(sim),
+    mmio_addrs(mmio_addrs),
+    max_pulse_length(max_pulse_length),
+    default_pulse_length(default_pulse_length),
+    reset_index(reset_index) {
+
+  std::string num_equals = std::to_string(reset_index) + std::string("=");
+  std::string pulse_length_arg  = std::string("+reset-pulse-length") + num_equals;
+
+  for (auto arg: args) {
+    if (arg.find(pulse_length_arg) == 0) {
+      char *str = const_cast<char*>(arg.c_str()) + pulse_length_arg.length();
+      this->pulse_length = atol(str);
+    }
+  }
+  if (this->pulse_length > this->max_pulse_length) {
+    fprintf(stderr, "Requested reset length of %u exceeds bridge maximum of %u cycles.\n",
+            this->pulse_length, this->max_pulse_length);
+    abort();
+  }
+}
+
+void reset_pulse_t::init() {
+  write(this->mmio_addrs->pulseLength, this->pulse_length);
+  write(this->mmio_addrs->doneInit, 1);
+}
+
+#endif // RESETPULSEBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/reset_pulse.h
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.h
@@ -1,0 +1,48 @@
+#ifndef __RESET_PULSE_H
+#define __RESET_PULSE_H
+
+#ifdef RESETPULSEBRIDGEMODULE_struct_guard
+
+#include <vector>
+
+#include "bridge_driver.h"
+
+// Bridge Driver Instantiation Template
+#define INSTANTIATE_RESET_PULSE(FUNC,IDX) \
+     RESETPULSEBRIDGEMODULE_ ## IDX ## _substruct_create; \
+     FUNC(new reset_pulse_t( \
+        this, \
+        args, \
+        RESETPULSEBRIDGEMODULE_ ## IDX ## _substruct, \
+        RESETPULSEBRIDGEMODULE_ ## IDX ## _max_pulse_length, \
+        RESETPULSEBRIDGEMODULE_ ## IDX ## _default_pulse_length, \
+        IDX)); \
+
+class reset_pulse_t: public bridge_driver_t
+{
+
+    public:
+        reset_pulse_t(simif_t* sim,
+                      std::vector<std::string> &args,
+                      RESETPULSEBRIDGEMODULE_struct * mmio_addrs,
+                      unsigned int max_pulse_length,
+                      unsigned int default_pulse_length,
+                      int reset_index);
+        // Bridge interface
+        virtual void init();
+        virtual void tick() {};
+        virtual bool terminate() { return false; };
+        virtual int exit_code() { return 0; };
+        virtual void finish() {};
+    private:
+        RESETPULSEBRIDGEMODULE_struct * mmio_addrs;
+        const unsigned int max_pulse_length;
+        const unsigned int default_pulse_length;
+        const int reset_index;
+
+        unsigned int pulse_length = default_pulse_length;
+};
+
+#endif // RESETPULSEBRIDGEMODULE_struct_guard
+
+#endif //__RESET_PULSE_H

--- a/sim/midas/src/main/scala/midas/widgets/ResetPulseBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ResetPulseBridge.scala
@@ -1,0 +1,87 @@
+//See LICENSE for license details
+
+package midas.widgets
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.config.Parameters
+
+import scala.collection.immutable
+
+/**
+  * The [[ResetPulseBridge]] drives a bool pulse from time zero for a
+  * runtime-configurable number of cycles. These are its elaboration-time parameters.
+  *
+  * @param activeHigh When true, reset is initially set at time 0.
+  * @param defaultPulseLength The number of cycles the reset is held at the time 0 value.
+  * @param maxPulseLength The maximum runtime-configurable pulse length that the bridge will support.
+  */
+case class ResetPulseBridgeParameters(
+    activeHigh: Boolean = true,
+    defaultPulseLength: Int = 50,
+    maxPulseLength: Int = 1023) {
+  require(defaultPulseLength <= maxPulseLength)
+}
+
+class ResetPulseBridgeTargetIO extends Bundle {
+  val clock = Input(Clock())
+  val reset = Output(Bool())
+}
+
+/**
+  * The host-side interface. This bridge has single channel with a bool
+  * payload. [[ChannelizedHostPortIO.OutputChannel]] associates the reset on
+  * the target side IF with a channel named reset on the host-side
+  * BridgeModule (determined by reflection, since we're extending Bundle).
+  *
+  * @param targetIO A reference to the bound target-side interface. This need
+  *        only be a hardware type during target-side instantiation, so that the
+  *        direction of the channel can be properly checked, and the correct
+  *        annotation can be emitted. During host-side instantiation, the unbound
+  *        default is used --- this is OK because generateAnnotations() will not be
+  *        called.
+  *
+  *        NB: This !MUST! be a private val when extending bundle, otherwise you'll get
+  *        some extra elements in your host-side IF.
+  */
+class ResetPulseBridgeHostIO(private val targetIO: ResetPulseBridgeTargetIO = new ResetPulseBridgeTargetIO)
+    extends Bundle with ChannelizedHostPortIO {
+  def targetClockRef = targetIO.clock
+  val reset = OutputChannel(targetIO.reset)
+}
+
+class ResetPulseBridge(params: ResetPulseBridgeParameters)
+    extends BlackBox with Bridge[ResetPulseBridgeHostIO, ResetPulseBridgeModule] {
+  val io = IO(new ResetPulseBridgeTargetIO)
+  val bridgeIO = new ResetPulseBridgeHostIO(io)
+  val constructorArg = Some(params)
+  generateAnnotations()
+}
+
+class ResetPulseBridgeModule(cfg: ResetPulseBridgeParameters)(implicit p: Parameters)
+    extends BridgeModule[ResetPulseBridgeHostIO]()(p) {
+  lazy val module = new BridgeModuleImp(this) {
+    val io = IO(new WidgetIO())
+    val hPort = IO(new ResetPulseBridgeHostIO())
+
+    val remainingPulseLength = genWOReg(Wire(UInt(log2Ceil(cfg.maxPulseLength + 1).W)), "pulseLength")
+    val pulseComplete = remainingPulseLength === 0.U
+    val doneInit = genWORegInit(Wire(Bool()), "doneInit", false.B)
+
+    hPort.reset.valid := doneInit
+    hPort.reset.bits := pulseComplete ^ cfg.activeHigh.B
+
+    when (hPort.reset.fire) {
+      remainingPulseLength := Mux(pulseComplete, 0.U, remainingPulseLength - 1.U)
+    }
+
+    override def genHeader(base: BigInt, sb: StringBuilder) {
+      import CppGenerationUtils._
+      val headerWidgetName = getWName.toUpperCase
+      super.genHeader(base, sb)
+      sb.append(genConstStatic(s"${headerWidgetName}_max_pulse_length", UInt32(cfg.maxPulseLength)))
+      sb.append(genConstStatic(s"${headerWidgetName}_default_pulse_length", UInt32(cfg.defaultPulseLength)))
+    }
+    genCRFile()
+  }
+}

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -10,6 +10,7 @@
 #include "bridges/tracerv.h"
 #include "bridges/groundtest.h"
 #include "bridges/autocounter.h"
+#include "bridges/reset_pulse.h"
 #include "bridges/dromajo.h"
 
 // Golden Gate provided bridge drivers
@@ -40,6 +41,9 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
     add_bridge_driver(new heartbeat_t(this, args));
 
+    #ifdef RESETPULSEBRIDGEMODULE_0_PRESENT
+    INSTANTIATE_RESET_PULSE(add_bridge_driver, 0)
+    #endif
 
 // DOC include start: UART Bridge Driver Registration
     // Here we instantiate our driver once for each bridge in the target

--- a/sim/src/main/cc/midasexamples/Driver.cc
+++ b/sim/src/main/cc/midasexamples/Driver.cc
@@ -79,6 +79,8 @@
 #include "PassthroughModels.h"
 #elif defined DESIGNNAME_PassthroughModelBridgeSource
 #include "PassthroughModels.h"
+#elif defined DESIGNNAME_ResetPulseBridgeTest
+#include "ResetPulseBridgeTest.h"
 #endif
 
 class dut_emul_t:

--- a/sim/src/main/cc/midasexamples/ResetPulseBridgeTest.h
+++ b/sim/src/main/cc/midasexamples/ResetPulseBridgeTest.h
@@ -1,0 +1,24 @@
+//See LICENSE for license details.
+
+#include "simif.h"
+#include "bridges/reset_pulse.h"
+
+#include <vector>
+
+class ResetPulseBridgeTest_t: virtual simif_t {
+  public:
+    reset_pulse_t * rb;
+    // Define a dummy function so we can use the instantiation macro
+    void register_rb(reset_pulse_t * new_rb) { rb = new_rb; }
+
+    ResetPulseBridgeTest_t(int argc, char** argv) {
+      std::vector<std::string> args(argv + 1, argv + argc);
+      INSTANTIATE_RESET_PULSE(register_rb, 0)
+    }
+    // Since we rely on an assertion firing to catch a failure, just run a
+    // similation that is at least the length of the expected pulse.
+    void run() {
+      rb->init();
+      step(2 * RESETPULSEBRIDGEMODULE_0_max_pulse_length);
+    }
+};

--- a/sim/src/main/scala/midasexamples/Config.scala
+++ b/sim/src/main/scala/midasexamples/Config.scala
@@ -34,3 +34,6 @@ class AutoCounterPrintf extends Config((site, here, up) => {
   case AutoCounterUsePrintfImpl => true
 })
 
+class NoSynthAsserts extends Config((site, here, up) => {
+  case SynthAsserts => false
+})

--- a/sim/src/main/scala/midasexamples/ResetPulseBridgeTest.scala
+++ b/sim/src/main/scala/midasexamples/ResetPulseBridgeTest.scala
@@ -1,0 +1,48 @@
+//See LICENSE for license details.
+
+package firesim.midasexamples
+
+import chisel3._
+import freechips.rocketchip.config.{Parameters, Field, Config}
+import midas.widgets.{RationalClockBridge, PeekPokeBridge, ResetPulseBridge, ResetPulseBridgeParameters}
+
+case object ResetPulseBridgeActiveHighKey extends Field[Boolean](true)
+class ResetPulseBridgeActiveLowConfig extends Config((site, here, up) => {
+  case ResetPulseBridgeActiveHighKey => false
+})
+
+object ResetPulseBridgeTestConsts {
+  val maxPulseLength = 1023
+}
+
+/**
+  * Instantiates the ResetClockBridge, and checks the created pulse matches an
+  * elaboration-time defined expected value with an unsynthesized assert.
+  *
+  * @param p Parameters instance. See above for relavent keys.
+  */
+
+class ResetPulseBridgeTest(implicit p: Parameters) extends RawModule {
+  import ResetPulseBridgeTestConsts._
+  val clock = RationalClockBridge().io.clocks.head
+
+  // TODO Remove once PeekPoke is excised from simif
+  val dummy = WireInit(false.B)
+  val peekPokeBridge = PeekPokeBridge(clock, dummy)
+
+  val activeHigh = p(ResetPulseBridgeActiveHighKey)
+  val resetBridge = Module(new ResetPulseBridge(ResetPulseBridgeParameters(
+    activeHigh = activeHigh,
+    // This will be overridden to the maxPulseLength by the bridge's plusArg
+    defaultPulseLength = 1,
+    maxPulseLength = maxPulseLength)))
+  resetBridge.io.clock := clock
+
+  withClockAndReset(clock, false.B) {
+    // Zero initialized
+    val cycle = Reg(UInt(32.W))
+    cycle := cycle + 1.U
+    printf(p"Cycle: ${cycle} Reset: ${resetBridge.io.reset}\n")
+    assert((cycle < maxPulseLength.U) ^ (resetBridge.io.reset ^ activeHigh.B))
+  }
+}

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -275,6 +275,26 @@ class PassthroughModelBridgeSourceTest extends TutorialSuite("PassthroughModelBr
   expectedFMR(1.0)
 }
 
+class ResetPulseBridgeActiveHighTest extends TutorialSuite(
+    "ResetPulseBridgeTest",
+    // Disable assertion synthesis to rely on native chisel assertions to catch bad behavior
+    platformConfigs = "NoSynthAsserts_HostDebugFeatures_DefaultF1Config",
+    simulationArgs = Seq(s"+reset-pulse-length0=${ResetPulseBridgeTestConsts.maxPulseLength}")) {
+  runTest(backendSimulator,
+    args = Seq(s"+reset-pulse-length0=${ResetPulseBridgeTestConsts.maxPulseLength + 1}"),
+    shouldPass = false)
+}
+
+class ResetPulseBridgeActiveLowTest extends TutorialSuite(
+    "ResetPulseBridgeTest",
+    targetConfigs = "ResetPulseBridgeActiveLowConfig",
+    platformConfigs = "NoSynthAsserts_HostDebugFeatures_DefaultF1Config",
+    simulationArgs = Seq(s"+reset-pulse-length0=${ResetPulseBridgeTestConsts.maxPulseLength}")) {
+  runTest(backendSimulator,
+    args = Seq(s"+reset-pulse-length0=${ResetPulseBridgeTestConsts.maxPulseLength + 1}"),
+    shouldPass = false)
+}
+
 // Suite Collections
 class ChiselExampleDesigns extends Suites(
   new GCDF1Test,
@@ -321,12 +341,14 @@ class GoldenGateMiscCITests extends Suites(
   new MultiRegF1Test
 )
 
-// Each group runs on a single worker instance
+// These groups are vestigial from CircleCI container limits
 class CIGroupA extends Suites(
   new ChiselExampleDesigns,
   new PrintfSynthesisCITests,
   new firesim.fasedtests.CIGroupA,
-  new AutoCounterCITests
+  new AutoCounterCITests,
+  new ResetPulseBridgeActiveHighTest,
+  new ResetPulseBridgeActiveLowTest,
 )
 
 class CIGroupB extends Suites(

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -38,15 +38,28 @@ abstract class TutorialSuite(
   }
 
 
-  def runTest(b: String, debug: Boolean = false) {
-    compileMlSimulator(b, debug)
-    val testEnv = s"${b} MIDAS-level simulation" + { if (debug) " with waves enabled" else "" }
+  /**
+    * Runs MIDAS-level simulation on the design.
+    *
+    * @param b Backend simulator: "verilator" or "vcs"
+    * @param debug When true, captures waves from the simulation
+    * @param args A seq of PlusArgs to pass to the simulator.
+    * @param shouldPass When false, asserts the test returns a non-zero code
+    */
+  def runTest(b: String, debug: Boolean = false, args: Seq[String] = simulationArgs, shouldPass: Boolean = true) {
+    val prefix =  if (shouldPass) "pass in " else "fail in "
+    val testEnvStr  = s"${b} MIDAS-level simulation"
+    val wavesStr = if (debug) " with waves enabled" else ""
+    val argStr = " with args: " + args.mkString(" ")
+
+    val haveThisBehavior = prefix + testEnvStr + wavesStr + argStr
+
     if (isCmdAvailable(b)) {
-      it should s"pass in ${testEnv}" in {
-        assert(run(b, debug, args = simulationArgs) == 0)
+      it should haveThisBehavior in {
+         assert((run(b, debug, args = args) == 0) == shouldPass)
       }
     } else {
-      ignore should s"pass in ${testEnv}" in { }
+      ignore should haveThisBehavior in { }
     }
   }
 
@@ -124,6 +137,7 @@ abstract class TutorialSuite(
   mkdirs()
   behavior of s"$targetName"
   elaborateAndCompile()
+  compileMlSimulator(backendSimulator)
   runTest(backendSimulator)
 }
 


### PR DESCRIPTION
Currently, reset in the target is implemented using the peek-poke widget, via a blocking call to `simif_t::target_reset`. Since other bridges are not being ticked while this function executes, the simulator can deadlock near time zero if any bridge stalls waiting on an invocation of `tick` (e.g., a synthesized assertion fires). 

This PR introduces a dedicated bridge that can produce a runtime-configurable reset pulse to drive the target. This will subsume target_reset(), allowing the simulator to enter it's main loop immediately upon simulation commence. 

Before i can remove target_reset from firesim_top, i'll need to instantiate the bridge in Chipyard. I will open separate PRs to do that after the release has been handled, and this PR has been merged. 

This is based off the hostIF PR (#778); i'll retarget to dev once it is merged. 