### PR TITLE
Bump to AMI 1.10 / AWS FPGA 1.4.19 / Vivado 2020

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -12,7 +12,7 @@ from fabric.api import local, hide, settings
 rootLogger = logging.getLogger()
 
 # this needs to be updated whenever the FPGA Dev AMI changes
-f1_ami_name = "FPGA Developer AMI - 1.6.1-40257ab5-6688-4c95-97d1-e251a40fd1fc-ami-01d5f32a3d517960b.4"
+f1_ami_name = "FPGA Developer AMI - 1.10.0-40257ab5-6688-4c95-97d1-e251a40fd1fc"
 
 def aws_resource_names():
     """ Get names for various aws resources the manager relies on. For example:

--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,27 +10,27 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0a0835b8c7f4fc6f3
+agfi=agfi-03ed6ca96115e8928
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-030dd5e1f7ca10d7a
+agfi=agfi-0a661df465d022916
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0935c26b816db7722
+agfi=agfi-0be82221639089652
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0a6cbb217f7cc16d6
+agfi=agfi-0da1f137842ad9850
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-0d2a8ebe39e59943f
+agfi=agfi-061f3675f9b73624d
 deploytripletoverride=None
 customruntimeconfig=None
 


### PR DESCRIPTION
This bumps AWS FPGA to get us hopefully better QoR and retiming support, and to support the new AMI. 

The old mechanism of unloading XOCL had to change for the new AMI. 

#### Related PRs / Issues
#728 

<!-- List any related issues here -->

#### UI / API Impact

No user visible change.

#### Verilog / AGFI Compatability

AGFIs have been regenerated, though the input verilog is the same. 

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatability impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [x] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you mark the proper milestone (1.12.0, 1.13.0) ?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
