### PR TITLE
Use FIRRTL 'FPGA backend' passes in the GG compiler for better BRAM use

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/xilinx/package.scala
+++ b/sim/midas/src/main/scala/midas/passes/xilinx/package.scala
@@ -20,16 +20,9 @@ package object xilinx {
     }
   }
 
-  object FPGAFriendlyMems extends Transform with NoAnalysisPass {
-    val transformer = StatementTransformer {
-      case mem: DefMemory if (mem.readLatency == 1 && mem.readUnderWrite == ReadUnderWrite.Undefined) =>
-        mem.copy(readUnderWrite = ReadUnderWrite.Old)
-    }
-  }
-
   object HostSpecialization extends SeqTransform {
     val inputForm = LowForm
     val outputForm = LowForm
-    val transforms = Seq(DefineBUFGCE, ReplaceAbstractClockGates, FPGAFriendlyMems)
+    val transforms = Seq(DefineBUFGCE, ReplaceAbstractClockGates)
   }
 }


### PR DESCRIPTION
This is a template for how I used the "FPGA backend" passes from chipsalliance/firrtl#2111 as part of the `GoldenGateCompilerPhase` to get better BRAM utilization. Adding these passes allows, for example, 2-RW memories like those in the faster async-mem model from #672 to be implemented with BRAMs. Since FireSim uses a custom compiler, it is generally better to mix them in with custom dependencies rather than running an FPGA-backend-enabled FIRRTL flow monolithically before or after the FireSim-specific passes.

This PR will not compile until the FIRRTL that FireSim depends on is bumped to include the new FPGA-backend passes, but I am opening this as a draft to show how I've integrated them with a locally-bumped FIRRTL repo.
