### PR TITLE
Add XDC Emission Support + Multicycle Setup constraints

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,27 +10,27 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-03ed6ca96115e8928
+agfi=agfi-020f55d5f8ff00dd4
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0a661df465d022916
+agfi=agfi-0e668e4c6524bb039
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0be82221639089652
+agfi=agfi-0f6d1a87970642c84
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0da1f137842ad9850
+agfi=agfi-08aa5142244e1378b
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-061f3675f9b73624d
+agfi=agfi-079909d9a5b64ce0e
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/firesim-lib/src/main/scala/passes/EC2F1Artefacts.scala
+++ b/sim/firesim-lib/src/main/scala/passes/EC2F1Artefacts.scala
@@ -19,40 +19,30 @@ import java.io.{File, FileWriter}
 object EC2F1Artefacts extends Transform {
   def inputForm: CircuitForm = LowForm
   def outputForm: CircuitForm = LowForm
-  override def name = "[FireSim] EC2 F1 Artefact Generation"
-
-  def writeOutputFile(f: File, contents: String): File = {
-    val fw = new FileWriter(f)
-    fw.write(contents)
-    fw.close
-    f
-  }
+  override def name = "[Golden Gate] EC2 F1 Artefact Generation"
 
   // Capture FPGA-toolflow related verilog defines
-  def generateHostVerilogHeader(targetDir: File) {
-    val headerName = "cl_firesim_generated_defines.vh"
-    writeOutputFile(new File(targetDir, headerName), s"\n")
-  }
+  def verilogHeaderAnno = GoldenGateOutputFileAnnotation(
+    """| # Strips out Chisel's default $fatal emission which Vivado chokes on
+       | `define SYNTHESIS
+       | # Don't let Vivado see $random, which is the default if this is not set
+       | `define RANDOM 64'b0
+       |""".stripMargin,
+    fileSuffix = "_defines.vh")
 
   // Emit TCL variables to control the FPGA compilation flow
-  def generateTclEnvFile(targetDir: File)(implicit hostParams: Parameters) {
-    val headerName = "cl_firesim_generated_env.tcl"
+  def tclEnvAnno(implicit hostParams: Parameters): GoldenGateOutputFileAnnotation =  {
     val requestedFrequency = hostParams(DesiredHostFrequency)
     val buildStrategy      = hostParams(BuildStrategy)
     val constraints = s"""# FireSim Generated Environment Variables
 set desired_host_frequency ${requestedFrequency}
 ${buildStrategy.emitTcl}
 """
-    writeOutputFile(new File(targetDir, headerName), constraints)
+    GoldenGateOutputFileAnnotation(constraints, fileSuffix = "_env.tcl")
   }
 
   def execute(state: CircuitState): CircuitState = {
     implicit val p = state.annotations.collectFirst({ case ConfigParametersAnnotation(p)  => p }).get
-    val targetDir = state.annotations.collectFirst({
-      case TargetDirAnnotation(dir) => new File(dir)
-    }).get
-    generateHostVerilogHeader(targetDir)
-    generateTclEnvFile(targetDir)
-    state
+    state.copy(annotations = verilogHeaderAnno +: tclEnvAnno +: state.annotations)
   }
 }

--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -7,24 +7,28 @@ r_dir = $(abspath ../resources)
 ########################################################################
 # Parameters:
 # 1) PLATFORM: FPGA platform board(by default zynq)
-# 2) DESIGN: Target design of midas
+# 2) DRIVER_NAME: Base name for compiled drivers and ML simulators
 # 3) GEN_DIR: Directory for generated source code
 # 4) OUT_DIR: Directory for binary files (by default GEN_DIR)
-# 5) DRIVER: software driver written by user
-# 6) CLOCK_PERIOD(optional): clock period of tests
-# 7) VERILATOR_FLAGS(optional): set of verilator flags to add
+# 5) GEN_FILE_BASENAME: Common prefix for all GG-emitted output files
+# 6) DRIVER: software driver written by user
+# 7) CLOCK_PERIOD(optional): clock period of tests
+# 8) VERILATOR_FLAGS(optional): set of verilator flags to add
 ########################################################################
-ifeq ($(strip $(DESIGN)),)
-$(error Define DESIGN, the target design)
+ifeq ($(strip $(DRIVER_NAME)),)
+$(error Define DRIVER_NAME, the base name used for compiled simulators and simulator drivers.)
+endif
+ifeq ($(strip $(GEN_FILE_BASENAME)),)
+$(error Define GEN_FILE_BASENAME, the base name used for all Golden Gate-generated files.)
 endif
 ifeq ($(strip $(GEN_DIR)),)
-$(error Define GEN_DIR, where all midas generated code reside)
+$(error Define GEN_DIR, the directory containing all Golden Gate-generated files.)
 endif
 ifeq ($(strip $(TOP_DIR)),)
 $(error Define TOP_DIR, the top of the chipyard directory)
 endif
 ifeq ($(strip $(DRIVER)),)
-$(error Define DRIVER, the source code of the simulation driver)
+$(error Define DRIVER, additional source files for the simulation driver)
 endif
 
 PLATFORM ?= zynq
@@ -32,13 +36,9 @@ OUT_DIR ?= $(GEN_DIR)
 CLOCK_PERIOD ?= 1.0
 
 $(info platform: $(PLATFORM))
-$(info target design: $(DESIGN))
 $(info generated source directory: $(GEN_DIR))
 $(info output directory: $(OUT_DIR))
-$(info driver source files: $(DRIVER))
 $(info clock period: $(CLOCK_PERIOD))
-
-shim := FPGATop
 
 testchip_dir=$(TOP_DIR)/generators/testchipip/src/main/resources
 testchip_csrc_dir=$(testchip_dir)/testchipip/csrc
@@ -51,16 +51,13 @@ include $(util_dir)/utils.mk
 $(OUT_DIR)/dramsim2_ini: $(testchip_dir)/dramsim2_ini
 	ln -sf $< $@
 
-$(OUT_DIR)/$(DESIGN).chain:
-	$(if $(wildcard $(GEN_DIR)/$(DESIGN).chain),cp $(GEN_DIR)/$(DESIGN).chain $@,)
-
 override CXXFLAGS += -I$(midas_dir) -I$(util_dir)
 # The trailing whitespace is important for some reason...
 override LDFLAGS := $(LDFLAGS) -L$(GEN_DIR) -lstdc++ -lpthread -lgmp -lmidas 
 
-design_v  := $(GEN_DIR)/$(shim).v
-design_h  := $(GEN_DIR)/$(DESIGN)-const.h
-design_vh := $(GEN_DIR)/$(DESIGN)-const.vh
+design_v  := $(GEN_DIR)/$(GEN_FILE_BASENAME).v
+design_h  := $(GEN_DIR)/$(GEN_FILE_BASENAME)_const.h
+design_vh := $(GEN_DIR)/$(GEN_FILE_BASENAME)_const.vh
 driver_h = $(foreach t, $(DRIVER), $(wildcard $(dir $(t))/*.h))
 bridge_h := $(wildcard $(bridge_dir)/*.h)
 bridge_cc := $(wildcard $(bridge_dir)/*.cc)
@@ -77,12 +74,12 @@ $(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h) $(platform_h)
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -include $(word 2, $^)
 
-$(OUT_DIR)/$(DESIGN)-$(PLATFORM): $(design_h) $(lib) $(DRIVER) $(driver_h) $(platform_o) $(bridge_o)
+$(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(design_h) $(lib) $(DRIVER) $(driver_h) $(platform_o) $(bridge_o)
 	mkdir -p $(OUT_DIR)
 	$(CXX) $(CXXFLAGS) -include $< \
 	-o $@ $(DRIVER) $(lib_o) $(platform_o) $(bridge_o) $(LDFLAGS)
 
-$(PLATFORM): $(OUT_DIR)/$(DESIGN)-$(PLATFORM) $(OUT_DIR)/$(DESIGN).chain
+$(PLATFORM): $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
 
 # Sources for building MIDAS-level simulators. Must be defined before sources VCS/Verilator Makefrags
 override CFLAGS += -include $(design_h)
@@ -102,8 +99,8 @@ verilator_harness := emul/verilator-harness.cc
 top_module := verilator_top
 include rtlsim/Makefrag-verilator
 
-verilator: $(OUT_DIR)/V$(DESIGN) $(OUT_DIR)/$(DESIGN).chain $(OUT_DIR)/dramsim2_ini
-verilator-debug: $(OUT_DIR)/V$(DESIGN)-debug $(OUT_DIR)/$(DESIGN).chain $(OUT_DIR)/dramsim2_ini
+verilator: $(OUT_DIR)/V$(DRIVER_NAME) $(OUT_DIR)/dramsim2_ini
+verilator-debug: $(OUT_DIR)/V$(DRIVER_NAME)-debug $(OUT_DIR)/dramsim2_ini
 
 # Add an extra wrapper source for VCS simulators
 vcs_wrapper_v := $(v_dir)/vcs_top.v
@@ -112,7 +109,7 @@ TB := emul
 VCS_FLAGS := -e vcs_main
 include rtlsim/Makefrag-vcs
 
-vcs: $(OUT_DIR)/$(DESIGN) $(OUT_DIR)/$(DESIGN).chain $(OUT_DIR)/dramsim2_ini
-vcs-debug: $(OUT_DIR)/$(DESIGN)-debug $(OUT_DIR)/$(DESIGN).chain $(OUT_DIR)/dramsim2_ini
+vcs: $(OUT_DIR)/$(DRIVER_NAME) $(OUT_DIR)/dramsim2_ini
+vcs-debug: $(OUT_DIR)/$(DRIVER_NAME)-debug $(OUT_DIR)/dramsim2_ini
 
 .PHONY: $(PLATFORM) verilator verilator-debug vcs vcs-debug

--- a/sim/midas/src/main/scala/midas/core/SimWrapper.scala
+++ b/sim/midas/src/main/scala/midas/core/SimWrapper.scala
@@ -241,7 +241,7 @@ class TargetBoxIO(config: SimWrapperConfig) extends ChannelizedWrapperIO(config)
   }
 
   val clockElement: (String, DecoupledIO[Data]) = chAnnos.collectFirst({
-    case ch @ FAMEChannelConnectionAnnotation(globalName, fame.TargetClockChannel(_), _, _, Some(sinks)) =>
+    case ch @ FAMEChannelConnectionAnnotation(globalName, fame.TargetClockChannel(_, _), _, _, Some(sinks)) =>
       sinks.head.ref.stripSuffix("_bits") -> Flipped(Decoupled(regenClockType(sinks)))
   }).get
 
@@ -262,7 +262,7 @@ class SimWrapperChannels(config: SimWrapperConfig) extends ChannelizedWrapperIO(
   def regenClockType(refTargets: Seq[ReferenceTarget]): Vec[Bool] = Vec(refTargets.size, Bool())
 
   val clockElement: (String, DecoupledIO[Vec[Bool]]) = chAnnos.collectFirst({
-    case ch @ FAMEChannelConnectionAnnotation(globalName, fame.TargetClockChannel(_), _, _, Some(sinks)) =>
+    case ch @ FAMEChannelConnectionAnnotation(globalName, fame.TargetClockChannel(_,_), _, _, Some(sinks)) =>
       sinks.head.ref.stripSuffix("_bits") -> Flipped(Decoupled(regenClockType(sinks)))
   }).get
 
@@ -436,7 +436,7 @@ class SimWrapper(val config: SimWrapperConfig)(implicit val p: Parameters) exten
   channelGroups foreach { case (name,  annos) => genPipeChannel(annos, name) }
 
   // Generate clock channels
-  val clockChannels = chAnnos.collect({case ch @ FAMEChannelConnectionAnnotation(_, fame.TargetClockChannel(_),_,_,_)  => ch })
+  val clockChannels = chAnnos.collect({case ch @ FAMEChannelConnectionAnnotation(_, fame.TargetClockChannel(_,_),_,_,_)  => ch })
   require(clockChannels.size == 1)
   genClockChannel(clockChannels.head)
 }

--- a/sim/midas/src/main/scala/midas/passes/TargetClockAnalysis.scala
+++ b/sim/midas/src/main/scala/midas/passes/TargetClockAnalysis.scala
@@ -26,7 +26,7 @@ object ChannelClockInfoAnalysis extends Transform {
   def outputForm = LowForm
   def analyze(state: CircuitState): Map[String, RationalClock] = {
     val clockChannels = state.annotations.collect {
-      case FAMEChannelConnectionAnnotation(_,TargetClockChannel(clocks),_,_,Some(clockRTs)) =>
+      case FAMEChannelConnectionAnnotation(_,TargetClockChannel(clocks,_),_,_,Some(clockRTs)) =>
         clockRTs zip clocks
     }
     require(clockChannels.size == 1,

--- a/sim/midas/src/main/scala/midas/passes/TriggerWiring.scala
+++ b/sim/midas/src/main/scala/midas/passes/TriggerWiring.scala
@@ -191,7 +191,7 @@ private[passes] object TriggerWiring extends firrtl.Transform {
 
       // Step 6) Synchronize and aggregate local counts into global counts in the base clock domain
       val refClockRT = wiredState.annotations.collectFirst({
-        case FAMEChannelConnectionAnnotation(_,TargetClockChannel(_),_,_,Some(clock :: _)) => clock
+        case FAMEChannelConnectionAnnotation(_,TargetClockChannel(_,_),_,_,Some(clock :: _)) => clock
       }).get
 
       // We only need to use a single register to synchronize a signal in GG, we use two here

--- a/sim/midas/src/main/scala/midas/passes/WriteXDCFile.scala
+++ b/sim/midas/src/main/scala/midas/passes/WriteXDCFile.scala
@@ -1,0 +1,62 @@
+// See LICENSE for license details.
+
+package midas.passes
+
+import java.io.{File, FileWriter}
+import firrtl._
+import firrtl.stage.Forms
+import firrtl.annotations._
+import firrtl.analyses.InstanceKeyGraph
+
+import midas.stage.XDCOutputNameAnnotation
+import midas.targetutils.{XDCAnnotation, XDCAnnotationConstants}
+
+private[midas] object WriteXDCFile extends Transform with DependencyAPIMigration with XDCAnnotationConstants {
+	override def prerequisites = Forms.LowForm
+  // Probably should run before emitter?
+
+  private def formatArguments(iGraph: InstanceKeyGraph, argumentList: Iterable[ReferenceTarget]): Iterable[String] = {
+    for (arg <- argumentList) yield {
+      val instances = iGraph.findInstancesInHierarchy(arg.module)
+      instances foreach println
+      require(instances.length == 1)
+      val tokens =
+        instances.head.tail.map { _.Instance.value } ++: // Path to root
+        arg.path.map { _._1.value } ++: // Path in the provided RT
+        arg.ref +: arg.component.map { _.value }
+      tokens.mkString("/")
+    }
+  }
+
+  private def serializeXDC(anno: XDCAnnotation, iGraph: InstanceKeyGraph): String = {
+    val segments = specifierRegex.split(anno.formatString)
+    val formattedArguments = formatArguments(iGraph, anno.argumentList)
+    // :scala emoji:
+    segments.zipAll(formattedArguments, "", "").foldLeft(""){ case (root, (a, b)) => root + a + b }
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    val targetDir = state.annotations.collectFirst({
+      case TargetDirAnnotation(dir) => new File(dir)
+    }).get
+
+    val outputFile = state.annotations.collectFirst({
+      case XDCOutputNameAnnotation(name) => new File(targetDir, name)
+    }).get
+
+    val iGraph = InstanceKeyGraph(state.circuit)
+
+    val xdcStrings = state.annotations.collect { case a: XDCAnnotation => serializeXDC(a, iGraph) }
+
+    val fw = new FileWriter(outputFile)
+    fw.write(xdcStrings.mkString("\n"))
+    fw.close
+
+    val cleanedAnnotations = state.annotations.filterNot {
+      case a: XDCOutputNameAnnotation => true
+      case a: XDCAnnotation => true
+      case _ => false
+    }
+    state.copy(annotations = cleanedAnnotations)
+  }
+}

--- a/sim/midas/src/main/scala/midas/passes/WriteXDCFile.scala
+++ b/sim/midas/src/main/scala/midas/passes/WriteXDCFile.scala
@@ -18,7 +18,6 @@ private[midas] object WriteXDCFile extends Transform with DependencyAPIMigration
   private def formatArguments(iGraph: InstanceKeyGraph, argumentList: Iterable[ReferenceTarget]): Iterable[String] = {
     for (arg <- argumentList) yield {
       val instances = iGraph.findInstancesInHierarchy(arg.module)
-      instances foreach println
       require(instances.length == 1)
       val tokens =
         instances.head.tail.map { _.Instance.value } ++: // Path to root

--- a/sim/midas/src/main/scala/midas/passes/fame/Annotations.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/Annotations.scala
@@ -152,8 +152,16 @@ case object DecoupledReverseChannel extends FAMEChannelInfo
 
 /**
   * Indicates that a channel connection carries target clocks
+  *
+  * @param clockInfo The user specified metadata, includeing a name, and ratio
+  *        relative to the base clock
+  *
+  * @param perClockMFMR Specifies the minimum number of host cycles
+  *        between clock edges. This is a property of the clock token schedule, and
+  *        permits relaxing timing constraints on clock domains with miniumum FMRS (MFMR) > 1.
+  *
   */
-case class TargetClockChannel(clockInfo: Seq[RationalClock])  extends FAMEChannelInfo
+case class TargetClockChannel(clockInfo: Seq[RationalClock], perClockMFMR: Seq[Int]) extends FAMEChannelInfo
 
 /**
   * Indicates that a channel connection is the forward (valid) half of

--- a/sim/midas/src/main/scala/midas/passes/fame/FAMETransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/FAMETransform.scala
@@ -15,6 +15,8 @@ import scala.collection.mutable
 import mutable.{LinkedHashSet, LinkedHashMap}
 
 import midas.passes._
+import midas.targetutils.XDCAnnotation
+import midas.widgets.{RationalClock}
 
 /**************
  PRECONDITIONS:
@@ -70,10 +72,20 @@ trait FAME1DataChannel extends FAME1Channel with HasModelPort {
   }
 }
 
-case class FAME1ClockChannel(name: String, ports: Seq[Port]) extends FAME1Channel with InputChannel with HasModelPort
+trait ClockChannel {
+  def clockInfo: Seq[RationalClock]
+  def clockMFMRs: Seq[Int]
+  lazy val clockMFMRMap: Map[RationalClock, Int] = clockInfo.zip(clockMFMRs).toMap
+}
 
-case class VirtualClockChannel(targetClock: Port) extends FAME1Channel with InputChannel {
+
+case class FAME1ClockChannel(name: String, ports: Seq[Port], clockInfo: Seq[RationalClock], clockMFMRs: Seq[Int])
+    extends FAME1Channel with InputChannel with HasModelPort with ClockChannel
+
+case class VirtualClockChannel(targetClock: Port) extends FAME1Channel with InputChannel with ClockChannel {
   val name = "VirtualClockChannel"
+  val clockInfo = Seq(RationalClock("NonHubClock", 1,1))
+  val clockMFMRs = Seq(1)
   val ports = Seq(targetClock)
   val isValid: Expression = UIntLiteral(1)
   def setReady(advanceCycle: Expression): Statement = EmptyStmt
@@ -107,7 +119,7 @@ case class FAME1OutputChannel(
 // - Use to initialize isFired for all channels (with negation)
 // - Finishing is gated with clock channel valid
 object FAMEModuleTransformer {
-  def apply(m: Module, analysis: FAMEChannelAnalysis): Module = {
+  def apply(m: Module, analysis: FAMEChannelAnalysis, addedAnnos: mutable.ArrayBuffer[Annotation]): Module = {
     // Step 0: Bookkeeping for port structure conventions
     implicit val ns = Namespace(m)
     val mTarget = ModuleTarget(analysis.circuit.main, m.name)
@@ -132,10 +144,11 @@ object FAMEModuleTransformer {
     }
 
 
-    val clockChannel = analysis.modelInputChannelPortMap(mTarget).find(isClockChannel) match {
-      case Some((name, (None, ports))) => FAME1ClockChannel(name, ports)
+    val (currentModuleIsHub, clockChannel) = analysis.modelInputChannelPortMap(mTarget).find(isClockChannel) match {
+      case Some((name, (None, ports))) =>
+        (true, FAME1ClockChannel(name, ports, analysis.targetClockChInfo.clockInfo, analysis.targetClockChInfo.perClockMFMR))
       case Some(_) => ??? // Clock channel cannot have an associated clock domain
-      case None => VirtualClockChannel(clocks.head) // Virtual clock channel for single-clock models
+      case None => (false, VirtualClockChannel(clocks.head)) // Virtual clock channel for single-clock models
     }
 
     /*
@@ -169,7 +182,7 @@ object FAMEModuleTransformer {
       clockBuffer: SignalInfo)
 
     // Multi-clock management step 4: Generate clock buffers for all target clocks
-    val clockMetadata: Seq[TargetClockMetadata] = clockChannel.ports.map { en =>
+    val clockMetadata: Seq[TargetClockMetadata] = clockChannel.ports.zip(clockChannel.clockInfo).map { case (en, info) =>
       val enableReg = hostFlagReg(s"${en.name}_enabled")
       val buf = WDefInstance(ns.newName(s"${en.name}_buffer"), DefineAbstractClockGate.blackbox.name)
       val clockFlag = DoPrim(PrimOps.AsUInt, Seq(clockChannel.replacePortRef(WRef(en))), Nil, BoolType)
@@ -178,6 +191,46 @@ object FAMEModuleTransformer {
         Connect(NoInfo, WSubField(WRef(buf), "I"), WRef(hostClock)),
         Connect(NoInfo, WSubField(WRef(buf), "CE"),
           And.reduce(Seq(WRef(enableReg), WRef(finishing), nReset)))))
+      // Add multicycle annotations
+      val clockName = info.name
+      val clockMFMR = clockChannel.clockMFMRMap(info)
+      val bufferOutputRT = mTarget.ref(buf.name).field("O")
+
+      if (currentModuleIsHub) {
+        // Leverage the MFMR hint provided by the clock bridge to relax the setup constraints on 
+        // intra-domain paths. Do this only for the hub, since it it is the only multiclock model.
+        //
+        // Using this multicycle setup constraint is conservative, since all
+        // inter-clock paths must still close timing at single a host cycle of
+        // delay. If we instead defined these generated clocks by specifying them
+        // as _divisions_ of the host_clock, the timer may give more margin to a
+        // path spanning two slower clock domains, when in reality they must meet
+        // a single host-cycle constraint.  For a counterexample, consider three
+        // clocks with periods of 2, 3, 4. This produces the following clock token schedule:
+        //
+        // token  : 0 1 2 3 4 5
+        // ====================
+        // clk 2  : 1 1 0 1 1 1
+        // clk 3  : 1 0 1 0 1 0
+        // clk 4  : 1 0 0 1 0 1
+        // t_time : 0 2 3 4 6 8
+        //
+        // While the latter two clocks have MFMRs of 2, they sometimes fire in
+        // back-to-back host-cycles (tokens 2->3).
+        //
+        // Note 1: The -hierarchical lookup is only safe to do because we're
+        // quering the netlist in implementation. This will need to change if we
+        // wish to apply these constraints to synthesis.
+        //
+        // Note 2: "host_clock" is defined statically in the shell XDC.
+        val xdcAnno = XDCAnnotation(s"""
+create_generated_clock -name ${clockName} -source [get_pins -of [get_clocks host_clock]] \\
+  [get_pins -hierarchical *{}] -divide_by 1
+set_multicycle_path $clockMFMR -setup -from [get_clocks $clockName] -to [get_clocks $clockName]
+set_multicycle_path 1 -hold  -from [get_clocks $clockName] -to [get_clocks $clockName]""", bufferOutputRT)
+        addedAnnos += xdcAnno
+      }
+
       TargetClockMetadata(
         en,
         WRef(enableReg),
@@ -405,10 +458,12 @@ class FAMETransform extends Transform {
     // TODO: pick a value that does not collide
     implicit val triggerName = "finishing"
 
+    val addedAnnos = mutable.ArrayBuffer[Annotation]()
+
     val toTransform = analysis.transformedModules
     val transformedModules = c.modules.map {
       case m: Module if (m.name == c.main) => transformTop(m, analysis)
-      case m: Module if (toTransform.contains(ModuleTarget(c.main, m.name))) => FAMEModuleTransformer(m, analysis)
+      case m: Module if (toTransform.contains(ModuleTarget(c.main, m.name))) => FAMEModuleTransformer(m, analysis, addedAnnos)
       case m => m // TODO (Albert): revisit this; currently, not transforming nested modules
     }
 
@@ -418,6 +473,6 @@ class FAMETransform extends Transform {
     }
 
     val newCircuit = c.copy(modules = transformedModules)
-    CircuitState(newCircuit, outputForm, filteredAnnos, Some(hostDecouplingRenames(analysis)))
+    CircuitState(newCircuit, outputForm, filteredAnnos ++ addedAnnos, Some(hostDecouplingRenames(analysis)))
   }
 }

--- a/sim/midas/src/main/scala/midas/passes/fame/FAMEUtils.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/FAMEUtils.scala
@@ -240,6 +240,10 @@ private[fame] class FAMEChannelAnalysis(val state: CircuitState, val fameType: F
 
   val hostClock = state.annotations.collect({ case FAMEHostClock(rt) => rt }).head
   val hostReset = state.annotations.collect({ case FAMEHostReset(rt) => rt }).head
+  lazy val targetClockChInfo = state.annotations.collectFirst({
+    case FAMEChannelConnectionAnnotation(_,chInfo: TargetClockChannel,_,_,_) => chInfo
+  }).get
+
 
   private def irPortFromGlobalTarget(mt: ModuleTarget)(rt: ReferenceTarget): Option[Port] = {
     val modelPort = topConnects(rt).pathlessTarget

--- a/sim/midas/src/main/scala/midas/passes/fame/FindDefaultClocks.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/FindDefaultClocks.scala
@@ -109,7 +109,7 @@ object FindDefaultClocks extends Transform {
 
     // Find an arbitrary clock channel sink
     val refClock = state.annotations.collectFirst {
-      case FAMEChannelConnectionAnnotation(_, TargetClockChannel(_), None, _, Some(sinks)) => sinks.head
+      case FAMEChannelConnectionAnnotation(_, TargetClockChannel(_,_), None, _, Some(sinks)) => sinks.head
     }
 
     // Get the wrapper top port reference it points to

--- a/sim/midas/src/main/scala/midas/stage/Annotations.scala
+++ b/sim/midas/src/main/scala/midas/stage/Annotations.scala
@@ -2,8 +2,12 @@
 
 package midas.stage
 
-import firrtl.options.{StageOption, ShellOption, HasShellOptions}
-import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.{StageOption, ShellOption, HasShellOptions, CustomFileEmission}
+import firrtl.annotations.{NoTargetAnnotation, Annotation}
+
+trait GoldenGateFileEmission extends CustomFileEmission { this: Annotation =>
+  override def baseFileName(annotations: firrtl.AnnotationSeq) = "FireSim-generated"
+}
 
 case class ConfigPackageAnnotation(packageName: String) extends NoTargetAnnotation
 

--- a/sim/midas/src/main/scala/midas/stage/Annotations.scala
+++ b/sim/midas/src/main/scala/midas/stage/Annotations.scala
@@ -45,3 +45,16 @@ object RuntimeConfigNameAnnotation extends HasShellOptions {
       shortOption = Some("ggrc"),
       helpValueName = Some("<filename>") ) )
 }
+
+case class XDCOutputNameAnnotation(name: String) extends NoTargetAnnotation
+
+object XDCOutputNameAnnotation extends HasShellOptions {
+
+  val options = Seq(
+    new ShellOption[String](
+      longOption = "xdc-filename",
+      toAnnotationSeq = (a: String) => Seq(XDCOutputNameAnnotation(a)),
+      helpText = "Specifies the filename for the generated xdc file.",
+      shortOption = Some("xf"),
+      helpValueName = Some("<filename>") ) )
+}

--- a/sim/midas/src/main/scala/midas/stage/Annotations.scala
+++ b/sim/midas/src/main/scala/midas/stage/Annotations.scala
@@ -2,14 +2,13 @@
 
 package midas.stage
 
-import firrtl.options.{StageOption, ShellOption, HasShellOptions, CustomFileEmission}
+import firrtl.options.{StageOption, ShellOption, HasShellOptions, CustomFileEmission, Unserializable}
 import firrtl.annotations.{NoTargetAnnotation, Annotation}
 
-trait GoldenGateFileEmission extends CustomFileEmission { this: Annotation =>
-  override def baseFileName(annotations: firrtl.AnnotationSeq) = "FireSim-generated"
-}
+// Prevent configuration annotations from propagating out.
+sealed trait GoldenGateOption extends Unserializable { this: Annotation => }
 
-case class ConfigPackageAnnotation(packageName: String) extends NoTargetAnnotation
+case class ConfigPackageAnnotation(packageName: String) extends NoTargetAnnotation with GoldenGateOption
 
 object ConfigPackageAnnotation extends HasShellOptions {
 
@@ -22,7 +21,7 @@ object ConfigPackageAnnotation extends HasShellOptions {
       helpValueName = Some("<scala package>") ) )
 }
 
-case class ConfigStringAnnotation(configString: String) extends NoTargetAnnotation
+case class ConfigStringAnnotation(configString: String) extends NoTargetAnnotation with GoldenGateOption
 
 object ConfigStringAnnotation extends HasShellOptions {
 
@@ -37,7 +36,7 @@ object ConfigStringAnnotation extends HasShellOptions {
 
 // Used to specify the name of the desired runtime configuration
 // file.  Will be emitted in the TargetDir
-case class RuntimeConfigNameAnnotation(configString: String) extends NoTargetAnnotation
+case class RuntimeConfigNameAnnotation(configString: String) extends NoTargetAnnotation with GoldenGateOption
 
 object RuntimeConfigNameAnnotation extends HasShellOptions {
 
@@ -50,15 +49,15 @@ object RuntimeConfigNameAnnotation extends HasShellOptions {
       helpValueName = Some("<filename>") ) )
 }
 
-case class XDCOutputNameAnnotation(name: String) extends NoTargetAnnotation
+case class OutputBaseFileNameAnnotation(name: String) extends NoTargetAnnotation with GoldenGateOption
 
-object XDCOutputNameAnnotation extends HasShellOptions {
-
+object OutputBaseFileNameAnnotation extends HasShellOptions {
   val options = Seq(
     new ShellOption[String](
-      longOption = "xdc-filename",
-      toAnnotationSeq = (a: String) => Seq(XDCOutputNameAnnotation(a)),
-      helpText = "Specifies the filename for the generated xdc file.",
-      shortOption = Some("xf"),
-      helpValueName = Some("<filename>") ) )
+      longOption = "--base-output-filename",
+      toAnnotationSeq = (a: String) => Seq(OutputBaseFileNameAnnotation(a)),
+      helpText = "Specifies the base (prefix) used on most Golden Gate generated files.",
+      shortOption = Some("bof"),
+      helpValueName = Some("<filename-base>") ) )
 }
+

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCli.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCli.scala
@@ -8,7 +8,7 @@ trait GoldenGateCli { this: Shell =>
   parser.note("Golden Gate Compiler Options")
   Seq(ConfigPackageAnnotation,
       ConfigStringAnnotation,
-      XDCOutputNameAnnotation,
+      OutputBaseFileNameAnnotation,
       firrtl.stage.FirrtlFileAnnotation,
       firrtl.stage.OutputFileAnnotation,
       firrtl.stage.FirrtlSourceAnnotation,

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCli.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCli.scala
@@ -8,6 +8,7 @@ trait GoldenGateCli { this: Shell =>
   parser.note("Golden Gate Compiler Options")
   Seq(ConfigPackageAnnotation,
       ConfigStringAnnotation,
+      XDCOutputNameAnnotation,
       firrtl.stage.FirrtlFileAnnotation,
       firrtl.stage.OutputFileAnnotation,
       firrtl.stage.FirrtlSourceAnnotation,

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
@@ -40,7 +40,10 @@ class GoldenGateCompilerPhase extends Phase with ConfigLookup {
 
     // Lower and emit simulator RTL and run user-requested host-transforms
     val hostLoweringCompiler = new Compiler(
-      Dependency[firrtl.VerilogEmitter] +:
+      // We should probably ensure all provided Host Transforms run before
+      // these two.  Perhaps we should just use a fourth compiler, or make sure
+      // user provided passes specify the write prerequisites?
+      Seq(Dependency[firrtl.VerilogEmitter], Dependency(midas.passes.WriteXDCFile)) ++:
       p(HostTransforms),Forms.LowForm)
     logger.info("Post-GG Host Transformation Ordering\n")
     logger.info(hostLoweringCompiler.prettyPrint("  "))

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateFileEmission.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateFileEmission.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package midas.stage
+
+import firrtl.annotations.{NoTargetAnnotation, Annotation}
+import firrtl.options.{CustomFileEmission}
+
+trait GoldenGateFileEmission extends CustomFileEmission { this: Annotation =>
+
+  // workaround CustomFileEmission's requirement that suffixes begin with ".".
+  // by shadowing the same feature, and appending it ourselves. This is the
+  // easiest way to preserve most of the existing output file names.
+  def fileSuffix: String
+  final def suffix = None
+
+  override def baseFileName(annotations: firrtl.AnnotationSeq) = {
+    val baseName = annotations.collectFirst{ case OutputBaseFileNameAnnotation(name) => name }.get
+    baseName + fileSuffix
+  }
+}
+
+/**
+  * A generic wrapper for output files that have no targets.
+  */
+case class GoldenGateOutputFileAnnotation(body: String, fileSuffix: String)
+    extends NoTargetAnnotation with GoldenGateFileEmission {
+  def getBytes = body.getBytes
+}
+
+/**
+  * Wraps a StringBuilder to incrementally build up an output file annotation.
+  */
+class OutputFileBuilder(header: String, fileSuffix: String) {
+  private val sb = new StringBuilder(header)
+  def getBuilder = sb
+  def append(str: String) = sb.append(str)
+  def toAnnotation = GoldenGateOutputFileAnnotation(sb.toString, fileSuffix)
+}

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -40,6 +40,22 @@ sealed trait ClockBridgeConsts {
 }
 
 /**
+  * Finds a virtual fast-clock whose period is the GCD of the periods of all requested
+  * clocks, and returns the period of each requested clock as an integer multiple of that
+  * high-frequency virtual clock.
+  */
+object FindScaledPeriodGCD {
+  def apply(phaseRelationships: Seq[(Int, Int)]): Seq[BigInt] = {
+    val periodDivisors = phaseRelationships.unzip._1
+    val productOfDivisors  = periodDivisors.foldLeft(BigInt(1))(_ * _)
+    val scaledMultipliers  = phaseRelationships.map({ case (divisor, multiplier) =>  multiplier * productOfDivisors / divisor })
+    val gcdOfScaledPeriods = scaledMultipliers.reduce((a, b) => a.gcd(b))
+    val reducedPeriods     = scaledMultipliers.map(_ / gcdOfScaledPeriods)
+    reducedPeriods
+  }
+}
+
+/**
   * A custom bridge annotation for the Clock Bridge. Unique so that we can
   * trivially match against it in bridge extraction.
   *
@@ -80,12 +96,16 @@ class RationalClockBridge(val allClocks: Seq[RationalClock]) extends BlackBox wi
     val clocks = Output(Vec(allClocks.size, Clock()))
   })
 
+  val scaledPeriods = FindScaledPeriodGCD(allClocks.map { c => (c.multiplier, c.divisor) })
+  val minPeriod = scaledPeriods.min
+  val clockMFMRs = scaledPeriods.map { period => ((period + (minPeriod - 1)) / minPeriod).toInt }
+
   // Generate the bridge annotation
   annotate(new ChiselAnnotation { def toFirrtl = ClockBridgeAnnotation(outer.toTarget, allClocks) })
   annotate(new ChiselAnnotation { def toFirrtl =
       FAMEChannelConnectionAnnotation(
         clockChannelName,
-        channelInfo = TargetClockChannel(allClocks),
+        channelInfo = TargetClockChannel(allClocks, clockMFMRs),
         clock = None, // Clock channels do not have a reference clock
         sinks = Some(io.clocks.map(_.toTarget)),
         sources = None
@@ -171,22 +191,6 @@ class ClockBridgeModule(clockInfo: Seq[RationalClock])(implicit p: Parameters)
     tCycleFastest := tCycleFastest + 1.U
   }
   genCRFile()
-}
-
-/**
-  * Finds a virtual fast-clock whose period is the GCD of the periods of all requested
-  * clocks, and returns the period of each requested clock as an integer multiple of that
-  * high-frequency virtual clock.
-  */
-object FindScaledPeriodGCD {
-  def apply(phaseRelationships: Seq[(Int, Int)]): Seq[BigInt] = {
-    val periodDivisors = phaseRelationships.unzip._1
-    val productOfDivisors  = periodDivisors.foldLeft(BigInt(1))(_ * _)
-    val scaledMultipliers  = phaseRelationships.map({ case (divisor, multiplier) =>  multiplier * productOfDivisors / divisor })
-    val gcdOfScaledPeriods = scaledMultipliers.reduce((a, b) => a.gcd(b))
-    val reducedPeriods     = scaledMultipliers.map(_ / gcdOfScaledPeriods)
-    reducedPeriods
-  }
 }
 
 /**

--- a/sim/midas/src/test/scala/midas/FAMEAnnotationSerializationSpec.scala
+++ b/sim/midas/src/test/scala/midas/FAMEAnnotationSerializationSpec.scala
@@ -28,7 +28,7 @@ class FAMEAnnotationSerialization extends AnyFlatSpec {
   }
 
   "ClockChannel FCCAs" should "serialize and deserialize correctly" in {
-    val clockInfo = TargetClockChannel(Seq(RationalClock("test",1,2)))
+    val clockInfo = TargetClockChannel(Seq(RationalClock("test",1,2)), Seq(1))
     val anno = baseFCCA.copy(channelInfo = clockInfo)
     val deserAnno = serializeAndDeserialize(anno)
     assert(anno == deserAnno)

--- a/sim/midas/targetutils/src/main/scala/midas/XDCAnnotation.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/XDCAnnotation.scala
@@ -1,0 +1,65 @@
+// See LICENSE for license details.
+
+package midas.targetutils
+
+import chisel3._
+import chisel3.experimental.{BaseModule, ChiselAnnotation, annotate}
+
+import firrtl.{RenameMap}
+import firrtl.annotations._
+import firrtl.transforms.DontTouchAllTargets
+
+trait XDCAnnotationConstants {
+  val specifierRegex = "\\{}".r
+}
+
+/**
+  * Encode a string to be emitted to an XDC file with specifiers derived from
+  * ReferenceTargets. RTs are specified using "{}" a la python. This makes the
+  * emitted XDC more robust against the module hierarchy manipulations (such as
+    * promotion/extraction and linking) that golden gate performs.
+  *
+  * For example:
+  *   XDCAnnotation("get_pins -of [get_clocks -hierarchical *{}]", clockRT)
+  *
+  * Would eventually emit:
+  *   get_pins -of [get_clocks -hierarchical *absolute/path/to/clock]
+  *
+  * Here the emission pass by default creates a full instance path to the
+  * reference to avoid multiple matches (in vivado this only really works in
+  * implementation). The wildcard is still included if emitted chisel is
+  * instantiated in a parent verilog hierarchy (as is the case with the F1
+  * shell).  TODO: Provide the enclosing instance path with an
+  * annotation/parameter to emit the full absolute path?
+  *
+  * Restrictions (that can be relaxed in the future, perhaps using different specifiers?):
+  *   - There can only be one instance of the target in the complete netlist
+  *     - Can't point at stuff in duplicated modules
+  *     - Can't point at an aggregates (since it will be lowered to multiple targets)
+  *   - No support for Module or Instance Targets
+  *
+  */
+
+case class XDCAnnotation(formatString: String, argumentList: ReferenceTarget*)
+    extends Annotation with XDCAnnotationConstants
+    // This is included until we figure out how to gracefully handle deletion.
+    with DontTouchAllTargets {
+  def update(renames: RenameMap): Seq[firrtl.annotations.Annotation] = {
+    val renamer = new ReferenceTargetRenamer(renames)
+    Seq(XDCAnnotation(formatString, argumentList.map(a => renamer.exactRename(a)):_*))
+  }
+}
+
+/**
+  * Chisel-side sugar for emitting XDCAnnotations.
+  */
+object XDC extends XDCAnnotationConstants {
+  def apply(formatString: String, argumentList: Data*): Unit = {
+    val numArguments = specifierRegex.findAllIn(formatString).size
+    require(numArguments == argumentList.size,
+      s"Format string requires ${numArguments}, provided ${argumentList.size}")
+    chisel3.experimental.annotate(new ChiselAnnotation {
+      def toFirrtl = XDCAnnotation(formatString, argumentList.map(_.toTarget):_*)
+    })
+  }
+}

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -26,9 +26,6 @@ long_name := $(DESIGN_PACKAGE).$(DESIGN).$(TARGET_CONFIG)
 FIRRTL_FILE := $(GENERATED_DIR)/$(long_name).fir
 ANNO_FILE := $(GENERATED_DIR)/$(long_name).anno.json
 
-VERILOG := $(GENERATED_DIR)/FPGATop.v
-HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
-
 CONF_NAME ?= runtime.conf
 firesim_sbt_project := {file:${firesim_base_dir}/}firesim
 chisel_src_dirs = \

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -26,9 +26,6 @@ long_name := $(DESIGN_PACKAGE).$(DESIGN).$(TARGET_CONFIG)
 FIRRTL_FILE := $(GENERATED_DIR)/$(long_name).fir
 ANNO_FILE := $(GENERATED_DIR)/$(long_name).anno.json
 
-VERILOG := $(GENERATED_DIR)/FPGATop.v
-HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
-
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := {file:${chipyard_dir}}firechip
 

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -21,9 +21,6 @@ long_name := $(DESIGN_PACKAGE).$(DESIGN).$(TARGET_CONFIG)
 FIRRTL_FILE := $(GENERATED_DIR)/$(long_name).fir
 ANNO_FILE := $(GENERATED_DIR)/$(long_name).anno.json
 
-VERILOG := $(GENERATED_DIR)/FPGATop.v
-HEADER  := $(GENERATED_DIR)/$(DESIGN)-const.h
-
 ifdef FIRESIM_STANDALONE
 	firesim_sbt_project := firesim
 else

--- a/sim/src/main/scala/midasexamples/Config.scala
+++ b/sim/src/main/scala/midasexamples/Config.scala
@@ -19,7 +19,11 @@ class DefaultF1Config extends Config(new Config((site, here, up) => {
   case EnableModelMultiThreading => true
   case SynthPrints => true
   case EnableAutoCounter => true
-}) ++ new Config(new firesim.configs.WithEC2F1Artefacts ++ new WithDefaultMemModel ++ new midas.F1Config))
+}) ++ new Config(
+  new firesim.configs.WithEC2F1Artefacts ++
+  new WithDefaultMemModel ++
+  new firesim.configs.WithILATopWiringTransform ++
+  new midas.F1Config))
 
 class PointerChaserConfig extends Config((site, here, up) => {
   case MemSize => BigInt(1 << 30) // 1 GB

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -60,6 +60,7 @@ $(VERILOG) $(HEADER) $(fame_annos): $(FIRRTL_FILE) $(ANNO_FILE) $(SCALA_BUILDTOO
 		-faf $(ANNO_FILE) \
 		-ggcp $(PLATFORM_CONFIG_PACKAGE) \
 		-ggcs $(PLATFORM_CONFIG) \
+		-xf cl_firesim_generated.xdc \
 		--no-dedup \
 		-E verilog \
 	)
@@ -173,6 +174,7 @@ fpga_v         := $(fpga_work_dir)/design/cl_firesim_generated.sv
 ila_work_dir   := $(fpga_work_dir)/design/ila_files/
 fpga_vh        := $(fpga_work_dir)/design/cl_firesim_generated_defines.vh
 fpga_tcl_env   := $(fpga_work_dir)/design/cl_firesim_generated_env.tcl
+fpga_gen_xdc   := $(fpga_work_dir)/design/cl_firesim_generated.xdc
 repo_state     := $(fpga_work_dir)/design/repo_state
 
 $(fpga_work_dir)/stamp: $(shell find $(board_dir)/cl_firesim -name '*')
@@ -192,6 +194,9 @@ $(fpga_vh): $(VERILOG) $(fpga_work_dir)/stamp
 $(fpga_tcl_env): $(VERILOG) $(fpga_work_dir)/stamp
 	cp -f $(GENERATED_DIR)/$(@F) $@
 
+$(fpga_gen_xdc): $(VERILOG) $(fpga_work_dir)/stamp
+	cp -f $(GENERATED_DIR)/$(@F) $@
+
 .PHONY: $(ila_work_dir)
 $(ila_work_dir): $(verilog) $(fpga_work_dir)/stamp
 	cp -f $(GENERATED_DIR)/firesim_ila_insert_* $(fpga_work_dir)/design/ila_files/
@@ -200,7 +205,7 @@ $(ila_work_dir): $(verilog) $(fpga_work_dir)/stamp
 
 # Goes as far as setting up the build directory without running the cad job
 # Used by the manager before passing a build to a remote machine
-replace-rtl: $(fpga_v) $(ila_work_dir) $(fpga_vh) $(fpga_tcl_env)
+replace-rtl: $(fpga_v) $(ila_work_dir) $(fpga_vh) $(fpga_tcl_env) $(fpga_gen_xdc)
 
 .PHONY: replace-rtl
 


### PR DESCRIPTION
This PR implements  does two things:
1) It adds runtime generation of XDC files. Which we'll use in implementation.
2) It implements an optimization I wrote about in my dissertation, wherein target clocks that do not fire in back to back host cycles are given a multi-cycle setup constraint equal to some lower bound > 1. This can improve f_max by up to 50% in some designs. 

On the XDC generation:

I think there's lots of room to make this more powerful. There's a comment explaining the limitations. 

On the MFMR bound:

This lower bound can be derived statically from the clock token stream. Here I do the stupid thing, and divide every slower clock by the period of the fastest, as there will always be at least one clock token firing the faster clock between tokens firing the slower one. This establishes a minimum FMR (MFMR) of ceil(slow_period / fast_period) in the slower clock domain.  We could do better still by counting the minimum number of clock tokens between active edges in each domain. When there are many clocks that are not divisions of the clock, this may substantially improve the MFMR bound. 


Other random thoughts:
- We emit a ton of different files now. We probably what to harmonize how emission is done:
   - use a common prefix for all generated files
   - clean up replace_rtl 
   - specify prefix on CML
   - document all output files in docs somewhere 

Additional TODOS;
- [ ] Use FIRRTLFile Emission trait
- [ ] Add tests.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
