### PR TITLE
Install Boost in the Machine Launch Script 

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -79,7 +79,7 @@ boost_minor_v=69
 wget https://sourceforge.net/projects/boost/files/boost/1.${boost_minor_v}.0/boost_1_${boost_minor_v}_0.tar.bz2
 tar --bzip2 -xf boost_1_${boost_minor_v}_0.tar.bz2
 cd boost_1_${boost_minor_v}_0
-sudo yum install bzip2-devel
+sudo yum -y install bzip2-devel
 sudo ./bootstrap.sh
 sudo ./b2 install
 cd ..

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -74,6 +74,16 @@ sudo activate-global-python-argcomplete
 # Upgrading pip2 clobbers the pip3 installation paths.
 sudo yum reinstall -y python36-pip
 
+# Install boost
+boost_minor_v=69
+wget https://sourceforge.net/projects/boost/files/boost/1.${boost_minor_v}.0/boost_1_${boost_minor_v}_0.tar.bz2
+tar --bzip2 -xf boost_1_${boost_minor_v}_0.tar.bz2
+cd boost_1_${boost_minor_v}_0
+sudo yum install bzip2-devel
+sudo ./bootstrap.sh
+sudo ./b2 install
+cd ..
+
 } 2>&1 | tee /home/centos/machine-launchstatus.log
 
 # get a regular prompt

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -100,7 +100,7 @@ DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, firesim/*)))
 	    $(DROMAJO_LIB) \
 	    $(TESTCHIPIP_CSRC_DIR)/testchip_tsi.cc
 
-TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include -I$(firesim_lib_dir)/lib/boost -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
+TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
 TARGET_LD_FLAGS := -L$(RISCV)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DIR) -l$(DROMAJO_LIB_NAME)
 # DOC include end: Bridge Build System Changes
 


### PR DESCRIPTION
It's not actually clear to me where we are using it.

#### Related PRs / Issues

None

#### UI / API Impact

Users will need to install boost on existing managers when upgrading, _if_ it's actually needed. 

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
