### PR TITLE
CPP Dependency Management Rework 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "utils/FlameGraph"]
 	path = utils/fireperf/FlameGraph
 	url = https://github.com/brendangregg/FlameGraph.git
-[submodule "sim/firesim-lib/src/main/cc/lib/boost"]
-	path = sim/firesim-lib/src/main/cc/lib/boost
-	url = https://github.com/boostorg/boost
 [submodule "sim/firesim-lib/src/main/cc/lib/elfutils"]
 	path = sim/firesim-lib/src/main/cc/lib/elfutils
 	url = git://sourceware.org/git/elfutils.git

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -205,10 +205,13 @@ if wget -T 1 -t 3 -O /dev/null http://169.254.169.254/; then
     bash -c "source ./hdk_setup.sh"
 fi
 
+# Per-repository dependencies are installed under this sysroot
+firesim_local_sysroot=$RDIR/sim/lib-install
 cd $RDIR
-./scripts/build-libelf.sh
-cd $RDIR
-./scripts/build-libdwarf.sh
+mkdir -p $firesim_local_sysroot
+./scripts/build-libdwarf.sh $firesim_local_sysroot
+./scripts/build-libelf.sh $firesim_local_sysroot
+env_append "export LD_LIBRARY_PATH=$firesim_local_sysroot/lib\${LD_LIBRARY_PATH:+\":\${LD_LIBRARY_PATH}\"}"
 
 cd $RDIR
 set +e

--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -335,8 +335,7 @@ class FireSimServerNode(FireSimNode):
         all_paths.append([self.server_hardware_config.get_local_runtime_conf_path(), ''])
 
         # shared libraries
-        all_paths.append(["$RISCV/lib/libdwarf.so", "libdwarf.so.1"])
-        all_paths.append(["$RISCV/lib/libelf.so", "libelf.so.1"])
+        all_paths += self.server_hardware_config.get_local_shared_libraries()
 
         all_paths += self.get_job().get_siminputs()
         return all_paths
@@ -497,8 +496,7 @@ class FireSimSuperNodeServerNode(FireSimServerNode):
                               self.get_rootfs_name()])
 
         # shared libraries
-        all_paths.append(["$RISCV/lib/libdwarf.so", "libdwarf.so.1"])
-        all_paths.append(["$RISCV/lib/libelf.so", "libelf.so.1"])
+        all_paths += self.server_hardware_config.get_local_shared_libraries()
 
         num_siblings = self.supernode_get_num_siblings_plus_one()
 

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -19,6 +19,7 @@ import os
 
 LOCAL_DRIVERS_BASE = "../sim/output/f1/"
 LOCAL_DRIVERS_GENERATED_SRC = "../sim/generated-src/f1/"
+LOCAL_SYSROOT_LIB = "../sim/lib-install/lib/"
 CUSTOM_RUNTIMECONFS_BASE = "../sim/custom-runtime-configs/"
 
 rootLogger = logging.getLogger()
@@ -62,6 +63,14 @@ class RuntimeHWConfig:
         drivers_software_base = LOCAL_DRIVERS_BASE + "/" + my_deploytriplet + "/"
         fpga_driver_local = drivers_software_base + self.get_local_driver_binaryname()
         return fpga_driver_local
+
+    def get_local_shared_libraries(self):
+        """ Returns a list of path tuples, (A, B), where:
+            A is the local file path on the manager instance to the library
+            B is the destination file path on the runfarm instance relative to the driver """
+
+        return [[LOCAL_SYSROOT_LIB + "/libdwarf.so", "libdwarf.so.1"],
+                [LOCAL_SYSROOT_LIB + "/libelf.so", "libelf.so.1"]]
 
     def get_local_runtimeconf_binaryname(self):
         """ Get the name of the runtimeconf file. """

--- a/scripts/build-libdwarf.sh
+++ b/scripts/build-libdwarf.sh
@@ -6,8 +6,17 @@ if [ -z "$RISCV" ]; then
     exit 1
 fi
 
+if [ $# -ne 1 ]; then
+    echo "$0 expects one argument, the installation prefix."
+    exit 1
+fi
+
+prefix=$1
+
 cd sim/firesim-lib/src/main/cc/lib/libdwarf
 sh scripts/FIX-CONFIGURE-TIMES
-./configure --prefix="${RISCV}" --enable-shared --disable-static CFLAGS="-g -I${RISCV}/include" LDFLAGS="-L${RISCV}/lib"
+mkdir build
+cd build
+../configure --prefix="${prefix}" --enable-shared --disable-static CFLAGS="-g -I${RISCV}/include" LDFLAGS="-L${RISCV}/lib"
 make
 make install

--- a/scripts/build-libelf.sh
+++ b/scripts/build-libelf.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 
 set -e
-if [ -z "$RISCV" ]; then
-    echo "You must set \$RISCV to run this script."
+if [ $# -ne 1 ]; then
+    echo "$0 expects one argument, the installation prefix."
     exit 1
 fi
 
+prefix=$1
+
 cd sim/firesim-lib/src/main/cc/lib/elfutils
 test -f configure || autoreconf -i -f
-./configure --prefix="${RISCV}" --enable-maintainer-mode
+./configure --prefix="${prefix}" --enable-maintainer-mode
 make
 make install
+# The build process modifies tracked sources. This to clean up after ourselves.
+git reset --hard

--- a/sim/.gitignore
+++ b/sim/.gitignore
@@ -7,5 +7,6 @@ tags
 AsyncResetReg.v
 firrtl_black_box_resource_files.f
 lib/firrtl.jar
+lib-install/
 *.swp
 .bsp/

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -104,8 +104,8 @@ DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, firesim/*)))
 # Per-repository dependencies (e.g., libdwarf) are installed under this sysroot
 firesim_local_sysroot = $(firesim_base_dir)/lib-install
 
-TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(firesim_local_sysroot)/include -I$(driver_dir)/firesim -I$(RISCV)/include -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
-TARGET_LD_FLAGS := -L$(RISCV)/lib -L$(firesim_local_sysroot)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DIR) -l$(DROMAJO_LIB_NAME)
+TARGET_CXX_FLAGS += -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(firesim_local_sysroot)/include -I$(driver_dir)/firesim -I$(RISCV)/include -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
+TARGET_LD_FLAGS += -L$(RISCV)/lib -L$(firesim_local_sysroot)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DIR) -l$(DROMAJO_LIB_NAME)
 # DOC include end: Bridge Build System Changes
 
 #######################################

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -100,7 +100,7 @@ DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, firesim/*)))
 	    $(DROMAJO_LIB) \
 	    $(TESTCHIPIP_CSRC_DIR)/testchip_tsi.cc
 
-TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include -I$(firesim_lib_dir)/lib/boost -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
+TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
 TARGET_LD_FLAGS := -L$(RISCV)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DIR) -l$(DROMAJO_LIB_NAME)
 # DOC include end: Bridge Build System Changes
 

--- a/sim/src/main/makefrag/firesim/Makefrag
+++ b/sim/src/main/makefrag/firesim/Makefrag
@@ -100,8 +100,12 @@ DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, firesim/*)))
 	    $(DROMAJO_LIB) \
 	    $(TESTCHIPIP_CSRC_DIR)/testchip_tsi.cc
 
-TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(driver_dir)/firesim -I$(RISCV)/include -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
-TARGET_LD_FLAGS := -L$(RISCV)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DIR) -l$(DROMAJO_LIB_NAME)
+
+# Per-repository dependencies (e.g., libdwarf) are installed under this sysroot
+firesim_local_sysroot = $(firesim_base_dir)/lib-install
+
+TARGET_CXX_FLAGS := -g -I$(TESTCHIPIP_CSRC_DIR) -I$(firesim_lib_dir) -I$(firesim_local_sysroot)/include -I$(driver_dir)/firesim -I$(RISCV)/include -I$(DROMAJO_DIR) -I$(GENERATED_DIR)
+TARGET_LD_FLAGS := -L$(RISCV)/lib -L$(firesim_local_sysroot)/lib -l:libdwarf.so -l:libelf.so -lz -L$(DROMAJO_DIR) -l$(DROMAJO_LIB_NAME)
 # DOC include end: Bridge Build System Changes
 
 #######################################


### PR DESCRIPTION
In service of making firesim more usable outside of FSim-as-top and CY, here I:
- remove the boost dependency (unused)
  - we can add this back when we need it
- install libelf + libdwarf to a firesim-local sysroot
  - want to decouple RISCV from firesim deps, which should make it easier to share preinstalled toolchains that use RISCV 
- clean up libelf + libdwarf builds to maintain a clean submodule state
  - there didn't seem to be a trivial way to do a clean out-of-source build with elfutils, hence the git reset

  
#### Related PRs / Issues

Subsumes #805, #804

#### UI / API Impact

None.

#### Verilog / AGFI Compatibility

No.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
