### PR TITLE
Remove deadcode in midas.passes.Utils

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/AssertPass.scala
+++ b/sim/midas/src/main/scala/midas/passes/AssertPass.scala
@@ -99,14 +99,14 @@ private[passes] class AssertPass extends firrtl.Transform {
     lazy val (childAsserts, childAssertClocksRTs): (Seq[WSubField], Seq[Seq[ReferenceTarget]])  =
     (for ((childInstName, (assertPort, clockRTs)) <- assertChildren) yield {
       val childWidth = firrtl.bitWidth(assertPort.tpe).toInt
-      val assertRef = wsub(wref(childInstName), assertPort.name)
+      val assertRef = WSubField(WRef(childInstName), assertPort.name)
       val clockRefs = clockRTs.map(_.addHierarchy(m.name, childInstName))
       (assertRef, clockRefs)
     }).unzip
 
     // Get references to all module-local synthesized assertions
     val sortedLocalAsserts = asserts(m.name).values.toSeq.sortWith(_._1 < _._1)
-    val (localAsserts, localClocks) = sortedLocalAsserts.map({ case (_, en, clk) => (wref(en), mT.ref(clk)) }).unzip
+    val (localAsserts, localClocks) = sortedLocalAsserts.map({ case (_, en, clk) => (WRef(en), mT.ref(clk)) }).unzip
 
     def allAsserts = localAsserts ++ childAsserts
     def allClocks = localClocks ++ childAssertClocksRTs.flatten

--- a/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
@@ -16,7 +16,6 @@ import freechips.rocketchip.config.{Parameters, Field}
 import midas.{EnableAutoCounter, AutoCounterUsePrintfImpl}
 import midas.widgets._
 import midas.targetutils._
-import midas.passes.Utils.{widx, wsub}
 import midas.passes.fame.{WireChannel, FAMEChannelConnectionAnnotation, And, Or, Negate, Neq}
 
 import java.io._

--- a/sim/midas/src/main/scala/midas/passes/Fame1Transform.scala
+++ b/sim/midas/src/main/scala/midas/passes/Fame1Transform.scala
@@ -12,7 +12,9 @@ import firrtl.Utils.BoolType
 import firrtl.transforms.{DedupModules}
 import firrtl.passes.MemPortUtils.memPortField
 import WrappedType.wt
-import Utils._
+
+import midas.passes.fame.{Or, And, Negate}
+
 
 import chisel3.experimental.ChiselAnnotation
 
@@ -24,7 +26,7 @@ private[passes] class Fame1Transform extends firrtl.passes.Pass {
   type Enables = collection.mutable.HashMap[String, Boolean]
   type Statements = collection.mutable.ArrayBuffer[Statement]
   private val targetFirePort = Port(NoInfo, "targetFire", Input, BoolType)
-  private val targetFire = wref(targetFirePort.name, targetFirePort.tpe)
+  private val targetFire = WRef(targetFirePort.name, targetFirePort.tpe)
 
   private def collect(ens: Enables)(s: Statement): Statement = {
     s match {
@@ -43,23 +45,23 @@ private[passes] class Fame1Transform extends firrtl.passes.Pass {
                       (s: Statement): Statement = s match {
     case s: WDefInstance =>
       Block(Seq(s,
-        Connect(NoInfo, wsub(wref(s.name), "targetFire"), targetFire)
+        Connect(NoInfo, WSubField(WRef(s.name), "targetFire"), targetFire)
       ))
     case s: DefRegister =>
-      val regRef = wref(s.name, s.tpe)
+      val regRef = WRef(s.name, s.tpe)
       stmts += Conditionally(NoInfo, targetFire, EmptyStmt, Connect(NoInfo, regRef, regRef))
-      s.copy(reset = and(s.reset, targetFire))
+      s.copy(reset = And(s.reset, targetFire))
     case s: Print =>
-      s.copy(en = and(s.en, targetFire))
+      s.copy(en = And(s.en, targetFire))
     case s: Stop =>
-      s.copy(en = and(s.en, targetFire))
+      s.copy(en = And(s.en, targetFire))
     case s: Connect => s.loc match {
       case e: WSubField => ens get e.serialize match {
         case None => s
         case Some(false) =>
-          s.copy(expr = and(s.expr, targetFire))
+          s.copy(expr = And(s.expr, targetFire))
         case Some(true) => // inverted port
-          s.copy(expr = or(s.expr, not(targetFire)))
+          s.copy(expr = Or(s.expr, Negate(targetFire)))
       }
       case _ => s
     }
@@ -112,7 +114,7 @@ class ModelFame1Transform(f1Modules: Map[String, String], f1ModuleSuffix: String
     def collectTargetFires(stmts: Statements)(s: Statement): Statement = s match {
       case s: WDefInstance if f1Modules.keys.toSeq.contains(s.module) =>
         val targetFireName = f1Modules(s.module)
-        stmts += Connect(NoInfo, wsub(wref(s.name), "targetFire"), wref(targetFireName, UnknownType))
+        stmts += Connect(NoInfo, WSubField(WRef(s.name), "targetFire"), WRef(targetFireName, UnknownType))
         s
       case s => s map collectTargetFires(stmts)
     }

--- a/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
+++ b/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
@@ -16,7 +16,6 @@ import firrtl.WrappedExpression._
 import logger.{Logger, LogLevel}
 import freechips.rocketchip.config.{Parameters, Field}
 
-import Utils._
 import midas.passes.fame.{FAMEChannelConnectionAnnotation, WireChannel}
 import midas.widgets.{PrintRecordBag, BridgeIOAnnotation, PrintBridgeModule}
 import midas.targetutils.SynthPrintfAnnotation
@@ -83,10 +82,10 @@ private[passes] class PrintSynthesis extends firrtl.Transform {
         val printName = getPrintName(p, associatedAnno, modNamespace)
         // Generate an aggregate with all of our arguments; this will be wired out
         val wire = DefWire(NoInfo, printName, genPrintBundleType(p))
-        val enableConnect = Connect(NoInfo, wsub(WRef(wire), "enable"), en)
+        val enableConnect = Connect(NoInfo, WSubField(WRef(wire), "enable"), en)
         val argumentConnects = (p.args.zipWithIndex).map({ case (arg, idx) =>
           Connect(NoInfo,
-                  wsub(WRef(wire), s"args_${idx}"),
+                  WSubField(WRef(wire), s"args_${idx}"),
                   arg)})
 
         val printBundleTarget = associatedAnno.mod.ref(printName)

--- a/sim/midas/src/main/scala/midas/passes/SimulationMapping.scala
+++ b/sim/midas/src/main/scala/midas/passes/SimulationMapping.scala
@@ -65,7 +65,7 @@ private[passes] class SimulationMapping(targetName: String) extends firrtl.Trans
       case s @ WDefInstance(_, name, _, _) if name == targetInstName =>
         Block(Seq(
           s copy (module = targetModuleName), // replace TargetBox with the actual target module
-          IsInvalid(NoInfo, wref(name))
+          IsInvalid(NoInfo, WRef(name))
         ))
       case s => s map initStmt(targetModuleName, targetInstName)
     }

--- a/sim/midas/src/main/scala/midas/passes/Utils.scala
+++ b/sim/midas/src/main/scala/midas/passes/Utils.scala
@@ -5,59 +5,15 @@ package passes
 
 import firrtl._
 import firrtl.ir._
-import firrtl.Mappers._
-import firrtl.annotations._
-import firrtl.Utils.{sub_type, field_type}
-import scala.collection.mutable.{ArrayBuffer, HashSet, LinkedHashSet, LinkedHashMap}
 import java.io.{File, FileWriter, Writer}
 
 object Utils {
-  val ut = UnknownType
-  val uw = UnknownWidth
-  val ug = UnknownFlow
-  
-  def wref(s: String, t: Type = ut, k: Kind = ExpKind) = WRef(s, t, k, ug)
-  def wsub(e: Expression, s: String) = WSubField(e, s, field_type(e.tpe, s), ug)
-  def widx(e: Expression, i: Int) = WSubIndex(e, i, sub_type(e.tpe), ug)
-  def not(e: Expression) = DoPrim(PrimOps.Not, Seq(e), Nil, e.tpe)
-  private def getType(e1: Expression, e2: Expression) = e2.tpe match {
-    case UnknownType => e1.tpe
-    case _ => e2.tpe
-  }
-  def or(e1: Expression, e2: Expression) =
-    DoPrim(PrimOps.Or, Seq(e1, e2), Nil, getType(e1, e2))
-  def and(e1: Expression, e2: Expression) =
-    DoPrim(PrimOps.And, Seq(e1, e2), Nil, getType(e1, e2))
-  def bits(e: Expression, high: BigInt, low: BigInt) =
-    DoPrim(PrimOps.Bits, Seq(e), Seq(high, low), e.tpe)
   def cat(es: Seq[Expression]): Expression =
     if (es.tail.isEmpty) es.head else {
       val left = cat(es.slice(0, es.length/2))
       val right = cat(es.slice(es.length/2, es.length))
-      DoPrim(PrimOps.Cat, Seq(left, right), Nil, ut)
+      DoPrim(PrimOps.Cat, Seq(left, right), Nil, UnknownType)
     }
-
-  def renameMods(c: Circuit, namespace: Namespace) = {
-    val (modules, nameMap) = (c.modules foldLeft (Seq[DefModule](), Map[String, String]())){
-      case ((ms, map), m: ExtModule) =>
-        val newMod = (map get m.name) match {
-          case None => m copy (name = namespace newName m.name)
-          case Some(name) => m copy (name = name)
-        }
-        ((ms :+ newMod), map + (m.name -> newMod.name))
-      case ((ms, map), m: Module) =>
-        val newMod = (map get m.name) match {
-          case None => m copy (name = namespace newName m.name)
-          case Some(name) => m copy (name = name)
-        }
-        ((ms :+ newMod), map + (m.name -> newMod.name))
-    }
-    def updateModNames(s: Statement): Statement = s match {
-      case s: WDefInstance => s copy (module = nameMap(s.module))
-      case s => s map updateModNames
-    }
-    c copy (modules = modules map (_ map updateModNames), main = nameMap(c.main))
-  }
 
   // Takes a circuit state and writes it out to the target-directory by selecting
   // an appropriate emitter for its form
@@ -77,25 +33,6 @@ object Utils {
     emitter.emit(state, writer)
     writer.close
   }
-
-  // Takes a circuitState that has been emitted and writes the result to file
-  def writeEmittedCircuit(state: CircuitState, file: File) {
-    val f = new FileWriter(file)
-    f.write(state.getEmittedCircuit.value)
-    f.close
-  }
-
-}
-
-// Lowers a circuitState from form A to form B, but unlike the lowering compilers
-// provided by firrtl, doesn't assume a chirrtl input form
-class IntermediateLoweringCompiler(inputForm: CircuitForm, outputForm: CircuitForm) extends firrtl.Compiler {
-  def emitter = outputForm match {
-    case LowForm  => new LowFirrtlEmitter
-    case MidForm  => new MiddleFirrtlEmitter
-    case HighForm => new HighFirrtlEmitter
-  }
-  def transforms = firrtl.CompilerUtils.getLoweringTransforms(inputForm, outputForm)
 }
 
 // Writes out the circuit to a file for debugging
@@ -103,7 +40,7 @@ class EmitFirrtl(fileName: String) extends firrtl.Transform {
 
   def inputForm = HighForm
   def outputForm = HighForm
-  override def name = s"[MIDAS] Debugging Emission Pass: $fileName"
+  override def name = s"[Golden Gate] Debugging Emission Pass: $fileName"
 
   def execute(state: CircuitState) = {
     Utils.writeState(state, fileName)


### PR DESCRIPTION
Here i remove some legacy strober utilities that either:
- are unused
- have first-class equivalents in FIRRTL
- or are subsumed by utilities in midas.passes.fame

#### Related PRs / Issues

#807 

#### UI / API Impact

I'm removing public APIs, but these were never intended to be used outside of midas.

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
