### PR TITLE
Build linux-poweroff in CI

### DIFF
--- a/.circleci/build-default-workloads.py
+++ b/.circleci/build-default-workloads.py
@@ -8,13 +8,16 @@ from ci_variables import ci_workflow_id
 def build_default_workloads():
     """ Builds workloads that will be run on F1 instances as part of CI """
 
-    with cd(manager_fsim_dir), prefix('source env.sh'):
-        with cd("target-design/chipyard/software/firemarshal"):
-            run("./init-submodules.sh")
-            run("./marshal -v build br-base.json")
+    with cd(manager_fsim_dir), \
+         prefix('source env.sh'), \
+         cd("target-design/chipyard/software/firemarshal"):
+        run("./init-submodules.sh")
+        run("./marshal -v build br-base.json")
 
-        with cd("deploy/workloads"):
-            run("make linux-poweroff")
+    with cd(manager_fsim_dir), \
+         prefix('source env.sh'), \
+         cd("deploy/workloads"):
+        run("make linux-poweroff")
 
 
 if __name__ == "__main__":

--- a/.circleci/build-default-workloads.py
+++ b/.circleci/build-default-workloads.py
@@ -9,14 +9,9 @@ def build_default_workloads():
     """ Builds workloads that will be run on F1 instances as part of CI """
 
     with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
-         prefix('cd target-design/chipyard/software/firemarshal'):
-        run("./init-submodules.sh")
-        run("./marshal -v build br-base.json")
-
-    with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
          prefix('cd deploy/workloads'):
+        run("marshal -v build br-base.json")
         run("make linux-poweroff")
-
 
 if __name__ == "__main__":
     execute(build_default_workloads, hosts=[manager_hostname(ci_workflow_id)])

--- a/.circleci/build-default-workloads.py
+++ b/.circleci/build-default-workloads.py
@@ -8,15 +8,13 @@ from ci_variables import ci_workflow_id
 def build_default_workloads():
     """ Builds workloads that will be run on F1 instances as part of CI """
 
-    with cd(manager_fsim_dir), \
-         prefix('source env.sh'), \
-         cd("target-design/chipyard/software/firemarshal"):
+    with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
+         prefix('cd target-design/chipyard/software/firemarshal'):
         run("./init-submodules.sh")
         run("./marshal -v build br-base.json")
 
-    with cd(manager_fsim_dir), \
-         prefix('source env.sh'), \
-         cd("deploy/workloads"):
+    with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
+         prefix('cd deploy/workloads'):
         run("make linux-poweroff")
 
 

--- a/.circleci/build-default-workloads.py
+++ b/.circleci/build-default-workloads.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+from fabric.api import *
+
+from common import manager_fsim_dir, manager_hostname
+from ci_variables import ci_workflow_id
+
+def build_default_workloads():
+    """ Builds workloads that will be run on F1 instances as part of CI """
+
+    with cd(manager_fsim_dir), prefix('source env.sh'):
+        with cd("target-design/chipyard/software/firemarshal"):
+            run("./init-submodules.sh")
+            run("./marshal -v build br-base.json")
+
+        with cd("deploy/workloads"):
+            run("make linux-poweroff")
+
+
+if __name__ == "__main__":
+    execute(build_default_workloads, hosts=[manager_hostname(ci_workflow_id)])

--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -5,6 +5,7 @@ from fabric.api import *
 # Remote paths
 manager_home_dir = "/home/centos"
 manager_fsim_dir = "/home/centos/firesim"
+manager_marshal_dir = manager_fsim_dir + "/target-design/chipyard/software/firemarshal"
 manager_ci_dir = manager_fsim_dir + "/.circleci"
 
 # Common fabric settings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,15 @@ jobs:
               max-runtime-hours: 6
           - initial-scala-compile
 
+  build-default-workloads:
+    description: "Invokes marshal to build the default rootfs."
+    executor: aws
+    steps:
+      - repo-setup-aws
+      - run:
+          command: |
+              .circleci/build-default-workloads.py
+          no_output_timeout: 30m
 
   run-manager-pytests:
     executor: aws
@@ -207,6 +216,10 @@ workflows:
   firesimCIall:
     jobs:
      - setup-default-manager
+
+     - build-default-workloads:
+         requires:
+         - setup-default-manager
 
      - run-test-groupA:
          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ executors:
     environment:
         JVM_MEMORY: 3500M # Default JVM maximum heap limit
         LANG: en_US.UTF-8 # required by sbt when it sees boost directories
+        MARSHAL_JLEVEL: 8 # This is unset by default, leading to starvation conditions on the manager
   aws:
     docker:
     - image: cimg/python:2.7-node


### PR DESCRIPTION
I'd like to boot linux on F1 instances in CI. This is one further step in that direction.

#### Related PRs / Issues

None

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
