### PR TITLE
Fix Library Build Order in Build Setup

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -209,8 +209,8 @@ fi
 firesim_local_sysroot=$RDIR/sim/lib-install
 cd $RDIR
 mkdir -p $firesim_local_sysroot
-./scripts/build-libdwarf.sh $firesim_local_sysroot
 ./scripts/build-libelf.sh $firesim_local_sysroot
+./scripts/build-libdwarf.sh $firesim_local_sysroot
 env_append "export LD_LIBRARY_PATH=$firesim_local_sysroot/lib\${LD_LIBRARY_PATH:+\":\${LD_LIBRARY_PATH}\"}"
 
 cd $RDIR

--- a/scripts/build-libdwarf.sh
+++ b/scripts/build-libdwarf.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 
 set -e
-if [ -z "$RISCV" ]; then
-    echo "You must set \$RISCV to run this script."
-    exit 1
-fi
 
 if [ $# -ne 1 ]; then
     echo "$0 expects one argument, the installation prefix."
@@ -15,8 +11,9 @@ prefix=$1
 
 cd sim/firesim-lib/src/main/cc/lib/libdwarf
 sh scripts/FIX-CONFIGURE-TIMES
-mkdir build
+mkdir -p build
 cd build
-../configure --prefix="${prefix}" --enable-shared --disable-static CFLAGS="-g -I${RISCV}/include" LDFLAGS="-L${RISCV}/lib"
+# Get libelf from our local sysroot ($prefix)
+../configure --prefix="${prefix}" --enable-shared --disable-static CFLAGS="-g -I${prefix}/include" LDFLAGS="-L${prefix}/lib"
 make
 make install


### PR DESCRIPTION
libdwarf depends on libelf. I mistakenly swapped the order, and on a manager instance build-setup.sh silently uses the system-provided libelf. Scala doc publishing runs in the CI containe ,and there elfutils is not installed, which causes scala doc publishing to break. Since that only runs on the dev and master branches, it was not picked up in pre-merge CI. 

#### Related PRs / Issues

#806 

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

No change.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
