### PR TITLE
Run Only a Single Manager Cleanup Job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,8 @@ workflows:
           cron: "0 0,12 * * *"
           filters:
             branches:
-              only: "/.*/"
+              only:
+               - dev
     jobs:
       - cull-old-ci-instances
 


### PR DESCRIPTION
I was concerned about the clean up job not running, but now circleci's UI is polluted with duplicated jobs. This ensures the cleanup job runs only twice a day (it still cleans up instances associated with all workflows).

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
