### PR TITLE
Limit builddir name length to 255 chars

### DIFF
--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -66,8 +66,7 @@ class BuildConfig:
 
     def get_build_dir_name(self):
         """" Get the name of the local build directory. """
-        return """{}-{}-{}""".format(self.launch_time,
-                                     self.get_chisel_triplet(), self.name)
+        return """{}-{}""".format(self.launch_time, self.name)
 
     # Builds up a string for a make invocation using the tuple variables
     def make_recipe(self, recipe):


### PR DESCRIPTION
<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

Will avoid some errors when user-requested build config string is very long

#### UI / API Impact

No impact.

#### Verilog / AGFI Compatibility

No effect

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
