### PR TITLE
Update docs to 1.10.0 AMI

### DIFF
--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -7,11 +7,11 @@ Launching a "Manager Instance"
 Now, we need to launch a "Manager Instance" that acts as a
 "head" node that we will ``ssh`` or ``mosh`` into to work from.
 Since we will deploy the heavy lifting to separate ``c5.4xlarge`` and
-``f1`` instances later, the Manager Instance can be a relatively cheap instance. 
+``f1`` instances later, the Manager Instance can be a relatively cheap instance.
 In this guide, however, we will use a ``c5.4xlarge``,
-running the AWS FPGA Developer AMI. (Be sure to subscribe to the AMI 
-if you have not done so. See :ref:`ami-subscription`. Note that it 
-might take a few minutes after subscribing to the AMI to be able to 
+running the AWS FPGA Developer AMI. (Be sure to subscribe to the AMI
+if you have not done so. See :ref:`ami-subscription`. Note that it
+might take a few minutes after subscribing to the AMI to be able to
 launch instances using it.)
 
 Head to the `EC2 Management
@@ -25,7 +25,7 @@ To launch a manager instance, follow these steps:
    data is preserved when you stop/start the instance, and your data is
    not lost when pricing spikes on the spot market.
 2. When prompted to select an AMI, search in the ``Community AMIs`` tab for
-   ``FPGA Developer AMI - 1.6.1`` and select the AMI that appears (there 
+   ``FPGA Developer AMI - 1.10.0`` and select the AMI that appears (there
    should be only one). **DO NOT USE ANY OTHER VERSION.**
 3. When prompted to choose an instance type, select the instance type of
    your choosing. A good choice is a ``c5.4xlarge``.


### PR DESCRIPTION
Update the setup docs to point to the 1.10.0 AMI

#### Related PRs / Issues

n/a

#### UI / API Impact

n/a

#### Verilog / AGFI Compatibility

n/a

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
