### PR TITLE
Fix build.ini spelling/spacing

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build.ini
+++ b/deploy/sample-backup-configs/sample_config_build.ini
@@ -16,14 +16,14 @@ postbuildhook=
 # Unnetworked designs use a three-domain configuration
 # Tiles: 1600 MHz
 #    <Rational Crossing>
-# Ucnore: 800 MHz
+# Uncore: 800 MHz
 #    <Async Crossing>
 # DRAM : 1000 MHz
 firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3
 firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3
 
 # All NIC-based designs use the legacy FireSim frequency selection, with the
-# tilesand uncore running at 3.2 GHz to sustain 200Gb theoretical NIC BW
+# tiles and uncore running at 3.2 GHz to sustain 200Gb theoretical NIC BW
 firesim-supernode-rocket-singlecore-nic-l2-lbp
 firesim-rocket-quadcore-nic-l2-llc4mb-ddr3
 firesim-boom-singlecore-nic-l2-llc4mb-ddr3


### PR DESCRIPTION
Minor spelling/spacing fixes to the build.ini

#### Related PRs / Issues

None

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
