### PR TITLE
Add timeout to CI manager initialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,14 @@ commands:
     parameters:
       max-runtime-hours:
         type: integer
+      timeout:
+        type: string
+        default: "30m"
     steps:
       - run:
           command: |
               .circleci/initialize-manager.py  << parameters.max-runtime-hours >>
+          no_output_timeout: << parameters.timeout >>
 
   # This avoids a race that occurs when multiple cold scala compilations are launched at the same time.
   initial-scala-compile:


### PR DESCRIPTION
Current CI is timing out when cloning RISC-V Linux (default timeout is 10m). This changes it to 30m.

#### Related PRs / Issues

#832 #831 

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
