### PR TITLE
Expand CI Timeouts + Log Monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
               command: |
                   .circleci/launch-manager-instance.py
           - initialize-manager:
-              max-runtime-hours: 6
+              max-runtime-hours: 10
           - initial-scala-compile
 
   build-default-workloads:

--- a/.circleci/initialize-manager.py
+++ b/.circleci/initialize-manager.py
@@ -49,7 +49,7 @@ def initialize_manager(max_runtime):
             # culled when the SSH session associated with teh run command ends.
             run("screen -S ttl -dm bash -c \'sleep {}; ./change-workflow-instance-states.py {} stop\'"
                 .format(int(max_runtime) * 3600, ci_workflow_id), pty=False)
-            run("screen -S workflow-monitor -dm ./workflow-monitor.py {} {}"
+            run("screen -S workflow-monitor -L -dm ./workflow-monitor.py {} {}"
                 .format(ci_workflow_id, ci_api_token), pty=False)
 
     except BaseException as e:

--- a/.circleci/launch-manager-instance.py
+++ b/.circleci/launch-manager-instance.py
@@ -14,7 +14,7 @@ from common import *
 sys.path.append(ci_workdir + "/deploy/awstools")
 import awstools
 
-INSTANCE_TYPE = 'c5.4xlarge'
+INSTANCE_TYPE = 'z1d.2xlarge'
 MARKET_TYPE = 'ondemand'
 SPOT_INT_BEHAVIOR = 'terminate'
 SPOT_MAX_PRICE = 'ondemand'


### PR DESCRIPTION
Abe's CI run failed because his manager went to sleep. That is probably a bug -- i'm logging the output so we can figure out what's happening there.  
 
 I've also:
  - extended the baseline timeout because in practice it won't cost much (thanks Krste)
  - upgraded the instance to have more memory
#### Related PRs / Issues

#833 

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
