### PR TITLE
Bump AGFIs, CY for clocking changes

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,27 +10,27 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-00c41a50c5f0ce09c
+agfi=agfi-0aa96f4214e125fa7
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-07fe2a6db70f55571
+agfi=agfi-05696fc3823b9c6db
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-02bcf07eec55eb409
+agfi=agfi-0e817cc7ccaf9fd0a
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0c232c9c64b24787f
+agfi=agfi-0833e931ad5f2fa38
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-06cfa99cf72b54e09
+agfi=agfi-02059611104e23100
 deploytripletoverride=None
 customruntimeconfig=None
 


### PR DESCRIPTION
#### Related PRs / Issues

Bumps CY for https://github.com/ucb-bar/chipyard/pull/900 , which pulls PRCI setup into lazy Harness/IOBinders.

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->
No change

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

Adds some control registers to the default targets that are unused by any standard software, so memory map is slightly different.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
