### PR TITLE
install ca-certificates for latest root certs

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -6,6 +6,7 @@ set -o pipefail
 echo "machine launch script started" > /home/centos/machine-launchstatus
 
 {
+sudo yum install -y ca-certificates
 sudo yum install -y mosh
 sudo yum groupinstall -y "Development tools"
 sudo yum install -y gmp-devel mpfr-devel libmpc-devel zlib-devel vim git java java-devel


### PR DESCRIPTION


ca-certificates rpm contains the most up-to-date Mozilla CA root certificate bundle.  The defaults in Centos tend to be old and you can run into signing issues if you don't install this and (for long-lived servers) update it periodically. See also https://centos.pkgs.org/7/centos-x86_64/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm.html

<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

fixes #839 

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

None.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

None.

### Contributor Checklist
- [X] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
  No methods added.
- [ ] Did you add at least one test demonstrating the PR?
  No but I manually checked that this fixes #839 
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
