### PR TITLE
Separate AWS `managerinit` items into `awsinit`

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -20,6 +20,25 @@ rootLogger = logging.getLogger()
 # https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Images:visibility=public-images;search=FPGA%20Developer;sort=name
 f1_ami_name = "FPGA Developer AMI - 1.11.0-40257ab5-6688-4c95-97d1-e251a40fd1fc"
 
+def valid_aws_configure_creds():
+    """ See if aws configure has been run. Returns False if aws configure
+    needs to be run, else True.
+
+    This DOES NOT perform any deeper validation.
+    """
+    import botocore.session
+    session = botocore.session.get_session()
+    creds = session.get_credentials()
+    if creds is None:
+        return False
+    if session.get_credentials().access_key == '':
+        return False
+    if session.get_credentials().secret_key == '':
+        return False
+    if session.get_config_variable('region') == '':
+        return False
+    return True
+
 def aws_resource_names():
     """ Get names for various aws resources the manager relies on. For example:
     vpcname, securitygroupname, keyname, etc.

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -72,7 +72,7 @@ def aws_resource_names():
     resp = None
     res = None
     # This takes multiple minutes without a timeout from the CI container. In
-    # practise it should resolve nearly instantly on an initialized EC2 instance.
+    # practice it should resolve nearly instantly on an initialized EC2 instance.
     curl_connection_timeout = 10
     with settings(warn_only=True), hide('everything'):
         res = local("""curl -s --connect-timeout {} http://169.254.169.254/latest/meta-data/instance-id""".format(curl_connection_timeout), capture=True)
@@ -141,8 +141,19 @@ def get_aws_userid():
     But it seems that by default many accounts do not have permission to run this,
     so instead we get it from instance metadata.
     """
-    res = local("""curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep -oP '(?<="accountId" : ")[^"]*(?=")'""", capture=True)
-    return res.stdout.lower()
+    res = None
+    # This takes multiple minutes without a timeout from a non-AWS instance. In
+    # practice it should resolve nearly instantly on an initialized EC2 instance.
+    curl_connection_timeout = 10
+    with settings(warn_only=True), hide('everything'):
+        res = local("""curl -s --connect-timeout {} http://169.254.169.254/latest/dynamic/instance-identity/document | grep -oP '(?<="accountId" : ")[^"]*(?=")'""".format(curl_connection_timeout), capture=True)
+
+    # Use some default string if we're not on an EC2 instance (e.g., when a
+    # manager is launched from CI; during demos; other etc)
+    if res.return_code != 0:
+        return "PREAWSINIT"
+    else:
+        return res.stdout.lower()
 
 def construct_instance_market_options(instancemarket, spotinterruptionbehavior, spotmaxprice):
     """ construct the dictionary necessary to configure instance market selection

--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -97,10 +97,11 @@ class GlobalBuildConfig:
         self.s3_bucketname = \
             global_build_configfile.get('afibuild', 's3bucketname')
 
-        aws_resource_names_dict = aws_resource_names()
-        if aws_resource_names_dict['s3bucketname'] is not None:
-            # in tutorial mode, special s3 bucket name
-            self.s3_bucketname = aws_resource_names_dict['s3bucketname']
+        if valid_aws_configure_creds():
+            aws_resource_names_dict = aws_resource_names()
+            if aws_resource_names_dict['s3bucketname'] is not None:
+                # in tutorial mode, special s3 bucket name
+                self.s3_bucketname = aws_resource_names_dict['s3bucketname']
 
         self.build_instance_market = \
                 global_build_configfile.get('afibuild', 'buildinstancemarket')

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -240,6 +240,8 @@ def construct_firesim_argparser():
                         help='For terminaterunfarm, force termination without prompting user for confirmation. Defaults to False')
     parser.add_argument('-t', '--launchtime', type=str,
                         help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildafi')
+    parser.add_argument('-o', '--copyonly', action='store_true',
+                        help='Only used by managerinit, only setup the default configuration files. Defaults to False')
 
     argcomplete.autocomplete(parser)
     return parser.parse_args()
@@ -262,7 +264,12 @@ def main(args):
 
     # tasks that have a special config/dispatch setup
     if args.task == 'managerinit':
-        managerinit()
+        if args.copyonly:
+            managerinit()
+        else:
+            rootLogger.warning("DEPRECATION: managerinit will move AWS setup strictly to awsinit in a future release.")
+            awsinit()
+            managerinit()
 
     if args.task == 'awsinit':
         awsinit()

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -197,6 +197,7 @@ def construct_firesim_argparser():
     parser.add_argument('task', type=str,
                         help='Management task to run.', choices=[
                             'managerinit',
+                            'awsinit',
                             'buildafi',
                             'launchrunfarm',
                             'infrasetup',

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -74,7 +74,8 @@ def managerinit():
             rootLogger.debug(m)
             rootLogger.debug(m.stderr)
 
-
+    # warn about AWS init
+    rootLogger.warning("If running the manager on AWS F1, run \"awsinit\" at least once.")
 
 def infrasetup(runtime_conf):
     """ do infrasetup. """

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -193,7 +193,7 @@ def shareagfi(buildconf):
 
 def construct_firesim_argparser():
     # parse command line args
-    parser = argparse.ArgumentParser(description='FireSim Simulation Manager.')
+    parser = argparse.ArgumentParser(description='FireSim Simulation Manager.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('task', type=str,
                         help='Management task to run.', choices=[
                             'managerinit',
@@ -210,16 +210,16 @@ def construct_firesim_argparser():
                             'tar2afi'
                             ])
     parser.add_argument('-c', '--runtimeconfigfile', type=str,
-                        help='Optional custom runtime/workload config file. Defaults to config_runtime.ini.',
+                        help='Optional custom runtime/workload config file.',
                         default='config_runtime.ini')
     parser.add_argument('-b', '--buildconfigfile', type=str,
-                        help='Optional custom build config file. Defaults to config_build.ini.',
+                        help='Optional custom build config file.',
                         default='config_build.ini')
     parser.add_argument('-r', '--buildrecipesconfigfile', type=str,
-                        help='Optional custom build recipe config file. Defaults to config_build_recipes.ini.',
+                        help='Optional custom build recipe config file.',
                         default='config_build_recipes.ini')
     parser.add_argument('-a', '--hwdbconfigfile', type=str,
-                        help='Optional custom HW database config file. Defaults to config_hwdb.ini.',
+                        help='Optional custom HW database config file.',
                         default='config_hwdb.ini')
     parser.add_argument('-x', '--overrideconfigdata', type=str,
                         help='Override a single value from one of the the RUNTIME e.g.: --overrideconfigdata "targetconfig linklatency 6405".',
@@ -237,11 +237,11 @@ def construct_firesim_argparser():
                         help='Only used by terminatesome. Terminates this many of the previously launched m4.16xlarges.',
                         default=-1)
     parser.add_argument('-q', '--forceterminate', action='store_true',
-                        help='For terminaterunfarm, force termination without prompting user for confirmation. Defaults to False')
+                        help='For terminaterunfarm, force termination without prompting user for confirmation.')
     parser.add_argument('-t', '--launchtime', type=str,
                         help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildafi')
     parser.add_argument('-o', '--copyonly', action='store_true',
-                        help='Only used by managerinit, only setup the default configuration files. Defaults to False')
+                        help='Only used by managerinit, only setup the default configuration files.')
 
     argcomplete.autocomplete(parser)
     return parser.parse_args()

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -29,27 +29,8 @@ from util.streamlogger import StreamLogger
 ## below are tasks that users can call
 ## to add a task, add it here and to the choices array
 
-def managerinit():
-    """ Setup local FireSim manager components. """
-
-    def valid_aws_configure_creds():
-        """ See if aws configure has been run. Returns False if aws configure
-        needs to be run, else True.
-
-        This DOES NOT perform any deeper validation.
-        """
-        import botocore.session
-        session = botocore.session.get_session()
-        creds = session.get_credentials()
-        if creds is None:
-            return False
-        if session.get_credentials().access_key == '':
-            return False
-        if session.get_credentials().secret_key == '':
-            return False
-        if session.get_config_variable('region') == '':
-            return False
-        return True
+def awsinit():
+    """ Setup AWS FireSim manager components. """
 
     valid_creds = valid_aws_configure_creds()
     while not valid_creds:
@@ -64,6 +45,16 @@ def managerinit():
         valid_creds = valid_aws_configure_creds()
         if not valid_creds:
             rootLogger.info("Invalid AWS credentials. Try again.")
+
+    useremail = raw_input("If you are a new user, supply your email address [abc@xyz.abc] for email notifications (leave blank if you do not want email notifications): ")
+    if useremail != "":
+        subscribe_to_firesim_topic(useremail)
+    else:
+        rootLogger.info("You did not supply an email address. No notifications will be sent.")
+    rootLogger.info("FireSim Manager setup completed.")
+
+def managerinit():
+    """ Setup local FireSim manager components. """
 
     rootLogger.info("Backing up initial config files, if they exist.")
     config_files = ["build", "build_recipes", "hwdb", "runtime"]
@@ -83,12 +74,7 @@ def managerinit():
             rootLogger.debug(m)
             rootLogger.debug(m.stderr)
 
-    useremail = raw_input("If you are a new user, supply your email address [abc@xyz.abc] for email notifications (leave blank if you do not want email notifications): ")
-    if useremail != "":
-        subscribe_to_firesim_topic(useremail)
-    else:
-        rootLogger.info("You did not supply an email address. No notifications will be sent.")
-    rootLogger.info("FireSim Manager setup completed.")
+
 
 def infrasetup(runtime_conf):
     """ do infrasetup. """
@@ -275,6 +261,9 @@ def main(args):
     # tasks that have a special config/dispatch setup
     if args.task == 'managerinit':
         managerinit()
+
+    if args.task == 'awsinit':
+        awsinit()
 
     if args.task in ['buildafi', 'shareagfi', 'tar2afi']:
         buildconfig = GlobalBuildConfig(args)

--- a/deploy/ssh-setup.sh
+++ b/deploy/ssh-setup.sh
@@ -33,6 +33,6 @@ else
     if ssh-add ~/firesim.pem; then
         echo "success: firesim.pem added to ssh-agent"
     else
-        echo "FAIL: ERROR adding ~/firesim.pem to ssh-agent. does it exist?"
+        echo "FAIL: ERROR adding ~/firesim.pem to ssh-agent. If on AWS F1, does it exist?"
     fi
 fi

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -2,14 +2,14 @@ usage: firesim [-h] [-c RUNTIMECONFIGFILE] [-b BUILDCONFIGFILE]
                [-r BUILDRECIPESCONFIGFILE] [-a HWDBCONFIGFILE]
                [-x OVERRIDECONFIGDATA] [-f TERMINATESOMEF116]
                [-g TERMINATESOMEF12] [-i TERMINATESOMEF14]
-               [-m TERMINATESOMEM416] [-q]
-
-               {awsinit,managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
+               [-m TERMINATESOMEM416] [-q] [-t LAUNCHTIME] [-o]
+               
+               {managerinit,awsinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck,tar2afi}
 
 FireSim Simulation Manager.
 
 positional arguments:
-  {awsinit,managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
+  {managerinit,awsinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck,tar2afi}
                         Management task to run.
 
 optional arguments:
@@ -44,3 +44,9 @@ optional arguments:
                         the previously launched m4.16xlarges.
   -q, --forceterminate  For terminaterunfarm, force termination without
                         prompting user for confirmation. Defaults to False
+  -t LAUNCHTIME, --launchtime LAUNCHTIME
+                        Give the "Y-m-d--H-M-S" prefix of results-build
+                        directory. Useful for tar2afi when finishing a partial
+                        buildafi
+  -o, --copyonly        Only used by managerinit, only setup the default
+                        configuration files. Defaults to False

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -3,13 +3,13 @@ usage: firesim [-h] [-c RUNTIMECONFIGFILE] [-b BUILDCONFIGFILE]
                [-x OVERRIDECONFIGDATA] [-f TERMINATESOMEF116]
                [-g TERMINATESOMEF12] [-i TERMINATESOMEF14]
                [-m TERMINATESOMEM416] [-q]
-               
-               {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
+
+               {awsinit,managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
 
 FireSim Simulation Manager.
 
 positional arguments:
-  {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
+  {awsinit,managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
                         Management task to run.
 
 optional arguments:

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -15,38 +15,38 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -c RUNTIMECONFIGFILE, --runtimeconfigfile RUNTIMECONFIGFILE
-                        Optional custom runtime/workload config file. Defaults
-                        to config_runtime.ini.
+                        Optional custom runtime/workload config file.
+                        (default: config_runtime.ini)
   -b BUILDCONFIGFILE, --buildconfigfile BUILDCONFIGFILE
-                        Optional custom build config file. Defaults to
-                        config_build.ini.
+                        Optional custom build config file. (default:
+                        config_build.ini)
   -r BUILDRECIPESCONFIGFILE, --buildrecipesconfigfile BUILDRECIPESCONFIGFILE
-                        Optional custom build recipe config file. Defaults to
-                        config_build_recipes.ini.
+                        Optional custom build recipe config file. (default:
+                        config_build_recipes.ini)
   -a HWDBCONFIGFILE, --hwdbconfigfile HWDBCONFIGFILE
-                        Optional custom HW database config file. Defaults to
-                        config_hwdb.ini.
+                        Optional custom HW database config file. (default:
+                        config_hwdb.ini)
   -x OVERRIDECONFIGDATA, --overrideconfigdata OVERRIDECONFIGDATA
                         Override a single value from one of the the RUNTIME
                         e.g.: --overrideconfigdata "targetconfig linklatency
-                        6405".
+                        6405". (default: )
   -f TERMINATESOMEF116, --terminatesomef116 TERMINATESOMEF116
                         Only used by terminatesome. Terminates this many of
-                        the previously launched f1.16xlarges.
+                        the previously launched f1.16xlarges. (default: -1)
   -g TERMINATESOMEF12, --terminatesomef12 TERMINATESOMEF12
                         Only used by terminatesome. Terminates this many of
-                        the previously launched f1.2xlarges.
+                        the previously launched f1.2xlarges. (default: -1)
   -i TERMINATESOMEF14, --terminatesomef14 TERMINATESOMEF14
                         Only used by terminatesome. Terminates this many of
-                        the previously launched f1.4xlarges.
+                        the previously launched f1.4xlarges. (default: -1)
   -m TERMINATESOMEM416, --terminatesomem416 TERMINATESOMEM416
                         Only used by terminatesome. Terminates this many of
-                        the previously launched m4.16xlarges.
+                        the previously launched m4.16xlarges. (default: -1)
   -q, --forceterminate  For terminaterunfarm, force termination without
-                        prompting user for confirmation. Defaults to False
+                        prompting user for confirmation. (default: False)
   -t LAUNCHTIME, --launchtime LAUNCHTIME
                         Give the "Y-m-d--H-M-S" prefix of results-build
                         directory. Useful for tar2afi when finishing a partial
-                        buildafi
+                        buildafi (default: None)
   -o, --copyonly        Only used by managerinit, only setup the default
-                        configuration files. Defaults to False
+                        configuration files. (default: False)

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -8,6 +8,28 @@ This page outlines all of the tasks that the FireSim manager supports.
 ``firesim managerinit``
 ----------------------------
 
+.. Warning:: DEPRECATION: managerinit will move AWS setup strictly to awsinit in a future release
+
+This is a setup command that does the following:
+
+* Run ``aws configure``, prompt for credentials
+* Replace the default config files (``config_runtime.ini``, ``config_build.ini``, ``config_build_recipes.ini``, and ``config_hwdb.ini``) with clean example versions.
+* Prompt the user for email address and subscribe them to notifications for their own builds.
+
+You can re-run this whenever you want to get clean configuration files -- you
+can just hit enter when prompted for aws configure credentials and your email
+address, and both will keep your previously specified values.
+You can re-run this whenever you want to get clean configuration files.
+
+If you run this command by accident and didn't mean to overwrite your
+configuration files, you'll find backed-up versions in
+``firesim/deploy/sample-backup-configs/backup*``.
+
+.. _firesim-managerinit:
+
+``firesim managerinit --copyonly``
+----------------------------
+
 This is a setup command that does the following:
 
 * Replace the default config files (``config_runtime.ini``, ``config_build.ini``, ``config_build_recipes.ini``, and ``config_hwdb.ini``) with clean example versions.

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -10,18 +10,23 @@ This page outlines all of the tasks that the FireSim manager supports.
 
 This is a setup command that does the following:
 
-* Run ``aws configure``, prompt for credentials
 * Replace the default config files (``config_runtime.ini``, ``config_build.ini``, ``config_build_recipes.ini``, and ``config_hwdb.ini``) with clean example versions.
-* Prompt the user for email address and subscribe them to notifications for their own builds.
 
-You can re-run this whenever you want to get clean configuration files -- you
-can just hit enter when prompted for aws configure credentials and your email
-address, and both will keep your previously specified values.
+You can re-run this whenever you want to get clean configuration files.
 
 If you run this command by accident and didn't mean to overwrite your
 configuration files, you'll find backed-up versions in
 ``firesim/deploy/sample-backup-configs/backup*``.
 
+.. _firesim-awsinit:
+
+``firesim awsinit``
+----------------------------
+
+This is a setup command that does the following:
+
+* Run ``aws configure``, prompt for credentials
+* Prompt the user for email address and subscribe them to notifications for their own builds.
 
 .. _firesim-buildafi:
 
@@ -80,14 +85,14 @@ This directory will contain:
 ----------------------
 
 This command can be used to run only steps 9 & 10 from an aborted ``firesim buildafi`` that has been
-manually corrected. ``firesim tar2afi`` assumes that you have a 
+manually corrected. ``firesim tar2afi`` assumes that you have a
 ``firesim/deploy/results-build/LAUNCHTIME-CONFIG_TRIPLET-BUILD_NAME/cl_firesim``
 directory tree that can be submitted to the AWS backend for conversion to an AFI.
 
 When using this command, you need to also provide the ``--launchtime LAUNCHTIME`` cmdline argument,
-specifying an already existing LAUNCHTIME.  
+specifying an already existing LAUNCHTIME.
 
-This command will run for the configurations specified in :ref:`config-build` and 
+This command will run for the configurations specified in :ref:`config-build` and
 :ref:`config-build-recipes` as with :ref:`firesim-buildafi`.  It is likely that you may want
 to comment out ``BUILD_NAME`` that successfully completed :ref:`firesim-builafi` before
 running this command.
@@ -282,7 +287,7 @@ workload configuration (see the :ref:`defining-custom-workloads` section).
 
 For
 non-networked simulations, it will wait for ALL simulations to complete (copying
-back results as each workload completes), then exit. 
+back results as each workload completes), then exit.
 
 For
 globally-cycle-accurate networked simulations, the global simulation will stop

--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -124,11 +124,12 @@ your firesim directory and source this file again.**
 Completing Setup Using the Manager
 ----------------------------------
 
-The FireSim manager contains a command that will interactively guide you
-through the rest of the FireSim setup process. To run it, do the following:
+The FireSim manager contains two commands that will interactively guide you
+through the rest of the FireSim setup process. To run them, do the following:
 
 ::
 
+    firesim awsinit
     firesim managerinit
 
 This will first prompt you to setup AWS credentials on the instance, which allows
@@ -137,10 +138,11 @@ https://docs.aws.amazon.com/cli/latest/userguide/tutorial-ec2-ubuntu.html#config
 for more about these credentials. When prompted, you should specify the same
 region that you chose above and set the default output format to ``json``.
 
-Next, it will create initial configuration files, which we will edit in later
-sections. Finally, it will prompt you for an email address, which is used to
+Next, it will prompt you for an email address, which is used to
 send email notifications upon FPGA build completion and optionally for
 workload completion. You can leave this blank if you do not wish to receive any
 notifications, but this is not recommended.
+Next, it will create initial configuration files, which we will edit in later
+sections.
 
 Now you're ready to launch FireSim simulations! Hit Next to learn how to run single-node simulations.


### PR DESCRIPTION
Separate `managerinit` setup related to AWS into its own manager command called `awsinit`. New `managerinit` functionality (i.e. only copying) is gated behind the `--copyonly` flag. Old `managerinit` functionality still exists but emits a deprecation warning.

#### Related PRs / Issues

#848 

#### UI / API Impact

See the description.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
