### PR TITLE
Fix CI Instance Cleanup 

### DIFF
--- a/.circleci/cull-old-ci-instances.py
+++ b/.circleci/cull-old-ci-instances.py
@@ -6,6 +6,7 @@
 import datetime
 import pytz
 import boto3
+import sys
 
 from common import unique_tag_key
 


### PR DESCRIPTION
Fixes a recent change that broke the clean up job.

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
