### PR TITLE
[targetutils] Check annotators expect hardware types where appropriate

### DIFF
--- a/sim/midas/targetutils/src/main/scala/midas/annotations.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/annotations.scala
@@ -286,7 +286,7 @@ object TriggerSource {
     // Hack: Create dummy nodes until chisel-side instance annotations have been improved
     val clock = WireDefault(Module.clock)
     reset.map(dontTouch.apply)
-    requireIsHardware(target, "Target passed to TriggerSoure:")
+    requireIsHardware(target, "Target passed to TriggerSource:")
     reset.foreach { requireIsHardware(_,  "Reset passed to TriggerSource:") }
     annotate(new ChiselAnnotation {
       def toFirrtl = TriggerSourceAnnotation(target.toNamed.toTarget, clock.toNamed.toTarget, reset.map(_.toTarget), tpe)

--- a/sim/midas/targetutils/src/main/scala/midas/annotations.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/annotations.scala
@@ -3,7 +3,7 @@
 package midas.targetutils
 
 import chisel3._
-import chisel3.experimental.{BaseModule, ChiselAnnotation, annotate}
+import chisel3.experimental.{BaseModule, ChiselAnnotation, annotate, requireIsHardware}
 
 import firrtl.{RenameMap}
 import firrtl.annotations._
@@ -24,6 +24,7 @@ case class FirrtlFpgaDebugAnnotation(target: ComponentName) extends
 
 object FpgaDebug {
   def apply(targets: chisel3.Data*): Unit = {
+    targets foreach { requireIsHardware(_, "Target passed to FpgaDebug:") }
     targets.map({ t => chisel3.experimental.annotate(FpgaDebugAnnotation(t)) })
   }
 }
@@ -227,8 +228,13 @@ object PerfCounter {
             reset: Reset,
             label: String,
             message: String): Unit = {
+    requireIsHardware(target, "Target passed to PerfCounter:")
+    requireIsHardware(clock,  "Clock passed to PerfCounter:")
+    requireIsHardware(reset,  "Reset passed to PerfCounter:")
     annotate(new ChiselAnnotation {
-      def toFirrtl = AutoCounterFirrtlAnnotation(target.toTarget, clock.toTarget,
+      def toFirrtl = AutoCounterFirrtlAnnotation(
+        target.toTarget,
+        clock.toTarget,
         reset.toTarget, label, message)
     })
   }
@@ -280,6 +286,8 @@ object TriggerSource {
     // Hack: Create dummy nodes until chisel-side instance annotations have been improved
     val clock = WireDefault(Module.clock)
     reset.map(dontTouch.apply)
+    requireIsHardware(target, "Target passed to TriggerSoure:")
+    reset.foreach { requireIsHardware(_,  "Reset passed to TriggerSource:") }
     annotate(new ChiselAnnotation {
       def toFirrtl = TriggerSourceAnnotation(target.toNamed.toTarget, clock.toNamed.toTarget, reset.map(_.toTarget), tpe)
     })

--- a/sim/midas/targetutils/src/test/scala/ElaborationUtils.scala
+++ b/sim/midas/targetutils/src/test/scala/ElaborationUtils.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package midas.targetutils
+
+import chisel3._
+import chisel3.stage.ChiselStage
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+trait ElaborationUtils { self: AnyFlatSpec =>
+  def elaborate(mod: =>Module): Unit = ChiselStage.emitFirrtl(mod)
+
+  class AnnotateChiselTypeModule[T <: Data](gen: =>T, annotator: T => Unit) extends Module {
+    val io = IO(new Bundle {
+      val test = gen
+      annotator(test)
+    })
+  }
+  class AnnotateHardwareModule[T <: Data](gen: =>T, annotator: T => Unit) extends Module {
+    val io = IO(new Bundle {
+      val test = gen
+    })
+    annotator(io.test)
+  }
+
+  /**
+    * Instantiates a module with IO of the provided type twice, checking that the provided
+    * annotator croaks when used before the IO is still unbound, but not otherwise.
+    *
+    */
+  def checkBehaviorOnUnboundTargets[T <: Data](gen: =>T, annotator: T => Unit) { 
+    it should "elaborate and compile correctly when annotating HW types" in {
+      elaborate(new AnnotateHardwareModule(gen, annotator))
+    }
+
+    it should "reject unbound types at elaboration time" in {
+      assertThrows[ExpectedHardwareException] {
+        elaborate(new AnnotateChiselTypeModule(gen, annotator))
+      }
+    }
+  }
+}
+

--- a/sim/midas/targetutils/src/test/scala/FpgaDebugSpec.scala
+++ b/sim/midas/targetutils/src/test/scala/FpgaDebugSpec.scala
@@ -1,0 +1,16 @@
+// See LICENSE for license details.
+
+package midas.targetutils
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import chisel3._
+
+class FpgaDebugSpec extends AnyFlatSpec with ElaborationUtils {
+  def annotator(t: Bool) = FpgaDebug(t)
+  def ioGen = Input(Bool())
+
+  behavior of "FPGADebug"
+  checkBehaviorOnUnboundTargets(ioGen, annotator)
+}

--- a/sim/midas/targetutils/src/test/scala/PerfCounterSpec.scala
+++ b/sim/midas/targetutils/src/test/scala/PerfCounterSpec.scala
@@ -1,0 +1,16 @@
+// See LICENSE for license details.
+
+package midas.targetutils
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import chisel3._
+
+class PerfCounterSpec extends AnyFlatSpec with ElaborationUtils {
+  def annotator(t: Bool) = PerfCounter(t, "", "")
+  def ioGen = Input(Bool())
+
+  behavior of "PerfCounter"
+  checkBehaviorOnUnboundTargets(ioGen, annotator)
+}


### PR DESCRIPTION
Putting calls to certain annotators in a Bundle definition (i.e., it will be invoked before the bundle is bound to HW) can produce unintuitive error messages in elaboration and during FIRRTL compilation. This ensures an error when the annotator is invoked. 

<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

Users get a better error message if they invoke annotators in the wrong place. 

#### Verilog / AGFI Compatibility

No change.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
