### PR TITLE
Update machine-launch-script.sh

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,17 +9,17 @@
 <!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
 <!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->
 
-#### Verilog / AGFI Compatability
+#### Verilog / AGFI Compatibility
 
 <!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->
 
 ### Contributor Checklist
-
+- [ ] Did you set dev as the base branch?
 - [ ] Did you add Scaladoc to every public function/method?
 - [ ] Did you add at least one test demonstrating the PR?
 - [ ] Did you delete any extraneous prints/debugging code?
 - [ ] Did you state the UI / API impact?
-- [ ] Did you specify the Verilog / AGFI compatability impact?
+- [ ] Did you specify the Verilog / AGFI compatibility impact?
 <!-- Do this if this PR changes verilog or breaks the default AGFIs -->
 - [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
 <!-- Do this if this PR is a bugfix that should be applied to master -->
@@ -27,5 +27,5 @@
 - [ ] (On merge) Did you update release notes in the dev-to-master PR ?
 
 ### Reviewer Checklist (only modified by reviewer)
-- [ ] Did you mark the proper milestone (1.12.0, 1.13.0) ?
+- [ ] Did you mark the proper release milestone?
 - [ ] Did you check whether all relevant Contributor checkboxes have been checked?

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -47,6 +47,9 @@ sudo yum -y install graphviz python-devel
 # used for CI
 sudo yum -y install expect
 
+# update ca-certificates
+sudo yum -y install ca-certificates
+
 # these need to match what's in deploy/requirements.txt
 # last working pip version before deprecation
 sudo pip2 install --upgrade pip==20.3.4


### PR DESCRIPTION
Need to update ca-certificates on Centos AFI to remove expired Let's Encrypt root certificate, which signs git.kernel.org, where we are downloading firesim dependency e2fsprogs.

Otherwise, get certificate verification error when `wget`ing the tarball in build-setup.sh

More info [here](https://blog.devgenius.io/rhel-centos-7-fix-for-lets-encrypt-change-8af2de587fe4).

<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
