### PR TITLE
Rsync workload outputs

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -5,6 +5,7 @@ import logging
 from runtools.switch_model_config import AbstractSwitchToSwitchConfig
 from util.streamlogger import StreamLogger
 from fabric.api import *
+from fabric.contrib.project import rsync_project
 
 rootLogger = logging.getLogger()
 
@@ -296,7 +297,13 @@ class FireSimServerNode(FireSimNode):
             ## copy back files from inside the rootfs
             with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
                 for outputfile in jobinfo.outputs:
-                    get(remote_path=mountpoint + outputfile, local_path=job_dir)
+                    rsync_cap = rsync_project(remote_dir=mountpoint + outputfile,
+                            local_dir=job_dir,
+                            ssh_opts="-o StrictHostKeyChecking=no",
+                            extra_opts="-L",
+                            capture=True)
+                    rootLogger.debug(rsync_cap)
+                    rootLogger.debug(rsync_cap.stderr)
 
             ## unmount
             with StreamLogger('stdout'), StreamLogger('stderr'):
@@ -313,7 +320,13 @@ class FireSimServerNode(FireSimNode):
         remote_sim_run_dir = """/home/centos/sim_slot_{}/""".format(simserverindex)
         for simoutputfile in jobinfo.simoutputs:
             with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
-                get(remote_path=remote_sim_run_dir + simoutputfile, local_path=job_dir)
+                rsync_cap = rsync_project(remote_dir=remote_sim_run_dir + simoutputfile,
+                        local_dir=job_dir,
+                        ssh_opts="-o StrictHostKeyChecking=no",
+                        extra_opts="-L",
+                        capture=True)
+                rootLogger.debug(rsync_cap)
+                rootLogger.debug(rsync_cap.stderr)
 
     def get_sim_kill_command(self, slotno):
         """ return the command to kill the simulation. assumes it will be

--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -301,6 +301,7 @@ class FireSimServerNode(FireSimNode):
                             local_dir=job_dir,
                             ssh_opts="-o StrictHostKeyChecking=no",
                             extra_opts="-L",
+                            upload=False,
                             capture=True)
                     rootLogger.debug(rsync_cap)
                     rootLogger.debug(rsync_cap.stderr)
@@ -324,6 +325,7 @@ class FireSimServerNode(FireSimNode):
                         local_dir=job_dir,
                         ssh_opts="-o StrictHostKeyChecking=no",
                         extra_opts="-L",
+                        upload=False,
                         capture=True)
                 rootLogger.debug(rsync_cap)
                 rootLogger.debug(rsync_cap.stderr)

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -23,7 +23,7 @@ switchinglatency=10
 netbandwidth=200
 profileinterval=-1
 
-# This references a section from config_hwconfigs.ini
+# This references a section from config_build_recipes.ini
 # In homogeneous configurations, use this to set the hardware config deployed
 # for all simulators
 defaulthwconfig=firesim-rocket-quadcore-nic-l2-llc4mb-ddr3

--- a/docs/Advanced-Usage/Workloads/Defining-Custom-Workloads.rst
+++ b/docs/Advanced-Usage/Workloads/Defining-Custom-Workloads.rst
@@ -100,7 +100,7 @@ when a workload running on a simulated cluster with ``firesim runworkload``
 completes, ``/etc/os-release`` will be copied out from each rootfs and placed
 in the job's output directory within the workload's output directory (See
 the :ref:`firesim-runworkload` section). You can add multiple paths
-here.
+here. Additionally, you can use bash globbing for file names (ex: ``file*name``).
 
 The ``common_simulation_outputs`` field is a list of outputs that the manager
 will copy off of the simulation host machine AFTER a simulation completes. In
@@ -111,7 +111,8 @@ full console output of the simulated system) and ``memory_stats.csv`` files
 will be copied out of the simulation's base directory on the host instance and
 placed in the job's output directory within the workload's output directory
 (see the :ref:`firesim-runworkload` section). You can add multiple
-paths here.
+paths here. Additionally, you can use bash globbing for file names
+(ex: ``file*name``).
 
 ..
   TODO: this is no longer relevant with firemarshal
@@ -125,7 +126,7 @@ paths here.
 Non-uniform Workload JSON (explicit job per simulated node)
 ---------------------------------------------------------------
 
-Now, we'll look at the ``ping-latency`` workload, which explicitly defines a 
+Now, we'll look at the ``ping-latency`` workload, which explicitly defines a
 job per simulated node.
 
 .. include:: /../deploy/workloads/ping-latency-firemarshal.json


### PR DESCRIPTION
Uses `rsync_project` instead of `get` to transfer files from simulation runfarm instance to the manager. This allows compressed transfers instead of the previous uncompressed transfers (`get` under the hood uses SFTP). This also fixes up the documentation a bit (clarifies globbing + small file fix in `runtime.ini`). Tested with the `clean.yaml` FireMarshal workload with `common_outputs` set to `/root/runOut*t` and `common_simulation_outputs` set to `memory_stats*.csv` to test globbing outputs.

#### Related PRs / Issues

Fixes #874 

#### UI / API Impact

N/a. It is clearer that workloads support globbing the file and simulation outputs.

#### Verilog / AGFI Compatibility

N/a

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
