### PR TITLE
Add HW config summary in per job outputs

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -273,6 +273,11 @@ class FireSimServerNode(FireSimNode):
             localcap = local("""mkdir -p {}""".format(job_dir), capture=True)
             rootLogger.debug("[localhost] " + str(localcap))
             rootLogger.debug("[localhost] " + str(localcap.stderr))
+            
+            # add hw config summary per job
+            localcap = local("""echo "{}" > {}/HW_CFG_SUMMARY""".format(str(self.server_hardware_config), job_dir), capture=True)
+            rootLogger.debug("[localhost] " + str(localcap))
+            rootLogger.debug("[localhost] " + str(localcap.stderr))
 
         # mount rootfs, copy files from it back to local system
         rfsname = self.get_rootfs_name()


### PR DESCRIPTION
Adds an extra file to all workload outputs indicating the runtime HW config details of that job (AFI, runtime conf, deploy triplet). This is useful to figure out what a workload was run on when you are running a heterogeneous user topology. 

Sample output of `HW_CFG_SUMMARY`:
```
RuntimeHWConfig: super-cool-hw-configuration-yay
DeployTriplet: FireSim-MyConfig-WithStuff_F20MHz_BaseF1Config
AGFI: agfi-deadbeef
CustomRuntimeConf: 100GHz.conf
```

#### Related PRs / Issues

None

#### UI / API Impact

Adds `HW_CFG_SUMMARY` file to all workload outputs.

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
