### PR TITLE
fased: Use right NastiKey to calculate TLError address

### DIFF
--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -234,7 +234,7 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
     // Since there is no diplomatic AXI4 width converter, use the TL one
     val xbar = LazyModule(new TLXbar)
     val error = LazyModule(new TLError(DevNullParams(
-        Seq(AddressSet(BigInt(1) << p(MemNastiKey).addrBits, 0xff)),
+        Seq(AddressSet(BigInt(1) << p(NastiKey).addrBits, 0xff)),
         maxAtomic = 1,
         maxTransfer = p(HostMemChannelKey).maxXferBytes),
       beatBytes = hostWidthBytes))


### PR DESCRIPTION
For target memory systems that use all available host-DRAM and require a target-to-host width adapter, the TLError instantiated in the width adapter will overlap with the target's address space.

This fixes that to use the address size of the target (not the host, oops...) to pick a location that can never overlap. 

<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None. 
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

None, since we don't need width adapters.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
