### PR TITLE
Workaround treadle firrtl-dependency management using sys.prop

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -47,8 +47,11 @@ SCALA_BUILDTOOL_DEPS ?= $(sbt_sources)
 
 SBT_THIN_CLIENT_TIMESTAMP = $(base_dir)/project/target/active.json
 
-# by default build chisel3/firrtl and other subprojects from source
-override SBT_OPTS += -Dsbt.sourcemode=true -Dsbt.workspace=$(chipyard_dir)/tools
+# By default build chisel3/firrtl and other subprojects from source
+# Workaround: Specify a firrtl version in system properties so that Treadle uses a
+# compatible version of FIRRTL and not 1.5-SNAPSHOT (which is the default
+# specified in it's build.sbt, and is not overridden by Chipyard's build.sbt)
+override SBT_OPTS += -DfirrtlVersion=1.4.1 -Dsbt.sourcemode=true -Dsbt.workspace=$(chipyard_dir)/tools
 
 ifdef ENABLE_SBT_THIN_CLIENT
 override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)


### PR DESCRIPTION
Unfortunately, our firrtl-dependency overriding in chipyard's build.sbt has a hole wherein treadle pulls in a 1.5-SNAPSHOT from maven instead of our desired version of 1.4.1. Recently, a slew of deprecated APIs were removed in the 1.5-SNAPSHOT recently, leading treadle compilation to fail. As a result, FireSim master (and thus, the 1.12 release) and dev are broken. Unless i'm woefully mistaken, this should be true of Chipyard dev and at least its most recent release. 

Workaround this problem by specifying a FIRRTL version through the java system properties, which treadle will pick up to override the 1.5-SNAPSHOT default. We could do Chisel too. 

The right solution to this (IMO) is to just use published dependencies for the big 5 instead of trying to build from source. 

This will need to be back-ported to master.

#### Related PRs / Issues

None

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

None 

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
