### PR TITLE
remove unused(deprecated) APIs.

### DIFF
--- a/sim/midas/src/main/scala/midas/FPGAQoRShimGenerator.scala
+++ b/sim/midas/src/main/scala/midas/FPGAQoRShimGenerator.scala
@@ -2,7 +2,6 @@
 package midas.unittest
 
 import chisel3._
-import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
 
 import freechips.rocketchip.config.{Parameters, Config, Field}
 import midas.widgets.ScanRegister

--- a/sim/midas/src/main/scala/midas/SynthUnitTests.scala
+++ b/sim/midas/src/main/scala/midas/SynthUnitTests.scala
@@ -5,7 +5,6 @@ package midas.unittest
 import midas.core._
 
 import chisel3._
-import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
 
 import freechips.rocketchip.config.{Parameters, Config, Field}
 import freechips.rocketchip.unittest.{UnitTests, TestHarness}


### PR DESCRIPTION
#### Related PRs / Issues
None

#### UI / API Impact
None

#### Verilog / AGFI Compatibility
None

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
