### PR TITLE
Use Published Dependencies For Chisel + FIRRTL

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.ini
+++ b/deploy/sample-backup-configs/sample_config_hwdb.ini
@@ -10,27 +10,27 @@
 # own images.
 
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0aa96f4214e125fa7
+agfi=agfi-011237cb56f4e09d0
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-05696fc3823b9c6db
+agfi=agfi-0527595dd6245d41a
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
-agfi=agfi-0e817cc7ccaf9fd0a
+agfi=agfi-027d8c3d242d7c024
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
-agfi=agfi-0833e931ad5f2fa38
+agfi=agfi-09f7ad49e6da339d5
 deploytripletoverride=None
 customruntimeconfig=None
 
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
-agfi=agfi-02059611104e23100
+agfi=agfi-0968f0d2b39fc2428
 deploytripletoverride=None
 customruntimeconfig=None
 

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -47,9 +47,6 @@ SCALA_BUILDTOOL_DEPS ?= $(sbt_sources)
 
 SBT_THIN_CLIENT_TIMESTAMP = $(base_dir)/project/target/active.json
 
-# by default build chisel3/firrtl and other subprojects from source
-override SBT_OPTS += -Dsbt.sourcemode=true -Dsbt.workspace=$(chipyard_dir)/tools
-
 ifdef ENABLE_SBT_THIN_CLIENT
 override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 # enabling speeds up sbt loading

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -47,11 +47,8 @@ SCALA_BUILDTOOL_DEPS ?= $(sbt_sources)
 
 SBT_THIN_CLIENT_TIMESTAMP = $(base_dir)/project/target/active.json
 
-# By default build chisel3/firrtl and other subprojects from source
-# Workaround: Specify a firrtl version in system properties so that Treadle uses a
-# compatible version of FIRRTL and not 1.5-SNAPSHOT (which is the default
-# specified in it's build.sbt, and is not overridden by Chipyard's build.sbt)
-override SBT_OPTS += -DfirrtlVersion=1.4.1 -Dsbt.sourcemode=true -Dsbt.workspace=$(chipyard_dir)/tools
+# by default build chisel3/firrtl and other subprojects from source
+override SBT_OPTS += -Dsbt.sourcemode=true -Dsbt.workspace=$(chipyard_dir)/tools
 
 ifdef ENABLE_SBT_THIN_CLIENT
 override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)

--- a/sim/build.sbt
+++ b/sim/build.sbt
@@ -58,7 +58,8 @@ lazy val firesimRef = ProjectRef(file("."), "firesim")
 
 lazy val midas = (project in file("midas"))
   .dependsOn(rocketchip)
-  .settings(libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.4.1" % "test")
+  .settings(libraryDependencies ++= Seq(
+    "org.scalatestplus" %% "scalacheck-1-14" % "3.1.3.0" % "test"))
   .settings(commonSettings)
 
 

--- a/sim/build.sbt
+++ b/sim/build.sbt
@@ -1,6 +1,6 @@
 import Tests._
 
-val chiselVersion = "3.4.1"
+val chiselVersion = "3.4.4"
 
 // This is set by CI and should otherwise be unmodified
 val apiDirectory = settingKey[String]("The site directory into which the published scaladoc should placed.")

--- a/sim/midas/src/main/scala/midas/passes/fame/FAMETransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/FAMETransform.scala
@@ -223,7 +223,7 @@ object FAMEModuleTransformer {
           XDCFiles.Implementation,
           s"""|create_generated_clock -name ${clockName} -source [get_pins -of [get_clocks host_clock]] [get_pins {}] -divide_by 1
               |set_multicycle_path $clockMFMR -setup -from [get_clocks $clockName] -to [get_clocks $clockName]
-              |set_multicycle_path 1 -hold  -from [get_clocks $clockName] -to [get_clocks $clockName]
+              |set_multicycle_path ${clockMFMR - 1} -hold  -from [get_clocks $clockName] -to [get_clocks $clockName]
               |""".stripMargin,
           bufferOutputRT)
         addedAnnos += xdcAnno

--- a/sim/midas/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/sim/midas/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.testutils
+
+import java.io._
+import java.security.Permission
+
+import logger.{LazyLogging, LogLevel, LogLevelAnnotation}
+
+import org.scalatest._
+import org.scalatestplus.scalacheck._
+
+import firrtl._
+import firrtl.ir._
+import firrtl.Parser.UseInfo
+import firrtl.options.Dependency
+import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
+import firrtl.annotations._
+import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation, RenameModules}
+import firrtl.util.BackendCompilationUtilities
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class CheckLowForm extends SeqTransform {
+  def inputForm = LowForm
+  def outputForm = LowForm
+  def transforms = Seq(
+    passes.CheckHighForm
+  )
+}
+
+case class RenameTopAnnotation(newTopName: String) extends NoTargetAnnotation
+
+object RenameTop extends Transform {
+  def inputForm = UnknownForm
+  def outputForm = UnknownForm
+  override def invalidates(a: Transform) = false
+
+  override val optionalPrerequisites = Seq(Dependency[RenameModules])
+
+  override val optionalPrerequisiteOf = Seq(Dependency[VerilogEmitter], Dependency[MinimumVerilogEmitter])
+
+  def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit
+    val ns = Namespace(c)
+
+    val newTopName = state.annotations
+      .collectFirst({
+        case RenameTopAnnotation(name) =>
+          require(ns.tryName(name))
+          name
+      })
+      .getOrElse(c.main)
+
+    state.annotations.collect {
+      case ModuleNamespaceAnnotation(mustNotCollideNS) => require(mustNotCollideNS.tryName(newTopName))
+    }
+
+    val modulesx = c.modules.map {
+      case m: Module if (m.name == c.main) => m.copy(name = newTopName)
+      case m => m
+    }
+
+    val renames = RenameMap()
+    renames.record(CircuitTarget(c.main), CircuitTarget(newTopName))
+    state.copy(circuit = c.copy(main = newTopName, modules = modulesx), renames = Some(renames))
+  }
+}
+
+trait FirrtlRunners extends BackendCompilationUtilities {
+
+  val cppHarnessResourceName: String = "/firrtl/testTop.cpp"
+
+  /** Extra transforms to run by default */
+  val extraCheckTransforms = Seq(new CheckLowForm)
+
+  /** Check equivalence of Firrtl transforms using yosys
+    *
+    * @param input string containing Firrtl source
+    * @param customTransforms Firrtl transforms to test for equivalence
+    * @param customAnnotations Optional Firrtl annotations
+    * @param timesteps the maximum number of timesteps to consider
+    */
+  def firrtlEquivalenceTest(
+    input:             String,
+    customTransforms:  Seq[Transform] = Seq.empty,
+    customAnnotations: AnnotationSeq = Seq.empty,
+    timesteps:         Int = 1
+  ): Unit = {
+    val circuit = Parser.parse(input.split("\n").toIterator)
+    val prefix = circuit.main
+    val testDir = createTestDirectory(prefix + "_equivalence_test")
+
+    def toAnnos(xforms: Seq[Transform]) = xforms.map(RunFirrtlTransformAnnotation(_))
+
+    def getBaseAnnos(topName: String) = {
+      val baseTransforms = RenameTop +: extraCheckTransforms
+      TargetDirAnnotation(testDir.toString) +:
+        InfoModeAnnotation("ignore") +:
+        RenameTopAnnotation(topName) +:
+        stage.FirrtlCircuitAnnotation(circuit) +:
+        stage.RunFirrtlTransformAnnotation.stringToEmitter("mverilog") +:
+        stage.OutputFileAnnotation(topName) +:
+        toAnnos(baseTransforms)
+    }
+
+    val customName = s"${prefix}_custom"
+    val customAnnos = customAnnotations ++: toAnnos((new GetNamespace) +: customTransforms) ++: getBaseAnnos(customName)
+
+    val customResult = (new firrtl.stage.FirrtlStage).execute(Array.empty, customAnnos)
+    val nsAnno = customResult.collectFirst { case m: ModuleNamespaceAnnotation => m }.get
+
+    val refSuggestedName = s"${prefix}_ref"
+    val refAnnos = Seq(RunFirrtlTransformAnnotation(new RenameModules), nsAnno) ++: getBaseAnnos(refSuggestedName)
+
+    val refResult = (new firrtl.stage.FirrtlStage).execute(Array.empty, refAnnos)
+    val refName =
+      refResult.collectFirst({ case stage.FirrtlCircuitAnnotation(c) => c.main }).getOrElse(refSuggestedName)
+
+    assert(BackendCompilationUtilities.yosysExpectSuccess(customName, refName, testDir, timesteps))
+  }
+
+  /** Compiles input Firrtl to Verilog */
+  def compileToVerilog(input: String, annotations: AnnotationSeq = Seq.empty): String = {
+    val circuit = Parser.parse(input.split("\n").toIterator)
+    val compiler = new VerilogCompiler
+    val res = compiler.compileAndEmit(CircuitState(circuit, HighForm, annotations), extraCheckTransforms)
+    res.getEmittedCircuit.value
+  }
+
+  /** Compile a Firrtl file
+    *
+    * @param prefix is the name of the Firrtl file without path or file extension
+    * @param srcDir directory where all Resources for this test are located
+    * @param annotations Optional Firrtl annotations
+    */
+  def compileFirrtlTest(
+    prefix:           String,
+    srcDir:           String,
+    customTransforms: Seq[Transform] = Seq.empty,
+    annotations:      AnnotationSeq = Seq.empty
+  ): File = {
+    val testDir = createTestDirectory(prefix)
+    val inputFile = new File(testDir, s"${prefix}.fir")
+    copyResourceToFile(s"${srcDir}/${prefix}.fir", inputFile)
+
+    val annos =
+      FirrtlFileAnnotation(inputFile.toString) +:
+        TargetDirAnnotation(testDir.toString) +:
+        InfoModeAnnotation("ignore") +:
+        annotations ++:
+        (customTransforms ++ extraCheckTransforms).map(RunFirrtlTransformAnnotation(_))
+
+    (new firrtl.stage.FirrtlStage).execute(Array.empty, annos)
+
+    testDir
+  }
+
+  /** Execute a Firrtl Test
+    *
+    * @param prefix is the name of the Firrtl file without path or file extension
+    * @param srcDir directory where all Resources for this test are located
+    * @param verilogPrefixes names of option Verilog resources without path or file extension
+    * @param annotations Optional Firrtl annotations
+    */
+  def runFirrtlTest(
+    prefix:           String,
+    srcDir:           String,
+    verilogPrefixes:  Seq[String] = Seq.empty,
+    customTransforms: Seq[Transform] = Seq.empty,
+    annotations:      AnnotationSeq = Seq.empty
+  ) = {
+    val testDir = compileFirrtlTest(prefix, srcDir, customTransforms, annotations)
+    val harness = new File(testDir, s"top.cpp")
+    copyResourceToFile(cppHarnessResourceName, harness)
+
+    // Note file copying side effect
+    val verilogFiles = verilogPrefixes.map { vprefix =>
+      val file = new File(testDir, s"$vprefix.v")
+      copyResourceToFile(s"$srcDir/$vprefix.v", file)
+      file
+    }
+
+    verilogToCpp(prefix, testDir, verilogFiles, harness) #&&
+      cppToExe(prefix, testDir) !
+      loggingProcessLogger
+    assert(executeExpectingSuccess(prefix, testDir))
+  }
+}
+
+trait FirrtlMatchers extends Matchers {
+  def dontTouch(ref: ReferenceTarget): DontTouchAnnotation = {
+    DontTouchAnnotation(ref)
+  }
+  def dontTouch(path: String): Annotation = {
+    val parts = path.split('.')
+    require(parts.size >= 2, "Must specify both module and component!")
+    val name = ComponentName(parts.tail.mkString("."), ModuleName(parts.head, CircuitName("Top")))
+    DontTouchAnnotation(name)
+  }
+  def dontDedup(mod: String): Annotation = {
+    require(mod.split('.').size == 1, "Can only specify a Module, not a component or instance")
+    NoDedupAnnotation(ModuleName(mod, CircuitName("Top")))
+  }
+  // Replace all whitespace with a single space and remove leading and
+  //   trailing whitespace
+  // Note this is intended for single-line strings, no newlines
+  def normalized(s: String): String = {
+    require(!s.contains("\n"))
+    s.replaceAll("\\s+", " ").trim
+  }
+
+  /** Helper to make circuits that are the same appear the same */
+  def canonicalize(circuit: Circuit): Circuit = {
+    import firrtl.Mappers._
+    def onModule(mod: DefModule) = mod.map(firrtl.Utils.squashEmpty)
+    circuit.map(onModule)
+  }
+  def parse(str: String) = Parser.parse(str.split("\n").toIterator, UseInfo)
+
+  /** Helper for executing tests
+    * compiler will be run on input then emitted result will each be split into
+    * lines and normalized.
+    */
+  def executeTest(
+    input:       String,
+    expected:    Seq[String],
+    compiler:    Compiler,
+    annotations: Seq[Annotation] = Seq.empty
+  ) = {
+    val finalState = compiler.compileAndEmit(CircuitState(parse(input), ChirrtlForm, annotations))
+    val lines = finalState.getEmittedCircuit.value.split("\n").map(normalized)
+    for (e <- expected) {
+      lines should contain(e)
+    }
+  }
+}
+
+object FirrtlCheckers extends FirrtlMatchers {
+  import matchers._
+  implicit class TestingFunctionsOnCircuitState(val state: CircuitState) extends AnyVal {
+    def search(pf: PartialFunction[Any, Boolean]): Boolean = state.circuit.search(pf)
+  }
+  implicit class TestingFunctionsOnCircuit(val circuit: Circuit) extends AnyVal {
+    def search(pf: PartialFunction[Any, Boolean]): Boolean = {
+      val f = pf.lift
+      def rec(node: Any): Boolean = {
+        f(node) match {
+          // If the partial function is defined on this node, return its result
+          case Some(res) => res
+          // Otherwise keep digging
+          case None =>
+            require(
+              node.isInstanceOf[Product] || !node.isInstanceOf[FirrtlNode],
+              "Error! Unexpected FirrtlNode that does not implement Product!"
+            )
+            val iter = node match {
+              case p: Product       => p.productIterator
+              case i: Iterable[Any] => i.iterator
+              case _ => Iterator.empty
+            }
+            iter.foldLeft(false) {
+              case (res, elt) => if (res) res else rec(elt)
+            }
+        }
+      }
+      rec(circuit)
+    }
+  }
+
+  /** Checks that the emitted circuit has the expected line, both will be normalized */
+  def containLine(expectedLine: String) = containLines(expectedLine)
+
+  /** Checks that the emitted circuit contains the expected lines contiguously and in order;
+    * all lines will be normalized
+    */
+  def containLines(expectedLines: String*) = new CircuitStateStringsMatcher(expectedLines)
+
+  class CircuitStateStringsMatcher(expectedLines: Seq[String]) extends Matcher[CircuitState] {
+    override def apply(state: CircuitState): MatchResult = {
+      val emitted = state.getEmittedCircuit.value
+      MatchResult(
+        emitted.split("\n").map(normalized).containsSlice(expectedLines.map(normalized)),
+        emitted + "\n did not contain \"" + expectedLines + "\"",
+        s"${state.circuit.main} contained $expectedLines"
+      )
+    }
+  }
+
+  def containTree(pf: PartialFunction[Any, Boolean]) = new CircuitStatePFMatcher(pf)
+
+  class CircuitStatePFMatcher(pf: PartialFunction[Any, Boolean]) extends Matcher[CircuitState] {
+    override def apply(state: CircuitState): MatchResult = {
+      MatchResult(
+        state.search(pf),
+        state.circuit.serialize + s"\n did not contain $pf",
+        s"${state.circuit.main} contained $pf"
+      )
+    }
+  }
+}
+
+abstract class FirrtlPropSpec extends AnyPropSpec with ScalaCheckPropertyChecks with FirrtlRunners with LazyLogging
+
+abstract class FirrtlFlatSpec extends AnyFlatSpec with FirrtlRunners with FirrtlMatchers with LazyLogging
+
+// Who tests the testers?
+class TestFirrtlFlatSpec extends FirrtlFlatSpec {
+  import FirrtlCheckers._
+
+  val c = parse("""
+                  |circuit Test:
+                  |  module Test :
+                  |    input in : UInt<8>
+                  |    output out : UInt<8>
+                  |    out <= in
+                  |""".stripMargin)
+  val state = CircuitState(c, ChirrtlForm)
+  val compiled = (new LowFirrtlCompiler).compileAndEmit(state, List.empty)
+
+  // While useful, ScalaTest helpers should be used over search
+  behavior.of("Search")
+
+  it should "be supported on Circuit" in {
+    assert(c.search {
+      case Connect(_, Reference("out", _, _, _), Reference("in", _, _, _)) => true
+    })
+  }
+  it should "be supported on CircuitStates" in {
+    assert(state.search {
+      case Connect(_, Reference("out", _, _, _), Reference("in", _, _, _)) => true
+    })
+  }
+  it should "be supported on the results of compilers" in {
+    assert(compiled.search {
+      case Connect(_, WRef("out", _, _, _), WRef("in", _, _, _)) => true
+    })
+  }
+
+  // Use these!!!
+  behavior.of("ScalaTest helpers")
+
+  they should "work for lines of emitted text" in {
+    compiled should containLine(s"input in : UInt<8>")
+    compiled should containLine(s"output out : UInt<8>")
+    compiled should containLine(s"out <= in")
+  }
+
+  they should "work for partial functions matching on subtrees" in {
+    val UInt8 = UIntType(IntWidth(8)) // BigInt unapply is weird
+    compiled should containTree { case Port(_, "in", Input, UInt8) => true }
+    compiled should containTree { case Port(_, "out", Output, UInt8) => true }
+    compiled should containTree { case Connect(_, WRef("out", _, _, _), WRef("in", _, _, _)) => true }
+  }
+}
+
+/** Super class for execution driven Firrtl tests */
+abstract class ExecutionTest(
+  name:        String,
+  dir:         String,
+  vFiles:      Seq[String] = Seq.empty,
+  annotations: AnnotationSeq = Seq.empty)
+    extends FirrtlPropSpec {
+  property(s"$name should execute correctly") {
+    runFirrtlTest(name, dir, vFiles, annotations = annotations)
+  }
+}
+
+/** Super class for compilation driven Firrtl tests */
+abstract class CompilationTest(name: String, dir: String) extends FirrtlPropSpec {
+  property(s"$name should compile correctly") {
+    compileFirrtlTest(name, dir)
+  }
+}
+
+trait Utils {
+
+  /** Run some Scala thunk and return STDOUT and STDERR as strings.
+    * @param thunk some Scala code
+    * @return a tuple containing STDOUT, STDERR, and what the thunk returns
+    */
+  def grabStdOutErr[T](thunk: => T): (String, String, T) = {
+    val stdout, stderr = new ByteArrayOutputStream()
+    val ret = scala.Console.withOut(stdout) { scala.Console.withErr(stderr) { thunk } }
+    (stdout.toString, stderr.toString, ret)
+  }
+
+  /** Encodes a System.exit exit code
+    * @param status the exit code
+    */
+  private case class ExitException(status: Int) extends SecurityException(s"Found a sys.exit with code $status")
+
+  /** A security manager that converts calls to System.exit into [[ExitException]]s by explicitly disabling the ability of
+    * a thread to actually exit. For more information, see:
+    *   - https://docs.oracle.com/javase/tutorial/essential/environment/security.html
+    */
+  private class ExceptOnExit extends SecurityManager {
+    override def checkPermission(perm: Permission): Unit = {}
+    override def checkPermission(perm: Permission, context: Object): Unit = {}
+    override def checkExit(status: Int): Unit = {
+      super.checkExit(status)
+      throw ExitException(status)
+    }
+  }
+
+  /** Encodes a file that some code tries to write to
+    * @param the file name
+    */
+  private case class WriteException(file: String) extends SecurityException(s"Tried to write to file $file")
+
+  /** A security manager that converts writes to any file into [[WriteException]]s.
+    */
+  private class ExceptOnWrite extends SecurityManager {
+    override def checkPermission(perm: Permission): Unit = {}
+    override def checkPermission(perm: Permission, context: Object): Unit = {}
+    override def checkWrite(file: String): Unit = {
+      super.checkWrite(file)
+      throw WriteException(file)
+    }
+  }
+
+  /** Run some Scala code (a thunk) in an environment where all System.exit are caught and returned. This avoids a
+    * situation where a test results in something actually exiting and killing the entire test. This is necessary if you
+    * want to test a command line program, e.g., the `main` method of [[firrtl.options.Stage Stage]].
+    *
+    * NOTE: THIS WILL NOT WORK IN SITUATIONS WHERE THE THUNK IS CATCHING ALL [[Exception]]s OR [[Throwable]]s, E.G.,
+    * SCOPT. IF THIS IS HAPPENING THIS WILL NOT WORK. REPEAT THIS WILL NOT WORK.
+    * @param thunk some Scala code
+    * @return either the output of the thunk (`Right[T]`) or an exit code (`Left[Int]`)
+    */
+  def catchStatus[T](thunk: => T): Either[Int, T] = {
+    try {
+      System.setSecurityManager(new ExceptOnExit())
+      Right(thunk)
+    } catch {
+      case ExitException(a) => Left(a)
+    } finally {
+      System.setSecurityManager(null)
+    }
+  }
+
+  /** Run some Scala code (a thunk) in an environment where file writes are caught and the file that a program tries to
+    * write to is returned. This is useful if you want to test that some thunk either tries to write to a specific file
+    * or doesn't try to write at all.
+    */
+  def catchWrites[T](thunk: => T): Either[String, T] = {
+    try {
+      System.setSecurityManager(new ExceptOnWrite())
+      Right(thunk)
+    } catch {
+      case WriteException(a) => Left(a)
+    } finally {
+      System.setSecurityManager(null)
+    }
+  }
+}
+
+/** Super class for equivalence driven Firrtl tests */
+abstract class EquivalenceTest(transforms: Seq[Transform], name: String, dir: String) extends FirrtlFlatSpec {
+  val fileName = s"$dir/$name.fir"
+  val in = getClass.getResourceAsStream(fileName)
+  if (in == null) {
+    throw new FileNotFoundException(s"Resource '$fileName'")
+  }
+  val source = scala.io.Source.fromInputStream(in)
+  val input =
+    try source.mkString
+    finally source.close()
+
+  s"$name with ${transforms.map(_.name).mkString(", ")}" should
+    s"be equivalent to $name without ${transforms.map(_.name).mkString(", ")}" in {
+    firrtlEquivalenceTest(input, transforms)
+  }
+}

--- a/sim/midas/src/test/scala/firrtl/testutils/LeanTransformSpec.scala
+++ b/sim/midas/src/test/scala/firrtl/testutils/LeanTransformSpec.scala
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.testutils
+
+import firrtl.{ir, AnnotationSeq, CircuitState, EmitCircuitAnnotation}
+import firrtl.options.Dependency
+import firrtl.passes.RemoveEmpty
+import firrtl.stage.TransformManager.TransformDependency
+import logger.LazyLogging
+import org.scalatest.flatspec.AnyFlatSpec
+
+class VerilogTransformSpec extends LeanTransformSpec(Seq(Dependency[firrtl.VerilogEmitter]))
+class LowFirrtlTransformSpec extends LeanTransformSpec(Seq(Dependency[firrtl.LowFirrtlEmitter]))
+
+/** The new cool kid on the block, creates a custom compiler for your transform. */
+class LeanTransformSpec(protected val transforms: Seq[TransformDependency])
+    extends AnyFlatSpec
+    with FirrtlMatchers
+    with LazyLogging {
+  private val compiler = new firrtl.stage.transforms.Compiler(transforms)
+  private val emitterAnnos = LeanTransformSpec.deriveEmitCircuitAnnotations(transforms)
+
+  protected def compile(src: String): CircuitState = compile(src, Seq())
+  protected def compile(src: String, annos: AnnotationSeq): CircuitState = compile(firrtl.Parser.parse(src), annos)
+  protected def compile(c:   ir.Circuit): CircuitState = compile(c, Seq())
+  protected def compile(c:   ir.Circuit, annos: AnnotationSeq): CircuitState =
+    compiler.transform(CircuitState(c, emitterAnnos ++ annos))
+  protected def execute(input: String, check: String): CircuitState = execute(input, check, Seq())
+  protected def execute(input: String, check: String, inAnnos: AnnotationSeq): CircuitState = {
+    val finalState = compiler.transform(CircuitState(parse(input), inAnnos))
+    val actual = RemoveEmpty.run(parse(finalState.getEmittedCircuit.value)).serialize
+    val expected = parse(check).serialize
+    logger.debug(actual)
+    logger.debug(expected)
+    actual should be(expected)
+    finalState
+  }
+}
+
+private object LeanTransformSpec {
+  private def deriveEmitCircuitAnnotations(transforms: Iterable[TransformDependency]): AnnotationSeq = {
+    val emitters = transforms.map(_.getObject()).collect { case e: firrtl.Emitter => e }
+    emitters.map(e => EmitCircuitAnnotation(e.getClass)).toSeq
+  }
+}
+
+/** Use this if you just need to create a standard compiler and want to save some typing. */
+trait MakeCompiler {
+  protected def makeVerilogCompiler(transforms: Seq[TransformDependency] = Seq()) =
+    new firrtl.stage.transforms.Compiler(Seq(Dependency[firrtl.VerilogEmitter]) ++ transforms)
+  protected def makeMinimumVerilogCompiler(transforms: Seq[TransformDependency] = Seq()) =
+    new firrtl.stage.transforms.Compiler(Seq(Dependency[firrtl.MinimumVerilogEmitter]) ++ transforms)
+  protected def makeLowFirrtlCompiler(transforms: Seq[TransformDependency] = Seq()) =
+    new firrtl.stage.transforms.Compiler(Seq(Dependency[firrtl.LowFirrtlEmitter]) ++ transforms)
+}

--- a/sim/midas/src/test/scala/firrtl/testutils/PassTests.scala
+++ b/sim/midas/src/test/scala/firrtl/testutils/PassTests.scala
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.testutils
+
+import org.scalatest.flatspec.AnyFlatSpec
+import firrtl.ir.Circuit
+import firrtl.options.{Dependency, IdentityLike}
+import firrtl.passes.{PassExceptions, RemoveEmpty}
+import firrtl.stage.Forms
+import firrtl._
+import firrtl.annotations._
+import logger._
+import org.scalatest.flatspec.AnyFlatSpec
+
+// An example methodology for testing Firrtl Passes
+// Spec class should extend this class
+abstract class SimpleTransformSpec extends AnyFlatSpec with FirrtlMatchers with Compiler with LazyLogging {
+  // Utility function
+  def squash(c: Circuit): Circuit = RemoveEmpty.run(c)
+
+  // Executes the test. Call in tests.
+  // annotations cannot have default value because scalatest trait Suite has a default value
+  def execute(input: String, check: String, annotations: Seq[Annotation]): CircuitState = {
+    val finalState = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annotations))
+    val actual = RemoveEmpty.run(parse(finalState.getEmittedCircuit.value)).serialize
+    val expected = parse(check).serialize
+    logger.debug(actual)
+    logger.debug(expected)
+    (actual) should be(expected)
+    finalState
+  }
+
+  def executeWithAnnos(
+    input:            String,
+    check:            String,
+    annotations:      Seq[Annotation],
+    checkAnnotations: Seq[Annotation]
+  ): CircuitState = {
+    val finalState = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annotations))
+    val actual = RemoveEmpty.run(parse(finalState.getEmittedCircuit.value)).serialize
+    val expected = parse(check).serialize
+    logger.debug(actual)
+    logger.debug(expected)
+    (actual) should be(expected)
+
+    annotations.foreach { anno =>
+      logger.debug(anno.serialize)
+    }
+
+    finalState.annotations.toSeq.foreach { anno =>
+      logger.debug(anno.serialize)
+    }
+    checkAnnotations.foreach { check =>
+      (finalState.annotations.toSeq) should contain(check)
+    }
+    finalState
+  }
+  // Executes the test, should throw an error
+  // No default to be consistent with execute
+  def failingexecute(input: String, annotations: Seq[Annotation]): Exception = {
+    intercept[PassExceptions] {
+      compile(CircuitState(parse(input), ChirrtlForm, annotations), Seq.empty)
+    }
+  }
+}
+
+@deprecated(
+  "Use a TransformManager including 'ReRunResolveAndCheck' as a target. This will be removed in 1.4.",
+  "FIRRTL 1.3"
+)
+class CustomResolveAndCheck(form: CircuitForm) extends SeqTransform {
+  def inputForm = form
+  def outputForm = form
+  def transforms: Seq[Transform] = Seq[Transform](new ResolveAndCheck)
+}
+
+/** Transform that re-runs resolve and check transforms as late as possible, but before any emitters. */
+object ReRunResolveAndCheck extends Transform with DependencyAPIMigration with IdentityLike[CircuitState] {
+
+  override val optionalPrerequisites = Forms.LowFormOptimized
+  override val optionalPrerequisiteOf = Forms.ChirrtlEmitters
+
+  override def invalidates(a: Transform) = {
+    val resolveAndCheck = Forms.Resolved.toSet -- Forms.WorkingIR
+    resolveAndCheck.contains(Dependency.fromTransform(a))
+  }
+
+  override def execute(a: CircuitState) = transform(a)
+
+}
+
+trait LowTransformSpec extends SimpleTransformSpec {
+  def emitter = new LowFirrtlEmitter
+  def transform: Transform
+  def transforms: Seq[Transform] = transform +: ReRunResolveAndCheck +: Forms.LowForm.map(_.getObject)
+}
+
+trait MiddleTransformSpec extends SimpleTransformSpec {
+  def emitter = new MiddleFirrtlEmitter
+  def transform: Transform
+  def transforms: Seq[Transform] = transform +: ReRunResolveAndCheck +: Forms.MidForm.map(_.getObject)
+}
+
+trait HighTransformSpec extends SimpleTransformSpec {
+  def emitter = new HighFirrtlEmitter
+  def transform: Transform
+  def transforms = transform +: ReRunResolveAndCheck +: Forms.HighForm.map(_.getObject)
+}

--- a/sim/project/plugins.sbt
+++ b/sim/project/plugins.sbt
@@ -24,6 +24,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.21")
 
-addSbtPlugin("com.eed3si9n" % "sbt-sriracha" % "0.1.0")
-
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.5" )


### PR DESCRIPTION
Building Chisel + FIRRTL + friends from source is becoming untenable due to enhanced compiler plugin support amoungst other things.  Since these tools are much more stable than they used to be the need to build specific versions from source is no longer as strong. Devs can still rely on publish-local should they wish to deliver a custom version of firrtl or chisel. 

Since firrtl.testutils is not published, i've elected to copy the sources into FireSim instead of building a jar from source. 

#### Related PRs / Issues

This is the FIreSim-side PR for ucb-bar/chipyard#1054

#### UI / API Impact

Should not affect users, will make development slightly more difficult when the dev wants to hack on FIRRTL / Chisel sources.

#### Verilog / AGFI Compatibility

Will regenerate AGFIs.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
