### PR TITLE
WithAutoILA by default

### DIFF
--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
@@ -21,7 +21,7 @@ appropriately sized ILA instance.
 Enabling AutoILA
 ----------------
 
-To enable AutoILA, mixins `WithILATopWiringTransform` and `WithAutoILA` must be appended to the `PLATFORM_CONFIG`. These are appended by default to the `BaseF1Config`.
+To enable AutoILA, mixin `WithAutoILA` must be appended to the `PLATFORM_CONFIG`. This is appended by default to the `BaseF1Config`.
 
 Annotating Signals
 ------------------------

--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
@@ -18,6 +18,11 @@ signals directly in the Chisel source. These will be consumed by a downstream
 FIRRTL pass which wires out the annotated signals, and binds them to an
 appropriately sized ILA instance.
 
+Enabling AutoILA
+----------------
+
+To enable AutoILA, mixins `WithILATopWiringTransform` and `WithAutoILA` must be appended to the `PLATFORM_CONFIG`. These are appended by default to the `BaseF1Config`.
+
 Annotating Signals
 ------------------------
 

--- a/sim/firesim-lib/src/main/scala/configs/CompilerConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/CompilerConfigs.scala
@@ -86,5 +86,6 @@ class BaseF1Config extends Config(
   new WithAsyncResetReplacement ++
   new WithEC2F1Artefacts ++
   new WithILATopWiringTransform ++
+  new WithAutoILA ++
   new midas.F1Config
 )


### PR DESCRIPTION
Appending WithAutoILA mixin to BaseF1Config. Config already has WithILATopWiringTransform by default, so it is doing the FIRRTL pass and listing it in annos.json. But unless unless the WithAutoILA mixin sets the EnableAutoILA parameter to true (false by default), the pass does not output anything to the ports/wires/inst Verilog files. Also adding a note about this in the docs.

<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

No change to API.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

No change to generated Verilog.

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
