### PR TITLE
Reduce Gemmini build's frequency

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -59,7 +59,7 @@ deploytriplet=None
 [firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
-PLATFORM_CONFIG=WithAutoILA_F110MHz_BaseF1Config
+PLATFORM_CONFIG=WithAutoILA_F30MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 


### PR DESCRIPTION
<!-- Provide a brief description of the PR, if the title is insufficient -->

Gemmini's default FPGA build frequency is too high, sometimes causing timing errors when large configs are used.

This PR reduces it to 30MHz, which is what we typically use when running Gemmini on FireSim.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

No change to UI/API

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

No changes

### Contributor Checklist
- [X] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
