### PR TITLE
Remove hardcoded aws fpga version

### DIFF
--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -385,14 +385,14 @@ class InstanceDeployManager:
         """ Installs the aws-sdk. This gets us access to tools to flash the fpga. """
 
         with cd("../"):
-            # use local version of awsfpga on runfarm nodes
-            awsfpga_upstream_version = local('git -C platforms/f1/aws-fpga describe --tags --always --dirty', capture=True)
-            if "-dirty" in awsfpga_upstream_version:
+            # use local version of aws_fpga on runfarm nodes
+            aws_fpga_upstream_version = local('git -C platforms/f1/aws-fpga describe --tags --always --dirty', capture=True)
+            if "-dirty" in aws_fpga_upstream_version:
                 rootLogger.critical("Unable to use local changes to aws-fpga. Continuing without them.")
-        self.instance_logger("""Installing AWS FPGA SDK on remote nodes. Upstream hash: {}""".format(awsfpga_upstream_version))
+        self.instance_logger("""Installing AWS FPGA SDK on remote nodes. Upstream hash: {}""".format(aws_fpga_upstream_version))
         with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
             run('git clone https://github.com/aws/aws-fpga')
-            run('cd aws-fpga && git checkout ' + awsfpga_upstream_version)
+            run('cd aws-fpga && git checkout ' + aws_fpga_upstream_version)
         with cd('/home/centos/aws-fpga'), StreamLogger('stdout'), StreamLogger('stderr'):
             run('source sdk_setup.sh')
 

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -384,14 +384,15 @@ class InstanceDeployManager:
     def get_and_install_aws_fpga_sdk(self):
         """ Installs the aws-sdk. This gets us access to tools to flash the fpga. """
 
-        # TODO: we checkout a specific version of aws-fpga here, in case upstream
-        # master is bumped. But now we have to remember to change AWS_FPGA_FIRESIM_UPSTREAM_VERSION
-        # when we bump our stuff. Need a better way to do this.
-        AWS_FPGA_FIRESIM_UPSTREAM_VERSION = "6c707ab4a26c2766b916dad9d40727266fa0e4ef"
-        self.instance_logger("""Installing AWS FPGA SDK on remote nodes. Upstream hash: {}""".format(AWS_FPGA_FIRESIM_UPSTREAM_VERSION))
+        with cd("../"):
+            # use local version of awsfpga on runfarm nodes
+            awsfpga_upstream_version = local('git -C platforms/f1/aws-fpga describe --tags --always --dirty', capture=True)
+            if "-dirty" in awsfpga_upstream_version:
+                rootLogger.critical("Unable to use local changes to aws-fpga. Continuing without them.")
+        self.instance_logger("""Installing AWS FPGA SDK on remote nodes. Upstream hash: {}""".format(awsfpga_upstream_version))
         with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):
             run('git clone https://github.com/aws/aws-fpga')
-            run('cd aws-fpga && git checkout ' + AWS_FPGA_FIRESIM_UPSTREAM_VERSION)
+            run('cd aws-fpga && git checkout ' + awsfpga_upstream_version)
         with cd('/home/centos/aws-fpga'), StreamLogger('stdout'), StreamLogger('stderr'):
             run('source sdk_setup.sh')
 
@@ -547,7 +548,7 @@ class InstanceDeployManager:
         self.instance_logger("Starting Vivado virtual JTAG.")
         with StreamLogger('stdout'), StreamLogger('stderr'):
             run("""screen -S virtual_jtag -d -m bash -c "script -f -c 'sudo fpga-start-virtual-jtag -P 10201 -S 0'"; sleep 1""")
-  
+
     def kill_ila_server(self):
         """ Kill the vivado hw_server and virtual jtag """
         with warn_only(), StreamLogger('stdout'), StreamLogger('stderr'):


### PR DESCRIPTION
Gets the AWS FPGA hash from the current version of `aws-fpga`

#### Related PRs / Issues

Fixes https://github.com/firesim/firesim/issues/762

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
