### PR TITLE
Fix Driver Return Code

### DIFF
--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -568,7 +568,7 @@ void firesim_top_t::run() {
     fprintf(stderr, "Commencing simulation.\n");
     record_start_times();
 
-    while (!simulation_complete() && !has_timed_out()) {
+    while (!simulation_complete() && !finished_scheduled_tasks()) {
         run_scheduled_tasks();
         take_steps(get_largest_stepsize(), false);
         while(!done() && !simulation_complete()){
@@ -582,10 +582,15 @@ void firesim_top_t::run() {
 
 int firesim_top_t::teardown() {
     int exitcode = exit_code();
-    if (exitcode) {
+
+    // If the simulator is idle and we've gotten here without any bridge
+    // indicating doneness, we've advanced to the +max_cycles limit in the fastest target clock domain.
+    bool max_cycles_timeout = !simulation_complete() && done() && finished_scheduled_tasks();
+
+    if (exitcode != 0) {
         fprintf(stderr, "*** FAILED *** (code = %d) after %" PRIu64 " cycles\n", exitcode, get_end_tcycle());
-    } else if (!simulation_complete() && has_timed_out()) {
-        fprintf(stderr, "*** FAILED *** (timeout) after %" PRIu64 " cycles\n", get_end_tcycle());
+    } else if (max_cycles_timeout) {
+        fprintf(stderr, "*** FAILED *** +max_cycles specified timeout after %" PRIu64 " cycles\n", get_end_tcycle());
     } else {
         fprintf(stderr, "*** PASSED *** after %" PRIu64 " cycles\n", get_end_tcycle());
     }
@@ -601,5 +606,5 @@ int firesim_top_t::teardown() {
     }
 
     this->host_finish();
-    return (exitcode || has_timed_out()) ? EXIT_SUCCESS : EXIT_FAILURE;
+    return ((exitcode != 0) || max_cycles_timeout) ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
This logical error wasn't caught because the RC-generated makefiles check the output for a specific string, and i guess we just drop the return code when we deploy. 

#### Related PRs / Issues

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

None.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
