### PR TITLE
Fix #909 cd'ing issue

### DIFF
--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -384,7 +384,9 @@ class InstanceDeployManager:
     def get_and_install_aws_fpga_sdk(self):
         """ Installs the aws-sdk. This gets us access to tools to flash the fpga. """
 
-        with cd("../"):
+        with prefix('cd ../'), \
+             StreamLogger('stdout'), \
+             StreamLogger('stderr'):
             # use local version of aws_fpga on runfarm nodes
             aws_fpga_upstream_version = local('git -C platforms/f1/aws-fpga describe --tags --always --dirty', capture=True)
             if "-dirty" in aws_fpga_upstream_version:


### PR DESCRIPTION
Properly determine the AWS FPGA hash when setting up run farm instances by `cd`ing within a `prefix` call.

#### Related PRs / Issues

Fixes #909

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
