### PR TITLE
Fix Scaladoc GH-A Build

### DIFF
--- a/.github/actions/machinelaunchscript/action.yml
+++ b/.github/actions/machinelaunchscript/action.yml
@@ -4,5 +4,7 @@ description: "Run FireSim's machine-launch-script.sh"
 runs:
   using: "composite"
   steps:
-    - run: cd scripts/ && /usr/bin/bash machine-launch-script.sh
+    - run: |
+        sudo yum -y remove git git224 git224-core ius-release.noarch # remove any older git versions and collateral first
+        cd scripts/ && /usr/bin/bash machine-launch-script.sh
       shell: bash

--- a/.github/actions/push-scaladoc-to-ghpages/action.yml
+++ b/.github/actions/push-scaladoc-to-ghpages/action.yml
@@ -4,26 +4,24 @@ description: "Pushes scaladoc to ghphage branch"
 runs:
   using: "composite"
   steps:
-    - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
+    - name: Install SSH key for Github.com
+      uses: webfactory/ssh-agent@v0.5.4
       with:
-        key: ${{ secrets.SERVER_KEY }}
-        known_hosts: ${{ secrets.SERVER_NAME }}
+        ssh-private-key: ${{ env.FIRESIM-REPO-DEP-KEY }}
 
     - run: |
-        git config --global user.email "biancolin@berkeley.edu"
+        git config --global user.email "abe.gonzalez@berkeley.edu"
         git config --global user.name "github-actions"
       shell: bash
 
     - run: |
-        if [[ "${{ GITHUB_REF_TYPE }}" != 'tag' ]]; then
+        if [[ "${{ github.ref_type }}" != 'tag' ]]; then
           source env.sh
-          export SBT_GHPAGES_COMMIT_MESSAGE="[ci skip] Update scaladoc for ${{ GITHUB_REF_NAME }} release"
-          make -C sim TARGET_PROJECT=midasexamples sbt SBT_COMMAND='set apiDirectory := \"${{ GITHUB_REF_NAME }}\"; ghpagesPushSite'
+          export SBT_GHPAGES_COMMIT_MESSAGE="[ci skip] Update scaladoc for ${{ github.ref_type }} release"
+          make -C sim TARGET_PROJECT=midasexamples sbt SBT_COMMAND='set apiDirectory := \"${{ github.ref_type }}\"; ghpagesPushSite'
         else
           source env.sh
-          export SBT_GHPAGES_COMMIT_MESSAGE="[ci skip] Update scaladoc for dev:${{ GITHUB_SHA }}"
+          export SBT_GHPAGES_COMMIT_MESSAGE="[ci skip] Update scaladoc for dev:${{ github.sha }}"
           make -C sim TARGET_PROJECT=midasexamples sbt SBT_COMMAND="ghpagesPushSite"
         fi
       shell: bash
-

--- a/.github/scripts/Dockerfile
+++ b/.github/scripts/Dockerfile
@@ -12,7 +12,8 @@ RUN pip2 install --upgrade pip==18.0
 # non-intuitive results
 # (the chipyard submodule is initialized to an apparently random commit)
 # If we want to get rid of this we could reclone the repo under the updated git
-RUN yum -y install git
+RUN yum -y install https://repo.ius.io/ius-release-el7.rpm
+RUN yum -y install git224
 
 RUN adduser centos
 RUN usermod -aG wheel centos

--- a/.github/workflows/firesim-publish-scala-doc.yml
+++ b/.github/workflows/firesim-publish-scala-doc.yml
@@ -13,6 +13,7 @@ env:
   AWS-SECRET-ACCESS-KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS-DEFAULT-REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   FIRESIM_PEM: ${{ secrets.FIRESIM_PEM }}
+  FIRESIM-REPO-DEP-KEY: ${{ secrets.FIRESIM_REPO_DEP_KEY }}
   LANG: "en_US.UTF-8" # required by SBT when it sees boost directories
   LANGUAGE: "en_US:en"
   LC_ALL: "en_US.UTF-8"
@@ -22,7 +23,7 @@ jobs:
     name: publish-scala-doc
     runs-on: ubuntu-18.04
     container:
-      image: firesim/firesim-ci:v1.1
+      image: firesim/firesim-ci:v1.3
       options: --entrypoint /bin/bash
       env:
         JVM_MEMORY: 3500M # Default JVM maximum heap limit

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -183,7 +183,7 @@ jobs:
     name: documentation-check
     runs-on: ubuntu-18.04
     container:
-      image: firesim/firesim-ci:v1.1
+      image: firesim/firesim-ci:v1.3
       options: --entrypoint /bin/bash
       env:
         JVM_MEMORY: 3500M # Default JVM maximum heap limit

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -8,15 +8,17 @@ sudo chgrp centos /home/centos/machine-launchstatus
 sudo chown centos /home/centos/machine-launchstatus
 
 {
+# remove any older git versions and collateral first
+sudo yum -y remove git git224 git224-core ius-release.noarch
 sudo yum install -y ca-certificates
 sudo yum install -y mosh
 sudo yum groupinstall -y "Development tools"
-sudo yum install -y gmp-devel mpfr-devel libmpc-devel zlib-devel vim git java java-devel
+sudo yum install -y gmp-devel mpfr-devel libmpc-devel zlib-devel vim java java-devel
 curl https://www.scala-sbt.org/sbt-rpm.repo | sudo tee /etc/yum.repos.d/scala-sbt-rpm.repo
 sudo yum install -y sbt texinfo gengetopt libffi-devel
 sudo yum install -y expat-devel libusb1-devel ncurses-devel cmake "perl(ExtUtils::MakeMaker)"
 # deps for poky
-sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath git wget
+sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath wget
 # deps for qemu
 sudo yum install -y gtk3-devel
 # deps for firesim-software (note that rsync is installed but too old)
@@ -28,9 +30,8 @@ sudo yum install -y devtoolset-8-make
 # install DTC
 sudo yum -y install dtc
 
-# get a proper version of git
+# get a proper version of git (remove git that was reinstalled)
 sudo yum -y remove git
-sudo yum -y install epel-release
 sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
 sudo yum -y install git224
 

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -8,17 +8,15 @@ sudo chgrp centos /home/centos/machine-launchstatus
 sudo chown centos /home/centos/machine-launchstatus
 
 {
-# remove any older git versions and collateral first
-sudo yum -y remove git git224 git224-core ius-release.noarch
 sudo yum install -y ca-certificates
 sudo yum install -y mosh
 sudo yum groupinstall -y "Development tools"
-sudo yum install -y gmp-devel mpfr-devel libmpc-devel zlib-devel vim java java-devel
+sudo yum install -y gmp-devel mpfr-devel libmpc-devel zlib-devel vim git java java-devel
 curl https://www.scala-sbt.org/sbt-rpm.repo | sudo tee /etc/yum.repos.d/scala-sbt-rpm.repo
 sudo yum install -y sbt texinfo gengetopt libffi-devel
 sudo yum install -y expat-devel libusb1-devel ncurses-devel cmake "perl(ExtUtils::MakeMaker)"
 # deps for poky
-sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath wget
+sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath git wget
 # deps for qemu
 sudo yum install -y gtk3-devel
 # deps for firesim-software (note that rsync is installed but too old)
@@ -30,8 +28,9 @@ sudo yum install -y devtoolset-8-make
 # install DTC
 sudo yum -y install dtc
 
-# get a proper version of git (remove git that was reinstalled)
+# get a proper version of git
 sudo yum -y remove git
+sudo yum -y install epel-release
 sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
 sudo yum -y install git224
 


### PR DESCRIPTION
Right now the CI is failing to publish the SBT docs. This PR does the following:

- This bumps the `git` version in the Docker container to 2.24 (new container is `v1.3`)
- Modifies the `machine-launch-script.sh` to work in the Docker container and on a fresh AWS instance
- Updates the "scaladoc push GH-A" to properly work (new deploy key, ssh key registration, proper variables)

#### Related PRs / Issues

Error: https://github.com/firesim/firesim/runs/4891407141?check_suite_focus=true

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
