### PR TITLE
Remove WithAutoILA from default recipes

### DIFF
--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -14,7 +14,7 @@
 [firesim-rocket-quadcore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.QuadRocketConfig
-PLATFORM_CONFIG=WithAutoILA_F90MHz_BaseF1Config
+PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -23,7 +23,7 @@ deploytriplet=None
 [firesim-rocket-quadcore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.QuadRocketConfig
-PLATFORM_CONFIG=WithAutoILA_F140MHz_BaseF1Config
+PLATFORM_CONFIG=F140MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -32,7 +32,7 @@ deploytriplet=None
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=WithAutoILA_F65MHz_BaseF1Config
+PLATFORM_CONFIG=F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -41,7 +41,7 @@ deploytriplet=None
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=WithAutoILA_F75MHz_BaseF1Config
+PLATFORM_CONFIG=F75MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -50,7 +50,7 @@ deploytriplet=None
 [firesim-cva6-singlecore-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
-PLATFORM_CONFIG=WithAutoILA_F90MHz_BaseF1Config
+PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -59,7 +59,7 @@ deploytriplet=None
 [firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
-PLATFORM_CONFIG=WithAutoILA_F30MHz_BaseF1Config
+PLATFORM_CONFIG=F30MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -68,7 +68,7 @@ deploytriplet=None
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
 DESIGN=FireSim
 TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomConfig
-PLATFORM_CONFIG=WithAutoILA_MCRams_F90MHz_BaseF1Config
+PLATFORM_CONFIG=MCRams_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
@@ -77,7 +77,7 @@ deploytriplet=None
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
 DESIGN=FireSim
 TARGET_CONFIG=WithNIC_SupernodeFireSimRocketConfig
-PLATFORM_CONFIG=WithAutoILA_F85MHz_BaseF1Config
+PLATFORM_CONFIG=F85MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 

--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hardware-Using-ILA.rst
@@ -13,7 +13,7 @@ and provided and interface for setting trigger and viewing samples waveforms
 from the FPGA. For more information about ILAs, please refer to the Xilinx
 guide on the topic.
 
-MIDAS, in its ``targetutils`` package, provides annotations for labeling
+The ``midas.targetutils`` package provides annotations for labeling
 signals directly in the Chisel source. These will be consumed by a downstream
 FIRRTL pass which wires out the annotated signals, and binds them to an
 appropriately sized ILA instance.
@@ -21,7 +21,8 @@ appropriately sized ILA instance.
 Enabling AutoILA
 ----------------
 
-To enable AutoILA, mixin `WithAutoILA` must be appended to the `PLATFORM_CONFIG`. This is appended by default to the `BaseF1Config`.
+To enable AutoILA, mixin `WithAutoILA` must be prepended to the
+`PLATFORM_CONFIG`. Prior to version 1.13, this was done by default.
 
 Annotating Signals
 ------------------------
@@ -40,7 +41,7 @@ vararg of chisel3.Data. Invoke it as follows:
        FpgaDebug(out1, in1)
     }
 
-You can annotate signals throughout FireSim, including in MIDAS and
+You can annotate signals throughout FireSim, including in Golden Gate
 Rocket-Chip Chisel sources, with the only exception being the Chisel3 sources
 themselves (eg. in Chisel3.util.Queue).
 

--- a/sim/firesim-lib/src/main/scala/configs/CompilerConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/CompilerConfigs.scala
@@ -86,6 +86,5 @@ class BaseF1Config extends Config(
   new WithAsyncResetReplacement ++
   new WithEC2F1Artefacts ++
   new WithILATopWiringTransform ++
-  new WithAutoILA ++
   new midas.F1Config
 )


### PR DESCRIPTION
Users should explicitly mix this in like other debug features. This makes it easier to check in default FPGADebugAnnotations and makes AutoILA consistent with other debug features.

<!-- Provide a brief description of the PR, if the title is insufficient -->

#### Related PRs / Issues

Resolves #695.

#### UI / API Impact

Users must mix in "WithAutoILA_" to their platform configs.

#### Verilog / AGFI Compatibility

None in practice, since we don't tend to include FPGADebugAnnotations by default.

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
