### PR TITLE
Workaround `rsync_project` `exclude` flag issue

### DIFF
--- a/deploy/buildtools/buildafi.py
+++ b/deploy/buildtools/buildafi.py
@@ -104,15 +104,13 @@ def aws_build(global_build_config, bypass=False):
         rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga",
                       remote_dir='/home/centos/firesim-build/platforms/f1/',
                       ssh_opts="-o StrictHostKeyChecking=no",
-                      exclude="hdk/cl/developer_designs/cl_*",
-                      extra_opts="-l", capture=True)
+                      extra_opts="-l --exclude \"hdk/cl/developer_designs/cl_*\"", capture=True)
         rootLogger.debug(rsync_cap)
         rootLogger.debug(rsync_cap.stderr)
         rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga/{}/*".format(fpgabuilddir),
                       remote_dir='/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir,
-                      exclude='build/checkpoints',
                       ssh_opts="-o StrictHostKeyChecking=no",
-                      extra_opts="-l", capture=True)
+                      extra_opts="-l --exclude \"build/checkpoints\"", capture=True)
         rootLogger.debug(rsync_cap)
         rootLogger.debug(rsync_cap.stderr)
 

--- a/deploy/buildtools/buildafi.py
+++ b/deploy/buildtools/buildafi.py
@@ -104,13 +104,15 @@ def aws_build(global_build_config, bypass=False):
         rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga",
                       remote_dir='/home/centos/firesim-build/platforms/f1/',
                       ssh_opts="-o StrictHostKeyChecking=no",
-                      extra_opts="-l --exclude \"hdk/cl/developer_designs/cl_*\"", capture=True)
+                      exclude=["hdk/cl/developer_designs/cl_*"],
+                      extra_opts="-l", capture=True)
         rootLogger.debug(rsync_cap)
         rootLogger.debug(rsync_cap.stderr)
         rsync_cap = rsync_project(local_dir=ddir + "/../platforms/f1/aws-fpga/{}/*".format(fpgabuilddir),
                       remote_dir='/home/centos/firesim-build/platforms/f1/aws-fpga/' + remotefpgabuilddir,
+                      exclude=['build/checkpoints'],
                       ssh_opts="-o StrictHostKeyChecking=no",
-                      extra_opts="-l --exclude \"build/checkpoints\"", capture=True)
+                      extra_opts="-l", capture=True)
         rootLogger.debug(rsync_cap)
         rootLogger.debug(rsync_cap.stderr)
 


### PR DESCRIPTION
Bypass the `exclude` `rsync_project` flag in favor of using the extra options. This fixes a `fab-classic` issue with `rsync_project`. This fixes `buildafi`

#### Related PRs / Issues

Fixes #920 

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
