### PR TITLE
[ci] Disable status caching for manager-hosted jobs

### DIFF
--- a/.github/actions/job-start/action.yml
+++ b/.github/actions/job-start/action.yml
@@ -1,3 +1,8 @@
+# With the job-end action, this provides the machinery to skip running jobs
+# that have previously passed. This is not supported on EC2-manager hosted
+# jobs, where all jobs must be re-run on restarting the workflow (since the
+# previous manager is lost.)
+
 name: job-start
 description: "Setup a job status"
 outputs:

--- a/.github/actions/job-start/action.yml
+++ b/.github/actions/job-start/action.yml
@@ -1,7 +1,7 @@
 # With the job-end action, this provides the machinery to skip running jobs
 # that have previously passed. This is not supported on EC2-manager hosted
-# jobs, where all jobs must be re-run on restarting the workflow (since the
-# previous manager is lost.)
+# jobs, where all related jobs must be re-run when restarting the workflow (since the
+# previous spot-instance manager is terminated on a failure)
 
 name: job-start
 description: "Setup a job status"

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -34,18 +34,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Install Python CI requirements
         uses: ./.github/actions/repo-setup-aws
-        if: steps.job-start.outputs.run_result != 'success'
       - name: Launch AWS instance used for the FireSim manager (instance info found here)
         run: ./.github/scripts/launch-manager-instance.py
-        if: steps.job-start.outputs.run_result != 'success'
       - name: Setup N Github Actions Runners on AWS instance
         run: ./.github/scripts/setup-manager-self-hosted.py
-        if: steps.job-start.outputs.run_result != 'success'
-      - uses: ./.github/actions/job-end
 
   setup-manager:
     name: setup-manager
@@ -53,17 +47,12 @@ jobs:
     runs-on: ${{ github.run_id }}
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Setup FireSim repo (.pem, build-setup.sh, AWS credentials, submodules) and CI daemons
         uses: ./.github/actions/initialize-manager
-        if: steps.job-start.outputs.run_result != 'success'
         with:
           max-runtime-hours: 10
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
-        if: steps.job-start.outputs.run_result != 'success'
-      - uses: ./.github/actions/job-end
 
   build-default-workloads:
     name: build-default-workloads
@@ -73,12 +62,8 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Build default workloads (FireMarshal and paper workloads)
         run: .github/scripts/build-default-workloads.py
-        if: steps.job-start.outputs.run_result != 'success'
-      - uses: ./.github/actions/job-end
 
   run-manager-pytests:
     name: run-manager-pytests
@@ -88,12 +73,8 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Run pytests
         run: .github/scripts/run-manager-pytests.py
-        if: steps.job-start.outputs.run_result != 'success'
-      - uses: ./.github/actions/job-end
 
   run-test-groupA:
     name: run-test-groupA
@@ -103,14 +84,10 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Run CIGroupA Scala tests
         uses: ./.github/actions/run-scala-test
-        if: steps.job-start.outputs.run_result != 'success'
         with:
           test-name: "CIGroupA"
-      - uses: ./.github/actions/job-end
 
   run-test-groupB:
     name: run-test-groupB
@@ -120,14 +97,10 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Run CIGroupB Scala tests
         uses: ./.github/actions/run-scala-test
-        if: steps.job-start.outputs.run_result != 'success'
         with:
           test-name: "CIGroupB"
-      - uses: ./.github/actions/job-end
 
   run-chipyard-tests:
     name: run-chipyard-tests
@@ -137,16 +110,12 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Run other (CITests) Scala tests
         uses: ./.github/actions/run-scala-test
-        if: steps.job-start.outputs.run_result != 'success'
         with:
           target-project: "firesim"
           test-package: "firesim.firesim"
           test-name: "CITests"
-      - uses: ./.github/actions/job-end
 
   run-basic-linux-poweroff:
     name: run-basic-linux-poweroff
@@ -157,12 +126,8 @@ jobs:
     environment: use-fpgas
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Run linux-poweroff test
         run: .github/scripts/run-linux-poweroff.py
-        if: steps.job-start.outputs.run_result != 'success'
-      - uses: ./.github/actions/job-end
 
   run-ini-api-tests:
     name: run-ini-api-tests
@@ -172,12 +137,8 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/job-start
-        id: job-start
       - name: Run .ini API verification tests
         run: .github/scripts/run-ini-api-tests.py
-        if: steps.job-start.outputs.run_result != 'success'
-      - uses: ./.github/actions/job-end
 
   documentation-check:
     name: documentation-check


### PR DESCRIPTION
This allows a fresh manager to be spun up when rerunning the test workflow. Previously you'd have to create new commit (which would invalidate the cache). 

#### Related PRs / Issues


<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
