### PR TITLE
Bypass manual input on `buildbitstream` cancellation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 conda-requirements-riscv-tools-linux-64.conda-lock.yml linguist-generated=true
+docs/Advanced-Usage/Manager/HELP_OUTPUT linguist-generated=true

--- a/deploy/buildtools/buildconfigfile.py
+++ b/deploy/buildtools/buildconfigfile.py
@@ -32,6 +32,7 @@ class BuildConfigFile:
         build_farm: Build farm used to host builds.
     """
     args: argparse.Namespace
+    forceterminate: bool
     agfistoshare: List[str]
     acctids_to_sharewith: List[str]
     hwdb: RuntimeHWDB
@@ -51,6 +52,8 @@ class BuildConfigFile:
             launch_time = strftime("%Y-%m-%d--%H-%M-%S", gmtime())
 
         self.args = args
+
+        self.forceterminate = args.forceterminate
 
         global_build_config_file = None
         with open(args.buildconfigfile, "r") as yaml_file:

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -260,7 +260,11 @@ def buildbitstream(build_config_file: BuildConfigFile) -> None:
     def release_build_hosts_handler(sig, frame) -> None:
         """ Handler that prompts to release build farm hosts if you press ctrl-c. """
         rootLogger.info("You pressed ctrl-c, so builds have been killed.")
-        userconfirm = firesim_input("Do you also want to terminate your build hosts? Type 'yes' to do so.\n")
+
+        userconfirm = "yes"
+        if not build_config_file.forceterminate:
+            userconfirm = firesim_input("Do you also want to terminate your build hosts? Type 'yes' to do so.\n")
+
         if userconfirm == "yes":
             build_config_file.release_build_hosts()
             rootLogger.info("Build farm hosts released.")
@@ -404,7 +408,7 @@ def construct_firesim_argparser() -> argparse.ArgumentParser:
     parser.add_argument('--terminatesome', action='append', type=terminatesomesplitter,
                         help='Only used by terminaterunfarm. Used to specify a restriction on how many instances to terminate. E.g., --terminatesome=f1.2xlarge:2 will terminate only 2 of the f1.2xlarge instances in the runfarm, regardless of what other instances are in the runfarm. This argument can be specified multiple times to terminate additional instance types/counts. Behavior when specifying the same instance type multiple times is undefined. This replaces the old --terminatesome{f116,f12,f14,m416} arguments. Behavior when specifying these old-style terminatesome flags and this new style flag at the same time is also undefined.')
     parser.add_argument('-q', '--forceterminate', action='store_true',
-                        help='For terminaterunfarm, force termination without prompting user for confirmation. Defaults to False')
+                        help='For terminaterunfarm and buildbitstream, force termination without prompting user for confirmation. Defaults to False')
     parser.add_argument('-t', '--launchtime', type=str,
                         help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildafi')
     parser.add_argument('--platform', type=str, choices=PLATFORM_LIST, default='f1',

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -68,8 +68,9 @@ optional arguments:
                         when specifying these old-style terminatesome flags
                         and this new style flag at the same time is also
                         undefined.
-  -q, --forceterminate  For terminaterunfarm, force termination without
-                        prompting user for confirmation. Defaults to False
+  -q, --forceterminate  For terminaterunfarm and buildbitstream, force
+                        termination without prompting user for confirmation.
+                        Defaults to False
   -t LAUNCHTIME, --launchtime LAUNCHTIME
                         Give the "Y-m-d--H-M-S" prefix of results-build
                         directory. Useful for tar2afi when finishing a partial

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -106,6 +106,18 @@ This directory will contain:
         This contains reports, ``stdout`` from the build, and the final bitstream ``xclbin`` file produced by Vitis.
         This also contains a copy of the generated verilog (``FireSim-generated.sv``) used to produce this build.
 
+If this command is cancelled by a SIGINT, it will prompt for confirmation
+that you want to terminate the build instances.
+If you respond in the affirmative, it will move forward with the termination.
+If you do not want to have to confirm the termination (e.g. you are using this
+command in a script), you can give the command the ``--forceterminate`` command
+line argument. For example, the following will terminate all build instances in the
+build farm without prompting for confirmation if a SIGINT is received:
+
+::
+
+    firesim buildbitstream --forceterminate
+
 .. _firesim-builddriver:
 
 ``firesim builddriver``


### PR DESCRIPTION
If a SIGINT is received when running `buildbitstream` a prompt will show for the user to terminate their build instances. This adds a bypass using the `--forceterminate` flag.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

This extends `firesim buildbitstream` with a new flag `--forceterminate` that terminates build instances on a SIGINT without a user prompt.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
