### PR TITLE
Buildafi CI

### DIFF
--- a/.github/scripts/ci_variables.py
+++ b/.github/scripts/ci_variables.py
@@ -11,3 +11,4 @@ ci_commit_sha1 = os.environ['GITHUB_SHA']
 ci_workdir = os.path.expanduser(os.environ['GITHUB_WORKSPACE'])
 ci_api_token = os.environ['GITHUB_TOKEN']
 ci_personal_api_token = os.environ['PERSONAL_ACCESS_TOKEN']
+ci_ref_name = os.environ['GITHUB_REF']

--- a/.github/scripts/run-default-buildafi.py
+++ b/.github/scripts/run-default-buildafi.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import sys
+
+from fabric.api import *
+
+from common import manager_fsim_dir, set_fabric_firesim_pem
+from ci_variables import ci_ref_name
+
+def run_default_buildafi():
+    """ Runs buildafi """
+
+    with prefix('cd {} && source sourceme-f1-manager.sh'.format(manager_fsim_dir)):
+        rc = 0
+        with settings(warn_only=True):
+            # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
+            # pty=False needed to avoid issues with screen -ls stalling in fabric
+            rc = run("timeout {} firesim buildafi --forceterminate &> buildafi.log".format(timeout), pty=False).return_code
+        if rc != 0:
+            print("Buildafi failed. Printing last lines of log. See buildafi.log for full info")
+            print("Log start =================================================================")
+            run("tail -n 300 buildafi.log")
+            print("Log end ===================================================================")
+            sys.exit(rc)
+        else:
+            # parse the output yamls, replace the sample hwdb's agfi line
+            hwdb_entry_dir = "{}/deploy/built-hwdb-entries".format(manager_fsim_dir)
+            built_hwdb_entries = [x for x in os.listdir(hwdb_entry_dir) if os.path.isfile(os.path.join(hwdb_entry_dir, x)]
+
+            sample_hwdb_postfix = "deploy/sample-backup-configs/sample_config_hwdb.ini"
+            sample_hwdb_filename = "{}/{}".format(manager_fsim_dir, sample_hwdb_postfix)
+            for hwdb in built_hwdb_entries:
+                sample_hwdb_lines = open(sample_hwdb_filename).read().split('\n')
+
+                with open(sample_hwdb_filename, "w") as sample_hwdb_file:
+                    match_agfi = False
+                    for line in sample_hwdb_lines:
+                        # found the hwdb entry
+                        if hwdb in line:
+                            match_agfi = True
+                            sample_hwdb_file.write(line + '\n')
+                        elif match_agfi == True and "agfi=" in line:
+                            # only replace this agfi
+                            match_agfi = False
+                            # print out the agfi line
+                            sample_hwdb_file.write(open("{}/{}".format(hwdb_entry_dir, hwdb)).read().split("\n")[1] + '\n')
+                        else:
+                            sample_hwdb_file.write(line + '\n')
+
+                    if match_agfi == True:
+                        sys.exit("ERROR: Unable to find matching AGFI line for HWDB entry")
+
+            # share agfis
+            sample_build_filename = "{}/deploy/sample-backup-configs/sample_config_build.ini".format(manager_fsim_dir)
+            sample_build_lines = open(sample_build_filename).read().split('\n')
+            with open(sample_build_filename, "w") as sample_build_file:
+                for line in sample_build_lines:
+                    if "somebodysname=" in line:
+                        sample_build_file.write("#" + line + "\n")
+                    elif "public=" in line:
+                        # get rid of the comment
+                        sample_build_file.write(line[1:] + "\n")
+                    else:
+                        sample_build_file.write(line + "\n")
+
+            run("firesim shareagfi -a {} -b {}".format(sample_hwdb_filename, sample_build_filename))
+
+            # make PR
+            # TODO: probably more efficient way? - https://github.com/marketplace/actions/add-commit
+            run("git clone --depth 1 {} temp-firesim".format(manager_fsim_dir))
+            with prefix("cd temp-firesim"):
+                run("git checkout {}".format(ci_ref_name))
+                run("cp {} {}".format(sample_hwdb_filename, sample_hwdb_postfix))
+                run("git commit -am \"Update HWDB\"")
+                run("git push origin {}".format(ci_ref_name))
+
+if __name__ == "__main__":
+    set_fabric_firesim_pem()
+    execute(run_default_buildafi, hosts=["localhost"])

--- a/.github/scripts/run-default-buildafi.py
+++ b/.github/scripts/run-default-buildafi.py
@@ -65,15 +65,6 @@ def run_default_buildafi():
 
             run("firesim shareagfi -a {} -b {}".format(sample_hwdb_filename, sample_build_filename))
 
-            # make PR
-            # TODO: probably more efficient way? - https://github.com/marketplace/actions/add-commit
-            run("git clone --depth 1 {} temp-firesim".format(manager_fsim_dir))
-            with prefix("cd temp-firesim"):
-                run("git checkout {}".format(ci_ref_name))
-                run("cp {} {}".format(sample_hwdb_filename, sample_hwdb_postfix))
-                run("git commit -am \"Update HWDB\"")
-                run("git push origin {}".format(ci_ref_name))
-
 if __name__ == "__main__":
     set_fabric_firesim_pem()
     execute(run_default_buildafi, hosts=["localhost"])

--- a/.github/scripts/run-default-buildafi.py
+++ b/.github/scripts/run-default-buildafi.py
@@ -15,7 +15,7 @@ def run_default_buildafi():
         with settings(warn_only=True):
             # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
             # pty=False needed to avoid issues with screen -ls stalling in fabric
-            rc = run("timeout {} firesim buildafi --forceterminate &> buildafi.log".format(timeout), pty=False).return_code
+            rc = run("timeout 16h firesim buildafi --forceterminate &> buildafi.log", pty=False).return_code
         if rc != 0:
             print("Buildafi failed. Printing last lines of log. See buildafi.log for full info")
             print("Log start =================================================================")
@@ -25,7 +25,7 @@ def run_default_buildafi():
         else:
             # parse the output yamls, replace the sample hwdb's agfi line
             hwdb_entry_dir = "{}/deploy/built-hwdb-entries".format(manager_fsim_dir)
-            built_hwdb_entries = [x for x in os.listdir(hwdb_entry_dir) if os.path.isfile(os.path.join(hwdb_entry_dir, x)]
+            built_hwdb_entries = [x for x in os.listdir(hwdb_entry_dir) if os.path.isfile(os.path.join(hwdb_entry_dir, x))]
 
             sample_hwdb_postfix = "deploy/sample-backup-configs/sample_config_hwdb.ini"
             sample_hwdb_filename = "{}/{}".format(manager_fsim_dir, sample_hwdb_postfix)

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -172,7 +172,6 @@ jobs:
     runs-on: ${{ github.run_id }}
     env:
       TERM: xterm-256-color
-    environment: build-afis
     steps:
       - uses: actions/checkout@v2
       - name: Run buildafi and commit changes

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup FireSim repo (.pem, build-setup.sh, AWS credentials, submodules) and CI daemons
         uses: ./.github/actions/initialize-manager
         with:
-          max-runtime-hours: 10
+          max-runtime-hours: 20
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
 

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -165,6 +165,18 @@ jobs:
       - name: Run linux-poweroff test
         run: .github/scripts/run-linux-poweroff.py
 
+  run-default-buildafi:
+    name: run-default-buildafi
+    needs: [run-basic-linux-poweroff]
+    runs-on: ${{ github.run_id }}
+    env:
+      TERM: xterm-256-color
+    environment: build-afis
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run buildafi and commit changes
+        run: .github/scripts/run-default-buildafi.py
+
   run-ini-api-tests:
     name: run-ini-api-tests
     needs: [setup-manager]

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -174,8 +174,14 @@ jobs:
       TERM: xterm-256-color
     steps:
       - uses: actions/checkout@v2
-      - name: Run buildafi and commit changes
+      - name: Run buildafi command and update sample AGFIs
         run: .github/scripts/run-default-buildafi.py
+      - uses: EndBug/add-and-commit@v8
+        with:
+            add: 'deploy/sample-backup-configs/sample_config_hwdb.ini'
+            # must align with `manager_fsim_dir`
+            cwd: '/home/centos/firesim'
+            message: 'Update AGFIs'
 
   run-ini-api-tests:
     name: run-ini-api-tests

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -166,8 +166,9 @@ jobs:
         run: .github/scripts/run-linux-poweroff.py
 
   run-default-buildafi:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:buildafi-deploy')
     name: run-default-buildafi
-    needs: [run-basic-linux-poweroff]
+    needs: [setup-manager]
     runs-on: ${{ github.run_id }}
     env:
       TERM: xterm-256-color

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -616,6 +616,5 @@ def main(args):
 
 if __name__ == '__main__':
     import sys
-    #sys.exit(main(sys.argv[1:]))
-    mycustom()
+    sys.exit(main(sys.argv[1:]))
 

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -256,7 +256,12 @@ def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavi
 
     # append the tags from the manager to the launched instance
     extra_tags = get_manager_tags()
-    extra_tags.pop('Name', None) # filter out the 'Name'
+    # filter out the 'Name'
+    extra_tags.pop('Name', None)
+    # filter out any tags with the word 'manager' (for CI)
+    for k in extra_tags.keys()
+        if "manager" in k:
+            del extra_tags[k]
     tags.update(extra_tags)
     rootLogger.debug(tags)
 

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -259,7 +259,7 @@ def launch_instances(instancetype, count, instancemarket, spotinterruptionbehavi
     # filter out the 'Name'
     extra_tags.pop('Name', None)
     # filter out any tags with the word 'manager' (for CI)
-    for k in extra_tags.keys()
+    for k in extra_tags.keys():
         if "manager" in k:
             del extra_tags[k]
     tags.update(extra_tags)

--- a/deploy/buildtools/buildconfig.py
+++ b/deploy/buildtools/buildconfig.py
@@ -130,6 +130,8 @@ class GlobalBuildConfig:
 
         self.builds_list = list(map(lambda x: build_recipes[x], builds_to_run_list))
 
+        self.forceterminate = args.forceterminate
+
 
     def launch_build_instances(self):
         """ Launch an instance for the builds we want to do """

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -116,7 +116,11 @@ def buildafi(globalbuildconf):
     def terminate_instances_handler(sig, frame):
         """ Handler that prompts to terminate build instances if you press ctrl-c. """
         rootLogger.info("You pressed ctrl-c, so builds have been killed.")
-        userconfirm = input("Do you also want to terminate your build instances? Type 'yes' to do so.\n")
+
+        userconfirm = "yes"
+        if globalbuildconf.forceterminate == False:
+            userconfirm = input("Do you also want to terminate your build instances? Type 'yes' to do so.\n")
+
         if userconfirm == "yes":
             globalbuildconf.terminate_all_build_instances()
             rootLogger.info("Instances terminated. Please confirm in your AWS Management Console.")
@@ -247,7 +251,7 @@ def construct_firesim_argparser():
                         help='Only used by terminatesome. Terminates this many of the previously launched m4.16xlarges.',
                         default=-1)
     parser.add_argument('-q', '--forceterminate', action='store_true',
-                        help='For terminaterunfarm, force termination without prompting user for confirmation. Defaults to False')
+                        help='For terminaterunfarm and buildafi, force termination without prompting user for confirmation. Defaults to False')
     parser.add_argument('-t', '--launchtime', type=str,
                         help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildafi')
 

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -2,14 +2,13 @@ usage: firesim [-h] [-c RUNTIMECONFIGFILE] [-b BUILDCONFIGFILE]
                [-r BUILDRECIPESCONFIGFILE] [-a HWDBCONFIGFILE]
                [-x OVERRIDECONFIGDATA] [-f TERMINATESOMEF116]
                [-g TERMINATESOMEF12] [-i TERMINATESOMEF14]
-               [-m TERMINATESOMEM416] [-q]
-               
-               {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
+               [-m TERMINATESOMEM416] [-q] [-t LAUNCHTIME]
+               {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck,tar2afi}
 
 FireSim Simulation Manager.
 
 positional arguments:
-  {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck}
+  {managerinit,buildafi,launchrunfarm,infrasetup,boot,kill,terminaterunfarm,runworkload,shareagfi,runcheck,tar2afi}
                         Management task to run.
 
 optional arguments:
@@ -42,5 +41,10 @@ optional arguments:
   -m TERMINATESOMEM416, --terminatesomem416 TERMINATESOMEM416
                         Only used by terminatesome. Terminates this many of
                         the previously launched m4.16xlarges.
-  -q, --forceterminate  For terminaterunfarm, force termination without
-                        prompting user for confirmation. Defaults to False
+  -q, --forceterminate  For terminaterunfarm and buildafi, force termination
+                        without prompting user for confirmation. Defaults to
+                        False
+  -t LAUNCHTIME, --launchtime LAUNCHTIME
+                        Give the "Y-m-d--H-M-S" prefix of results-build
+                        directory. Useful for tar2afi when finishing a partial
+                        buildafi

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -73,6 +73,17 @@ This directory will contain:
 
 - ``FireSim-generated.sv``: This is a copy of the generated verilog used to produce this build. You can also find a copy inside ``cl_firesim``.
 
+If this command is cancelled by a SIGINT, it will prompt for confirmation
+that you want to terminate the build instances.
+If you respond in the affirmative, it will move forward with the termination.
+If you do not want to have to confirm the termination (e.g. you are using this
+command in a script), you can give the command the ``--forceterminate`` command
+line argument. For example, the following will TERMINATE ALL BUILD INSTANCES IN THE
+BUILD FARM WITHOUT PROMPTING FOR CONFIRMATION IF A SIGINT IS RECEIVED:
+
+::
+
+    firesim buildafi --forceterminate
 
 .. _firesim-tar2afi:
 


### PR DESCRIPTION
Implementation of adding a `firesim buildafi` task to the CI. It does/changes the following:

* Runs the `buildafi` command, updates the default HWDB entries, and commits them.
* Cleans up the `aws_build` implementation so that it terminates the build instance earlier.
* Cleans up `awstools.py`. Updates the `launch_instances` function to inherit the tags from the manager (this doesn't include the tags called "Name" and "\*manager\*").

#### Related PRs / Issues

Builds off #923. Needs #921

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
