### PR TITLE
Use a unique runfarm tag in FPGA CI tests

### DIFF
--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -5,6 +5,7 @@ import sys
 from fabric.api import *
 
 from common import manager_fsim_dir, set_fabric_firesim_pem
+from ci_variables import ci_workflow_run_id
 
 def run_linux_poweroff():
     """ Runs Linux poweroff workloads """
@@ -19,6 +20,9 @@ def run_linux_poweroff():
             :arg: workload (str) - workload ini (abs path)
             :arg: timeout (str) - timeout amount for the workload to run
             """
+            # rename runfarm tag with a unique tag based on the ci workflow
+            run("sed -i 's/runfarmtag=.*/runfarmtag={}/g' {}".format(ci_workflow_run_id, workload))
+
             rc = 0
             with settings(warn_only=True):
                 # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)


### PR DESCRIPTION
Use the CI workflow ID number as the runfarm tag. Prevents multiple FPGAs runs happening at the same time colliding on the same runfarm tag and failing.

#### Related PRs / Issues

Most likely fixes #926 

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
