### PR TITLE
Ensure Delay on Unstable Peek/Poke Regardless of Log Setting

### DIFF
--- a/sim/src/main/cc/midasexamples/simif_peek_poke.cc
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.cc
@@ -9,7 +9,7 @@ simif_peek_poke_t::simif_peek_poke_t() {
 
 void simif_peek_poke_t::target_reset(int pulse_length) {
   poke(reset, 1);
-  take_steps(pulse_length, true);
+  this->step(pulse_length, true);
   poke(reset, 0);
 }
 
@@ -44,7 +44,9 @@ data_t simif_peek_poke_t::peek(size_t id, bool blocking) {
     }
     throw;
   }
-  if (log && blocking && !wait_on_stable_peeks(0.1))
+
+  bool peek_may_be_unstable = blocking && !wait_on_stable_peeks(0.1);
+  if (log && peek_may_be_unstable)
     fprintf(stderr, "* WARNING : The following peek is on an unstable value!\n");
   data_t value = read(((unsigned int*) OUTPUT_ADDRS)[id]);
   if (log)

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.cc
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.cc
@@ -123,7 +123,7 @@ int simif_peek_poke_t::teardown() {
   record_end_times();
   fprintf(stderr, "[%s] %s Test", pass ? "PASS" : "FAIL", TARGET_NAME);
   if (!pass) { fprintf(stdout, " at cycle %llu", fail_t); }
-  fprintf(stderr, "SEED: %ld\n", get_seed());
+  fprintf(stderr, "\nSEED: %ld\n", get_seed());
   this->print_simulation_performance_summary();
 
   this->host_finish();

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.h
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.h
@@ -51,9 +51,8 @@ class simif_peek_poke_t: public virtual simif_t
     bool pass = true;
     uint64_t t = 0;
     uint64_t fail_t = 0;
-    // random numbers
-    PEEKPOKEBRIDGEMODULE_struct * defaultiowidget_mmio_addrs;
 
+    PEEKPOKEBRIDGEMODULE_struct * defaultiowidget_mmio_addrs;
 
     bool wait_on(size_t flag_addr, double timeout) {
       midas_time_t start = timestamp();

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.h
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.h
@@ -47,7 +47,7 @@ class simif_peek_poke_t: public virtual simif_t
 
   private:
     // simulation information
-    bool log;
+    bool log = true;
     bool pass = true;
     uint64_t t = 0;
     uint64_t fail_t = 0;


### PR DESCRIPTION
The way expect was written, the wait on unstable pokes would only be affected if the log was also enabled. This ensures that always runs. I also permanently enable the log by default.

Fixes CI failures on multiple branches. 

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None.

#### Verilog / AGFI Compatibility

None.

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
