### PR TITLE
Update NBD mirror

### DIFF
--- a/scripts/install-nbd-kmod.sh
+++ b/scripts/install-nbd-kmod.sh
@@ -10,7 +10,7 @@ KSRC='3.10.0-957.5.1.el7'
 
 # other vars
 TARGET=x86_64
-DISTSITE='http://vault.centos.org/7.6.1810'
+DISTSITE='http://mirror.nsc.liu.se/centos-store/7.6.1810'
 
 GENERICBUILDDIR=$(pwd)/build
 NBDBUILDDIR=$GENERICBUILDDIR/nbdbuild


### PR DESCRIPTION
Use a more dependable mirror for installing the NBD kmod.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
