### PR TITLE
Skip validate in Chipyard `init-submodules`

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -140,7 +140,7 @@ if [ "$IS_LIBRARY" = false ]; then
     git config --unset submodule.target-design/chipyard.update
     git submodule update --init target-design/chipyard
     cd $RDIR/target-design/chipyard
-    ./scripts/init-submodules-no-riscv-tools.sh --no-firesim --skip-validate
+    ./scripts/init-submodules-no-riscv-tools.sh --skip-validate
     cd $RDIR
 
     # Configure firemarshal to know where our firesim installation is.

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -140,7 +140,7 @@ if [ "$IS_LIBRARY" = false ]; then
     git config --unset submodule.target-design/chipyard.update
     git submodule update --init target-design/chipyard
     cd $RDIR/target-design/chipyard
-    ./scripts/init-submodules-no-riscv-tools.sh --no-firesim
+    ./scripts/init-submodules-no-riscv-tools.sh --no-firesim --skip-validate
     cd $RDIR
 
     # Configure firemarshal to know where our firesim installation is.


### PR DESCRIPTION
See PR title. Should be re-tested once CY is bumped into dev before the release.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Did you set dev as the base branch?
- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
