### PR TITLE
[ci] Lengthen machine launch timeout 

### DIFF
--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -24,7 +24,7 @@ def initialize_manager_hosted():
         # wait until machine launch is complete
         with cd(manager_home_dir):
             with settings(warn_only=True):
-                rc = run("timeout 10m grep -q '.*machine launch script complete.*' <(tail -f machine-launchstatus)").return_code
+                rc = run("timeout 20m grep -q '.*machine launch script complete.*' <(tail -f machine-launchstatus)").return_code
                 if rc != 0:
                     run("cat machine-launchstatus.log")
                     raise Exception("machine-launch-script.sh failed to run")


### PR DESCRIPTION
~~This makes the CI instance responsible for tearding down down the manager if a failure occurs before aws configure is run (since that needs to happen if the manager is going to terminate itself).~~

This was not the right fix. Just including the timeout change for now and merging. 

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact
None
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
None
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
