### PR TITLE
Replace call to fpga_pci_init with fpga_mgmt_init

### DIFF
--- a/sim/midas/src/main/cc/simif_f1.cc
+++ b/sim/midas/src/main/cc/simif_f1.cc
@@ -64,8 +64,8 @@ void simif_f1_t::fpga_setup(int slot_id) {
     uint16_t pci_vendor_id = 0x1D0F; /* Amazon PCI Vendor ID */
     uint16_t pci_device_id = 0xF000; /* PCI Device ID preassigned by Amazon for F1 applications */
 
-    int rc = fpga_pci_init();
-    check_rc(rc, "fpga_pci_init FAILED");
+    int rc = fpga_mgmt_init();
+    check_rc(rc, "fpga_mgmt_init FAILED");
 
     /* check AFI status */
     struct fpga_mgmt_image_info info = {0};


### PR DESCRIPTION
This fixes a bug in simif when deploying to F1 instances. Also subsumes #949 to ensure at least some log from the CI deployment is visible.  h/t @CobbledSteel

#### Related PRs / Issues

Resolves #949 

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

None 

### Contributor Checklist
- [x] Did you set dev as the base branch?
- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [x] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
