### PR TITLE
[ci] Put FPGA deployment on a tag ci:fpga-deploy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,9 +35,18 @@ Provide a brief description of the PR immediately below this comment, if the tit
 - [ ] Did you state the UI / API impact?
 - [ ] Did you specify the Verilog / AGFI compatibility impact?
 <!-- Do this if this PR changes verilog or breaks the default AGFIs -->
-- [ ] (If applicable) Did you regenerate and publicly share default AGFIs?
+- [ ] If applicable, did you regenerate and publicly share default AGFIs?
+<!--
+  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
+  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
+  - If in doubt request a deployment, or ask another developer.
+
+  NB: This *label* should be applied before the PR is created, or the branch
+  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
+-->
+- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
 <!-- Do this if this PR is a bugfix that should be applied to the latest release -->
-- [ ] (If applicable) Did you mark the PR as "Please Backport"?
+- [ ] If applicable, did you apply the `Please Backport` label?
 
 ### Reviewer Checklist (only modified by reviewer)
 - [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -88,6 +88,9 @@ jobs:
         uses: ./.github/actions/initial-scala-compile
 
   build-default-workloads:
+    # Conditionally build rootfs images only if deploying to FPGA to save CI resources
+    # https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label/62331521#comment122159108_62331521
+    if: contains(github.event.pull_request.labels.*.name, 'ci:fpga-deploy')
     name: build-default-workloads
     needs: [setup-manager]
     runs-on: ${{ github.run_id }}
@@ -151,12 +154,12 @@ jobs:
           test-name: "CITests"
 
   run-basic-linux-poweroff:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:fpga-deploy')
     name: run-basic-linux-poweroff
     needs: [build-default-workloads]
     runs-on: ${{ github.run_id }}
     env:
       TERM: xterm-256-color
-    environment: use-fpgas
     steps:
       - uses: actions/checkout@v2
       - name: Run linux-poweroff test


### PR DESCRIPTION
Prototyping a change to make it easier to request FPGA deployments. 

TODO, if we like this : 
- [x] update the PR Template to explain how to use the tag
- [x] Remove the deployment environment

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

None

### Contributor Checklist
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] (If applicable) Did you regenerate and publicly share default AGFIs?
<!-- Do this if this PR is a bugfix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?
- [ ] (On merge) Did you update release notes in the dev-to-master PR ?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
