### PR TITLE
Fix search term for AMI selection in setup docs

### DIFF
--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -25,7 +25,7 @@ To launch a manager instance, follow these steps:
    data is preserved when you stop/start the instance, and your data is
    not lost when pricing spikes on the spot market.
 2. When prompted to select an AMI, search in the ``Community AMIs`` tab for
-   ``FPGA Developer AMI - 1.11.0`` and select the AMI that appears (there
+   ``FPGA Developer AMI - 1.11.0-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and select the AMI that appears (there
    should be only one). **DO NOT USE ANY OTHER VERSION.**
 3. When prompted to choose an instance type, select the instance type of
    your choosing. A good choice is a ``c5.4xlarge``.


### PR DESCRIPTION
The old search term resulted in two AMIs (once centos and one AL2).

#### Related PRs / Issues

N/A

#### UI / API Impact

Fix user-facing docs.

#### Verilog / AGFI Compatibility

No change.

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
