### PR TITLE
update libdwarf submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = git://sourceware.org/git/elfutils.git
 [submodule "sim/firesim-lib/src/main/cc/lib/libdwarf"]
 	path = sim/firesim-lib/src/main/cc/lib/libdwarf
-	url = git://git.code.sf.net/p/libdwarf/code
+	url = https://github.com/davea42/libdwarf-code


### PR DESCRIPTION
The libdwarf upstream appears to have changed and the old sourceforge url no longer works for me.

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

No change

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
