### PR TITLE
Use pagination for boto3 calls in the manager

### DIFF
--- a/deploy/awstools/afitools.py
+++ b/deploy/awstools/afitools.py
@@ -14,13 +14,13 @@ def get_current_region():
     boto_session = boto3.session.Session()
     return boto_session.region_name
 
-def paginated_describe_fpga_images(client, operation_params):
-    paginator = client.get_paginator('describe_fpga_images')
+def depaginated_boto_query(client, operation, operation_params, return_key):
+    paginator = client.get_paginator(operation)
     page_iterator = paginator.paginate(**operation_params)
-    fpga_images_all = []
+    return_values_all = []
     for page in page_iterator:
-        fpga_images_all += page['FpgaImages']
-    return fpga_images_all
+        return_values_all += page[return_key]
+    return return_values_all
 
 def get_afi_for_agfi(agfi_id, region=None):
     """ Get the AFI for the AGFI in the specified region.
@@ -42,7 +42,7 @@ def get_afi_for_agfi(agfi_id, region=None):
             },
         ]
     }
-    fpga_images_all = paginated_describe_fpga_images(client, operation_params)
+    fpga_images_all = depaginated_boto_query(client, 'describe_fpga_images', operation_params, 'FpgaImages')
     rootLogger.debug(fpga_images_all)
     return fpga_images_all[0]['FpgaImageId']
 
@@ -126,7 +126,7 @@ def get_firesim_tagval_for_afi(afi_id, tagkey):
             afi_id
         ]
     }
-    result = paginated_describe_fpga_images(client, operation_params)[0]['Description']
+    result = depaginated_boto_query(client, 'describe_fpga_images', operation_params, 'FpgaImages')[0]['Description']
     return firesim_description_to_tags(result)[tagkey]
 
 def get_firesim_tagval_for_agfi(agfi_id, tagkey):

--- a/deploy/awstools/afitools.py
+++ b/deploy/awstools/afitools.py
@@ -2,6 +2,7 @@
 
 import logging
 import boto3
+from awstools.awstools import depaginated_boto_query
 
 rootLogger = logging.getLogger()
 
@@ -13,14 +14,6 @@ def get_fpga_regions():
 def get_current_region():
     boto_session = boto3.session.Session()
     return boto_session.region_name
-
-def depaginated_boto_query(client, operation, operation_params, return_key):
-    paginator = client.get_paginator(operation)
-    page_iterator = paginator.paginate(**operation_params)
-    return_values_all = []
-    for page in page_iterator:
-        return_values_all += page[return_key]
-    return return_values_all
 
 def get_afi_for_agfi(agfi_id, region=None):
     """ Get the AFI for the AGFI in the specified region.

--- a/deploy/tests/awstools/test_awstools.py
+++ b/deploy/tests/awstools/test_awstools.py
@@ -127,9 +127,20 @@ class TestLaunchInstances(object):
         ids.shouldnt.be.empty
 
         ec2_client = boto3.client('ec2')
-        desc = ec2_client.describe_instances(InstanceIds=ids)
-        desc['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-        tags = {t['Key']:t['Value'] for t in desc['Reservations'][0]['Instances'][0]['Tags']}
+
+        paginator = ec2_client.get_paginator('describe_instances')
+
+        operation_params = {
+            'InstanceIds': ids
+        }
+        page_iterator = paginator.paginate(**operation_params)
+
+        all_reservations = []
+        for page in page_iterator:
+            page['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+            all_reservations += page['Reservations']
+
+        tags = {t['Key']:t['Value'] for t in all_reservations[0]['Instances'][0]['Tags']}
         tags.should.have.key('fsimcluster')
         tags['fsimcluster'].should.equal('testcluster')
         tags.should.have.key('secondtag')
@@ -138,9 +149,15 @@ class TestLaunchInstances(object):
     @mock_ec2
     def test_moto_resets_instances_between_tests(self):
         ec2_client = boto3.client('ec2')
-        desc = ec2_client.describe_instances()
-        desc['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-        desc['Reservations'].should.be.empty
+        paginator = ec2_client.get_paginator('describe_instances')
+        page_iterator = paginator.paginate()
+
+        all_reservations = []
+        for page in page_iterator:
+            page['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+            all_reservations += page['Reservations']
+
+        all_reservations.should.be.empty
 
     @mock_ec2
     def test_can_query_multiple_instance_tags(self):
@@ -174,10 +191,17 @@ class TestLaunchInstances(object):
 
         # There should be two instances total now, across two reservations
         ec2_client = boto3.client('ec2')
-        desc = ec2_client.describe_instances()
-        desc['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-        desc['Reservations'].should.have.length_of(2)
-        [i for r in desc['Reservations'] for i in r['Instances']].should.have.length_of(2)
+
+        paginator = ec2_client.get_paginator('describe_instances')
+        page_iterator = paginator.paginate()
+
+        all_reservations = []
+        for page in page_iterator:
+            page['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+            all_reservations += page['Reservations']
+        all_reservations.should.have.length_of(2)
+
+        [i for r in all_reservations for i in r['Instances']].should.have.length_of(2)
 
         # get_instances_by_tag_type with both tags should only return one instance
         instances = get_instances_by_tag_type({**tag1, **tag2},type)
@@ -187,9 +211,19 @@ class TestLaunchInstances(object):
         ids = [i.id for i in instances]
         ids.shouldnt.be.empty
 
-        desc = ec2_client.describe_instances(InstanceIds=ids)
-        desc['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-        tags = {t['Key']:t['Value'] for t in desc['Reservations'][0]['Instances'][0]['Tags']}
+        operation_params = {
+            'InstanceIds': ids
+        }
+
+        paginator = ec2_client.get_paginator('describe_instances')
+        page_iterator = paginator.paginate(**operation_params)
+
+        all_reservations = []
+        for page in page_iterator:
+            page['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+            all_reservations += page['Reservations']
+
+        tags = {t['Key']:t['Value'] for t in all_reservations[0]['Instances'][0]['Tags']}
         tags.should.equal({**tag1, **tag2})
 
         # get_instances_by_tag_type with only the original tag should return both instances
@@ -224,10 +258,17 @@ class TestLaunchInstances(object):
 
         # There should be two instances total now, across two reservations
         ec2_client = boto3.client('ec2')
-        desc = ec2_client.describe_instances()
-        desc['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-        desc['Reservations'].should.have.length_of(2)
-        [i for r in desc['Reservations'] for i in r['Instances']].should.have.length_of(2)
+
+        paginator = ec2_client.get_paginator('describe_instances')
+        page_iterator = paginator.paginate()
+
+        all_reservations = []
+        for page in page_iterator:
+            page['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+            all_reservations += page['Reservations']
+        all_reservations.should.have.length_of(2)
+
+        [i for r in all_reservations for i in r['Instances']].should.have.length_of(2)
 
     @mock_ec2
     def test_non_additive_requires_tags(self):
@@ -279,7 +320,13 @@ class TestLaunchInstances(object):
 
         # There should be one instance total now, across one reservation
         ec2_client = boto3.client('ec2')
-        desc = ec2_client.describe_instances()
-        desc['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-        desc['Reservations'].should.have.length_of(1)
-        [i for r in desc['Reservations'] for i in r['Instances']].should.have.length_of(1)
+        paginator = ec2_client.get_paginator('describe_instances')
+        page_iterator = paginator.paginate()
+
+        all_reservations = []
+        for page in page_iterator:
+            page['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+            all_reservations += page['Reservations']
+        all_reservations.should.have.length_of(1)
+
+        [i for r in all_reservations for i in r['Instances']].should.have.length_of(1)

--- a/deploy/tests/test_scripts.py
+++ b/deploy/tests/test_scripts.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.xfail(strict=True, reason="cleanup update_test_amis.py to use moto.ec2.utils.gen_moto_amis")
+@pytest.mark.xfail(reason="cleanup update_test_amis.py to use moto.ec2.utils.gen_moto_amis")
 def test_for_update_test_amis_cleanup():
     from moto.ec2.utils import gen_moto_amis
     return type(gen_moto_amis)

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -67,7 +67,7 @@ sudo python3 -m pip install pandas==1.1.5
 sudo python3 -m pip install awscli==1.22.21
 sudo python3 -m pip install pytest==6.2.5
 sudo python3 -m pip install pytest-dependency==0.5.1
-sudo python3 -m pip install moto==2.2.17
+sudo python3 -m pip install moto==3.1.0
 sudo python3 -m pip install sure==2.0.0
 # needed for the awstools cmdline parsing
 sudo python3 -m pip install pyyaml==5.4.1


### PR DESCRIPTION
Several boto3 APIs require pagination, which we have been ignoring, this fixes that:

https://boto3.amazonaws.com/v1/documentation/api/1.20.21/guide/paginators.html

This rarely seems to happen in practice for our use cases, but we did see it once during the tutorial setup for AGFIs.

Also, this updates the relevant tests in deploy/tests/ and bumps moto to 3.1.0 which enables running all of the tests. Of those tests, 9 passed and 1 xpassed (confirmed as expected result with @timsnyder).

#### Related PRs / Issues

Partially addresses #968 (moto3 bump).

There's no issue for the actual problem this fixes.

#### UI / API Impact

None.

#### Verilog / AGFI Compatibility

No change.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
