### PR TITLE
Fix synthesized assertions stop-printf pair detection

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/HoistStopAndPrintfEnables.scala
+++ b/sim/midas/src/main/scala/midas/passes/HoistStopAndPrintfEnables.scala
@@ -1,0 +1,50 @@
+
+// See LICENSE for license details.
+
+package midas.passes
+
+import firrtl._
+import firrtl.Mappers._
+import firrtl.passes._
+import firrtl.ir._
+import firrtl.options.Dependency
+
+/**
+  * Pushes enable expressions into seperate nodes that can be consistently
+  * optimized across by CSE. This ensures that associated pairs of stops and
+  * printfs will have references to a common enable node, which allows
+  * AssertionSynthesis to correctly group and synthesize them.
+  *
+  */
+
+object HoistStopAndPrintfEnables extends Transform with DependencyAPIMigration {
+  override def prerequisites          = Nil
+  override def optionalPrerequisites  = Seq(Dependency(firrtl.transforms.formal.ConvertAsserts))
+  override def optionalPrerequisiteOf = Seq(Dependency(firrtl.passes.CommonSubexpressionElimination))
+  override def invalidates(a: Transform): Boolean         = false
+
+  def onModule(m: DefModule): DefModule = {
+    val namespace = Namespace(m)
+
+    def hoistEnable(enable: Expression, stmtUpdater: Expression => Statement): Statement = {
+      val hoistedEnable = DefNode(NoInfo, namespace.newTemp, enable)
+      Block(hoistedEnable, stmtUpdater(Reference(hoistedEnable)))
+    }
+
+    def onStmt(s: Statement): Statement = s.map(onStmt) match {
+      case stop@Stop(_,_,_,en: DoPrim)     => hoistEnable(en, (e: Expression) => stop. copy(en = e))
+      case print@Print(_,_,_,_,en: DoPrim) => hoistEnable(en, (e: Expression) => print.copy(en = e))
+      case o => o
+    }
+
+    m match {
+      case mod: Module => mod.copy(body = mod.body.map(onStmt))
+      case ext: ExtModule => ext
+    }
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit
+    state.copy(circuit = c.copy(modules = c.modules.map(onModule)))
+  }
+}

--- a/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/sim/midas/src/main/scala/midas/passes/MidasTransforms.scala
@@ -31,9 +31,14 @@ private[midas] class MidasTransforms extends Transform {
     else Seq()
 
     val xforms = Seq(
+      new ResolveAndCheck,
+      HoistStopAndPrintfEnables,
       firrtl.passes.RemoveValidIf,
       new firrtl.transforms.ConstantPropagation,
       firrtl.passes.SplitExpressions,
+      // SplitExpressions invalidates ResolveKinds which can lead to missed CSE opportunities since
+      // identical expressions may have different Kinds
+      firrtl.passes.ResolveKinds,
       firrtl.passes.CommonSubexpressionElimination,
       new firrtl.transforms.DeadCodeElimination,
       new firrtl.transforms.InferResets,


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

FireSim synthesizes assertions by finding matching pairs of stops and printfs. It does this currently by finding pairs that have matching _serialized_ `enable` expressions. However, in some cases it is possible for these expressions to be logically equivalent without being syntactically equal.  This change does not remove the possibility of that entirely, but makes the probability considerably lower. 

It also fixes a bug wherein expression `Kind`s were not being re-resolved after SplitExpressions. I suspect I was serializing the enable expression because of this problem (since it essentially removes the influence of `Flow` and `Kind` in determining equality) We should consider just pushing the optimizations into the Dependency-managed section of the compiler instead of our statically scheduled list. 

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None.

#### Verilog / AGFI Compatibility

The verilog is likely to be better optimized (so fewer LOC), but i highly doubt Vivado QoR will change. No memory map changes. 

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
