### PR TITLE
revert the change from #842 that makes launchrunfarm block on instances passing status checks

### DIFF
--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -12,8 +12,8 @@ from common import *
 from ci_variables import *
 
 # Reuse manager utilities
-sys.path.append(ci_workdir + "/deploy/runtools")
-from runtools import instance_liveness
+sys.path.append(ci_workdir + "/deploy")
+from runtools.firesim_topology_with_passes import instance_liveness
 
 def initialize_manager_hosted():
     """ Performs the prerequisite tasks for all CI jobs that will run on the manager instance

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -11,10 +11,6 @@ from common import *
 # This is expected to be launch from the ci container
 from ci_variables import *
 
-# Reuse manager utilities
-sys.path.append(ci_workdir + "/deploy")
-from runtools.firesim_topology_with_passes import instance_liveness
-
 def initialize_manager_hosted():
     """ Performs the prerequisite tasks for all CI jobs that will run on the manager instance
 
@@ -25,9 +21,6 @@ def initialize_manager_hosted():
 
     # Catch any exception that occurs so that we can gracefully teardown
     try:
-        # wait for machine to be reachable
-        instance_liveness()
-
         # wait until machine launch is complete
         with cd(manager_home_dir):
             with settings(warn_only=True):

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -11,6 +11,10 @@ from common import *
 # This is expected to be launch from the ci container
 from ci_variables import *
 
+# Reuse manager utilities
+sys.path.append(ci_workdir + "/deploy/runtools")
+from runtools import instance_liveness
+
 def initialize_manager_hosted():
     """ Performs the prerequisite tasks for all CI jobs that will run on the manager instance
 
@@ -21,6 +25,9 @@ def initialize_manager_hosted():
 
     # Catch any exception that occurs so that we can gracefully teardown
     try:
+        # wait for machine to be reachable
+        instance_liveness()
+
         # wait until machine launch is complete
         with cd(manager_home_dir):
             with settings(warn_only=True):

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -429,19 +429,12 @@ def instance_privateip_lookup_table(instances):
     ips_to_instances = zip(ips, instances)
     return { ip: instance for (ip, instance) in ips_to_instances }
 
-def wait_on_instance_boot(instance_id):
-    """ Blocks on EC2 instance boot """
-    ec2_client = boto3.client('ec2')
-    waiter = ec2_client.get_waiter('instance_status_ok')
-    waiter.wait(InstanceIds=[instance_id])
-
 def wait_on_instance_launches(instances, message=""):
     """ Take a list of instances (as returned by create_instances), wait until
     instance is running. """
     rootLogger.info("Waiting for instance boots: " + str(len(instances)) + " " + message)
     for instance in instances:
         instance.wait_until_running()
-        wait_on_instance_boot(instance.id)
         rootLogger.info(str(instance.id) + " booted!")
 
 def terminate_instances(instanceids, dryrun=True):

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -133,7 +133,8 @@ def buildafi(globalbuildconf):
     # remote items will map themselves
     globalbuildconf.launch_build_instances()
 
-    # confirm that build instances have finished booting
+    # confirm that build instances are in running state so that they have
+    # been assigned IP addresses
     globalbuildconf.wait_build_instances()
 
     # run builds, then terminate instances

--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -20,7 +20,7 @@ rootLogger = logging.getLogger()
 
 @parallel
 def instance_liveness():
-    """ Confirm that all instances are running first so that we don't run any
+    """ Confirm that all instances are accessible (are running and can be ssh'ed into) first so that we don't run any
     actual firesim-related commands on only some of the run farm machines."""
     rootLogger.info("""[{}] Checking if host instance is up...""".format(env.host_string))
     with StreamLogger('stdout'), StreamLogger('stderr'):

--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -20,7 +20,8 @@ rootLogger = logging.getLogger()
 
 @parallel
 def instance_liveness():
-    """ confirm that all instances are running first. """
+    """ Confirm that all instances are running first so that we don't run any
+    actual firesim-related commands on only some of the run farm machines."""
     rootLogger.info("""[{}] Checking if host instance is up...""".format(env.host_string))
     with StreamLogger('stdout'), StreamLogger('stderr'):
         run("uname -a")

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -271,9 +271,8 @@ class RunFarm:
                                      runinstancemarket, spotinterruptionbehavior,
                                      spotmaxprice, timeout, always_expand)
 
-        # wait for instances to finish launching
-        # TODO: maybe we shouldn't do this, but just let infrasetup block. That
-        # way we get builds out of the way while waiting for instances to launch
+        # wait for instances to get to running state, so that they have been
+        # assigned IP addresses
         wait_on_instance_launches(f1_16s, 'f1.16xlarges')
         wait_on_instance_launches(f1_4s, 'f1.4xlarges')
         wait_on_instance_launches(m4_16s, 'm4.16xlarges')


### PR DESCRIPTION
This reverts the change from #842 that makes `launchrunfarm` block on instances passing status checks. This prevents us from overlapping ec2 instance boot with building fpga drivers (and soon metasim drivers). The manager already relies on `instance_liveness` as a cross-platform way of checking for instance reachability, because we don't want to run firesim-related commands on a runfarm where some instances are down for some reason.

CI doesn't need any special form of waiting because it's only booting one manager and thus the first command it tries to run on the manager via fabric will block anyway (and it looks like CI is using the same fabric connection params as the manager).

I also updated the `instance_liveness` docstring to clarify why it is run during `infrasetup`.

#### UI / API Impact

No functionality change.

`firesim launchrunfarm` will be faster (like before #842). infrasetup, etc. still check for `instance_liveness` like before.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
