### PR TITLE
Add a Developer Section to docs.fires.im

### DIFF
--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hanging-Simulators.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Debugging-Hanging-Simulators.rst
@@ -9,7 +9,7 @@ obvious if it's a bug in the target, or somewhere in the host. To make it easier
 identify the problem, the simulation driver includes a polling watchdog that
 tracks for simulation progress, and periodically updates an output file,
 ``heartbeat.csv``, with a target cycle count and a timestamp. When debugging
-these issues, we always encourage the use of meta-simulation to try
+these issues, we always encourage the use of metasimulation to try
 reproducing the failure if possible. We outline three common cases in the
 section below.
 

--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Dromajo.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Dromajo.rst
@@ -87,8 +87,8 @@ located in ``$CHIPYARD/tools/dromajo/dromajo-src/src/`` folder.
 Troubleshooting Dromajo Simulations with Meta-Simulations
 ----------------------------------------------------------
 
-If FPGA simulation fails with Dromajo, you can use meta-simulation to determine if your Dromajo setup is correct.
-First refer to :ref:`meta-simulation` for more information on meta-simulation.
+If FPGA simulation fails with Dromajo, you can use metasimulation to determine if your Dromajo setup is correct.
+First refer to :ref:`metasimulation` for more information on metasimulation.
 The main difference between those instructions and simulations with Dromajo is that you need to manually point to the ``dtb``, ``rom``, and binary files when invoking the simulator.
 Here is an example of a ``make`` command that can be run to check for a correct setup.
 

--- a/docs/Advanced-Usage/Debugging-in-Software/RTL-Simulation.rst
+++ b/docs/Advanced-Usage/Debugging-in-Software/RTL-Simulation.rst
@@ -4,34 +4,34 @@ Debugging & Testing with Meta-Simulation
 =========================================
 
 When we speak of RTL simulation in FireSim, we are generally referring to
-`meta-simulation`: simulating the FireSim simulator's RTL, typically using VCS or
-verilator. In contrast, we we'll refer to simulation of the target's RTL
+_meta-simulation: simulating the FireSim simulator's RTL, typically using VCS or
+verilator. In contrast, we we'll refer to native simulation of the target's RTL
 as target-level simulation. Target-level simulation in Chipyard is described at length
 `here <https://chipyard.readthedocs.io/en/latest/Simulation/Software-RTL-Simulation.html>`_.
 
 Meta-simulation is the most productive way to catch bugs
 before generating an AGFI, and a means for reproducing bugs seen on the FPGA.
 By default, meta-simulation uses an abstract but fast model of the host: the
-FPGA's DRAM controllers are modeled with DRAMSim2, the PCI-E subsystem is not
+FPGA's DRAM controllers are modelled with DRAMSim2, the PCI-E subsystem is not
 simulated, instead the driver presents DMA and MMIO traffic directly via
 verilog DPI. Since FireSim simulations are robust against timing differences
 across hosts, target behavior observed in an FPGA-hosted simulation should be
 exactly reproducible in a meta-simulation.
 
-Generally, meta-simulators are only slightly slower than target-level
+Generally, meta-simulators only slightly slower than target-level
 ones. This illustrated in the chart below.
 
 ====== ===== =======  ========= ============= =============
 Type   Waves VCS      Verilator Verilator -O1 Verilator -O2
 ====== ===== =======  ========= ============= =============
-Target Off   4.8 kHz  3.9 kHz   6.6 kHz       N/A
-Target On    0.8 kHz  3.0 kHz   5.1 kHz       N/A
-Meta   Off   3.8 kHz  2.4 kHz   4.5 kHz       5.3 KHz
-Meta   On    2.9 kHz  1.5 kHz   2.7 kHz       3.4 KHz
+Target Off   4.8 kHz  3.9 kHz   6.6 kHz       N/A          
+Target On    0.8 kHz  3.0 kHz   5.1 kHz       N/A          
+Meta   Off   3.8 kHz  2.4 kHz   4.5 kHz       5.3 KHz      
+Meta   On    2.9 kHz  1.5 kHz   2.7 kHz       3.4 KHz      
 ====== ===== =======  ========= ============= =============
 
-Note that using more aggressive optimization levels when compiling the
-Verilated-design dramatically lengthens compile time:
+Note that using more agressive optimization levels when compiling the
+Verilated-design dramatically lengths compile time:
 
 ====== ===== =======  ========= ============= =============
 Type   Waves VCS      Verilator Verilator -O1 Verilator -O2
@@ -42,10 +42,10 @@ Meta   On    35s      49s       5m27s         6m33s
 
 Notes: Default configurations of a single-core, Rocket-based instance running
 rv64ui-v-add. Frequencies are given in target-Hz. Presently, the default
-compiler flags passed to Verilator and VCS differ between meta-simulation and target-level simulation. Hence,
+compiler flags passed to Verilator and VCS differ from level to level. Hence,
 these numbers are only intended to ball park simulation speeds, not provide a
-scientific comparison between simulators. VCS numbers collected on a local Berkeley machine,
-Verilator numbers collected on a c4.4xlarge. (meta-simulation verilator version: 4.002, target-level
+scientific comparison between simulators. VCS numbers collected on Millenium,
+Verilator numbers collected on a c4.4xlarge. (ML verilator version: 4.002, TL
 verilator version: 3.904)
 
 
@@ -97,7 +97,7 @@ Additionally, you can run a unique binary in the following way:
 Examples
 ++++++++
 
-Run all RISCV-tools assembly and benchmark tests on a Verilated simulator.
+Run all RISCV-tools assembly and benchmark tests on a verilated simulator.
 
 ::
 
@@ -106,7 +106,7 @@ Run all RISCV-tools assembly and benchmark tests on a Verilated simulator.
     make -j run-asm-tests
     make -j run-bmark-tests
 
-Run all RISCV-tools assembly and benchmark tests on a Verilated simulator with waveform dumping.
+Run all RISCV-tools assembly and benchmark tests on a verilated simulator with waveform dumping.
 
 ::
 
@@ -114,7 +114,7 @@ Run all RISCV-tools assembly and benchmark tests on a Verilated simulator with w
     make -j run-asm-tests-debug
     make -j run-bmark-tests-debug
 
-Run rv64ui-p-simple (a single assembly test) on a Verilated simulator.
+Run rv64ui-p-simple (a single assembly test) on a verilated simulator.
 
 ::
 
@@ -130,57 +130,59 @@ Run rv64ui-p-simple (a single assembly test) on a VCS simulator with waveform du
     make EMUL=vcs $(pwd)/output/f1/FireSim-FireSimRocketConfig-BaseF1Config/rv64ui-p-simple.vpd
 
 
-Understanding A Meta-Simulation Waveform
+Understanding A Metasimulation Waveform
 ----------------------------------------
 
 Module Hierarchy
 ++++++++++++++++
-To build out a simulator, Golden Gate adds multiple layers of module hierarchy to the target
-design and performs additional hierarchy mutations to implement bridges and
-resource optimizations. Meta-simulation uses the ``FPGATop`` module as the
-top-level module, which excludes the platform shim layer (``F1Shim``, for EC2 F1).
+To build out a simulator, Golden Gate adds multiple layers of module hierarchy
+to the target design and performs additional hierarchy mutations to implement bridges and
+resource optimizations. Metasimulation uses the ``FPGATop`` module as the
+top-level module, which excludes the platform shim layer (``F1Shim``, for EC2 F1). 
 The original top-level of the input design is nested three levels below FPGATop:
 
 .. figure:: /img/metasim-module-hierarchy.png
 
-    The module hierarchy visible in a typical meta-simulation.
+    The module hierarchy visible in a typical metasimulation.
 
 Note that many other bridges (under ``FPGATop``), channel implementations
 (under ``SimWrapper``), and optimized models (under ``FAMETop``) may be
 present, and vary from target to target. Under the ``FAMETop`` module instance
 you will find the original top-level module (``FireSimPDES_``, in this case),
 however it has now been host-decoupled using the default LI-BDN FAME
-transformation and is referred to as the `hub model`. It will have ready-valid
+tranformation and is referred to as the `hub model`. It will have ready-valid
 I/O interfaces for all of the channels bound to it, and internally containing
 additional channel enqueue and clock firing logic to control the advance of
 simulated time. Additionally, modules for bridges and optimized models will no
 longer be found contained in this submodule hierarchy. Instead, I/O for those
-extracted modules will now be as channel interfaces.
+extraced modules will now be as channel interfaces.
 
 
 Clock Edges and Event Timing
 ++++++++++++++++++++++++++++
 Since FireSim derives target clocks by clock gating a single host clock, and
 since bridges and optimized models may introduce stalls of their own, timing of
-target clock edges in a meta-simulation will appear contorted relative to a
+target clock edges in a metasimulation will appear contorted relative to a
 conventional target-simulation. This is expected.
 
 Finding The Source Of Simulation Stalls
 +++++++++++++++++++++++++++++++++++++++
 In the best case, FireSim simulators will be able to launch new target clock
 pulses on every host clock cycle. In other words, for single-clock targets the
-simulation can run at FMR = 1. In the single clock case, delays are introduced
+simulation can run at FMR = 1. In the single clock case delays are introduced
 by bridges (like FASED memory timing models) and optimized models. You can
-identify which bridges are responsible for additional delays between target
-clocks by filtering for input valid and output ready to the hub model.  When
-input valid is deasserted, the corresponding bridge or model has not yet produced a token for the
-current timestep, effectively stalling the hub.
+identify which bridges are reponsible for additional delays between target
+clocks by filtering for ``*sink_valid`` and ``*source_ready`` on the hub model.
+When ``<channel>_sink_valid`` is deasserted, a bridge or model has not yet
+produced a token for the current timestep, stalling the hub. When
+``<channel>_source_ready`` is deasserted, a bridge or model is backpressuring
+the channel.
 
 Scala Tests
 -----------
 
-To make it easier to do RTL-simulation-based regression testing, the Scala
-tests wrap calls to Makefiles, and run a limited set of tests on a set of selected
+To make it easier to do metasimulation-based regression testing, the ScalaTests
+wrap calls to Makefiles, and run a limited set of tests on a set of selected
 designs, including all of the MIDAS examples and FireSimNoNIC.
 
 The selected tests, target configurations, as well as the type of RTL simulator

--- a/docs/Advanced-Usage/Generating-Different-Targets.rst
+++ b/docs/Advanced-Usage/Generating-Different-Targets.rst
@@ -147,7 +147,7 @@ Specifying A Target Instance
 To generate a specific instance of a target, the build system leverages four Make variables:
 
 1. ``TARGET_PROJECT``: this points the Makefile (`sim/Makefile`) at the right
-   target-specific Makefrag, which defines the generation and meta-simulation
+   target-specific Makefrag, which defines the generation and metasimulation
    software recipes.  The makefrag for the default target project is
    defined at ``sim/src/main/makefrag/firesim``.
 

--- a/docs/Developer-Docs/Host-Platform-Debugging.rst
+++ b/docs/Developer-Docs/Host-Platform-Debugging.rst
@@ -1,0 +1,63 @@
+Complete FPGA Metasimulation
+=========================================
+
+Generally speaking, users will only ever need to use conventional
+metasimulation (formerly, MIDAS-level simulation). However, when bringing up a
+new FPGA platform, or making changes to an existing one, doing a complete
+pre-synthesis RTL simulation of the FPGA project (which we will refer to as
+FPGA-level metasimulation) may be required. This will simulate the entire RTL
+project passed to Vivado, and includes exact RTL models of the host memory
+controllers and PCI-E subsystem used on the FPGA.  Note, since FPGA-level
+metasimulation should generally not be deployed by users, when we refer to
+metasimulation in absence of the FPGA-level qualifier we mean the faster form
+described in :ref:`Debugging & Testing with Metasimulation<metasimulation>`
+
+FPGA-level metasimulations run out of ``firesim/sim``, and consist of two components:
+
+1. A FireSim-f1 driver that talks to a simulated DUT instead of the FPGA
+2. The DUT, a simulator compiled with either XSIM or VCS, that receives commands from the aforementioned
+   FireSim-f1 driver
+
+-----
+Usage
+-----
+
+To run a simulation you need to make both the DUT and driver targets by typing::
+
+    make xsim
+    make xsim-dut <VCS=1> & # Launch the DUT
+    make run-xsim SIM_BINARY=<PATH/TO/BINARY/FOR/TARGET/TO/RUN> # Launch the driver
+
+When following this process, you should wait until ``make xsim-dut`` prints
+``opening driver to xsim`` before running ``make run-xsim`` (getting these prints from
+``make xsim-dut`` will take a while).
+
+Once both processes are running, you should see::
+
+    opening driver to xsim
+    opening xsim to driver
+
+This indicates that the DUT and driver are successfully communicating.
+Eventually, the DUT will print a commit trace from Rocket Chip. There will
+be a long pause (minutes, possibly an hour, depending on the size of the
+binary) after the first 100 instructions, as the program is being loaded
+into FPGA DRAM.
+
+XSIM is used by default, and will work on EC2 instances with the FPGA developer
+AMI.  If you have a license, setting ``VCS=1`` will use VCS to compile the DUT
+(4x faster than XSIM). Berkeley users running on the Millennium machines should
+be able to source ``firesim/scripts/setup-vcsmx-env.sh`` to setup their
+environment for VCS-based FPGA-level simulation.
+
+The waveforms are dumped in the FPGA build directories (
+``firesim/platforms/f1/aws-fpga/hdk/cl/developer_designs/cl_<DESIGN>-<TARGET_CONFIG>-<PLATFORM_CONFIG>``).
+
+For XSIM::
+
+    <BUILD_DIR>/verif/sim/vivado/test_firesim_c/tb.wdb
+
+And for VCS::
+
+    <BUILD_DIR>/verif/sim/vcs/test_firesim_c/test_null.vpd
+
+When finished, be sure to kill any lingering processes if you interrupted simulation prematurely.

--- a/docs/Golden-Gate/Bridge-Walkthrough.rst
+++ b/docs/Golden-Gate/Bridge-Walkthrough.rst
@@ -157,4 +157,4 @@ Here the main order of business is to add header and source files to
     :end-before: DOC include end: Bridge Build System Changes
 
 That's it! At this point you should be able to both test your bridge in software
-simulation using meta-simulation, or deploy it to an FPGA.
+simulation using metasimulation, or deploy it to an FPGA.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,8 @@ New to FireSim? Jump to the :ref:`firesim-basics` page for more info.
    :maxdepth: 3
    :caption: Developer Docs:
 
-   Developer-Docs/Driver-and-Compiler
+   Developer-Docs/GoldenGate-and-Driver-Development
+   Developer-Docs/Host-Platform-Debugging
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,12 @@ New to FireSim? Jump to the :ref:`firesim-basics` page for more info.
    Golden-Gate/Resource-Optimizations
    Golden-Gate/Output-Files
 
+.. toctree::
+   :maxdepth: 3
+   :caption: Developer Docs:
+
+   Developer-Docs/Driver-and-Compiler
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
This adds a brain dump of documentation explaining FPGA-level metasimulation (for F1), and gives an overview of the tests available for Scala and C++ development. 

I've also unilaterally renamed meta-simulation to metasimulation since the hyphen pisses me off and this is how i've been spelling it out everywhere else. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None. 
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

No change.
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
