### PR TITLE
Manager support for deploying verilator/vcs metasimulations, plusarg passthrough, and various manager improvements

### DIFF
--- a/deploy/firesim
+++ b/deploy/firesim
@@ -173,21 +173,21 @@ def launchrunfarm(runtime_conf):
     runtime_conf.runfarm.launch_run_farm()
 
 
-def terminaterunfarm(runtime_conf, terminatesomef1_16, terminatesomef1_4, terminatesomef1_2,
-                     terminatesomem4_16, forceterminate):
+def terminaterunfarm(runtime_conf, terminate_some_dict, forceterminate):
     """ Terminate instances in the runfarm.
 
     This works in 2 modes:
 
-    1) If you pass no --terminatesomeINSTANCETYPE flags, it will terminate all
+    1) If you pass no --terminatesomeINSTANCETYPE or
+       --terminatesome=INSTANCETYPE:count flags, it will terminate all
        instances with the specified runfarm tag.
 
-    2) If you pass ANY --terminatesomeINSTANCETYPE flag, it will terminate only
+    2) If you pass ANY --terminatesomeINSTANCETYPE or
+       --terminatesome=INSTANCETYPE:count flag, it will terminate only
        that many instances of the specified types and leave all others
        untouched.
     """
-    runtime_conf.terminate_run_farm(terminatesomef1_16, terminatesomef1_4, terminatesomef1_2,
-                                    terminatesomem4_16, forceterminate)
+    runtime_conf.terminate_run_farm(terminate_some_dict, forceterminate)
 
 def shareagfi(buildconf):
     """ Share the agfis specified in the [agfistoshare] section with the users
@@ -235,17 +235,23 @@ def construct_firesim_argparser():
                         help='Override a single value from one of the the RUNTIME e.g.: --overrideconfigdata "targetconfig linklatency 6405".',
                         default="")
     parser.add_argument('-f', '--terminatesomef116', type=int,
-                        help='Only used by terminatesome. Terminates this many of the previously launched f1.16xlarges.',
+                        help='DEPRECATED. Use --terminatesome=f1.16xlarge:count instead. Will be removed in the next major version of FireSim (1.15.X). Old help message: Only used by terminaterunfarm. Terminates this many of the previously launched f1.16xlarges.',
                         default=-1)
     parser.add_argument('-g', '--terminatesomef12', type=int,
-                        help='Only used by terminatesome. Terminates this many of the previously launched f1.2xlarges.',
+                        help='DEPRECATED. Use --terminatesome=f1.2xlarge:count instead. Will be removed in the next major version of FireSim (1.15.X). Old help message: Only used by terminaterunfarm. Terminates this many of the previously launched f1.2xlarges.',
                         default=-1)
     parser.add_argument('-i', '--terminatesomef14', type=int,
-                        help='Only used by terminatesome. Terminates this many of the previously launched f1.4xlarges.',
+                        help='DEPRECATED. Use --terminatesome=f1.4xlarge:count instead. Will be removed in the next major version of FireSim (1.15.X). Old help message: Only used by terminaterunfarm. Terminates this many of the previously launched f1.4xlarges.',
                         default=-1)
     parser.add_argument('-m', '--terminatesomem416', type=int,
-                        help='Only used by terminatesome. Terminates this many of the previously launched m4.16xlarges.',
+                        help='DEPRECATED. Use --terminatesome=m4.16xlarge:count instead. Will be removed in the next major version of FireSim (1.15.X). Old help message: Only used by terminaterunfarm. Terminates this many of the previously launched m4.16xlarges.',
                         default=-1)
+
+    def terminatesomesplitter(raw_arg):
+        split_arg = raw_arg.split(":")
+        return split_arg[0], int(split_arg[1])
+    parser.add_argument('--terminatesome', action='append', type=terminatesomesplitter,
+                        help='Only used by terminaterunfarm. Used to specify a restriction on how many instances to terminate. E.g., --terminatesome=f1.2xlarge:2 will terminate only 2 of the f1.2xlarge instances in the runfarm, regardless of what other instances are in the runfarm. This argument can be specified multiple times to terminate additional instance types/counts. Behavior when specifying the same instance type multiple times is undefined. This replaces the old --terminatesome{f116,f12,f14,m416} arguments. Behavior when specifying these old-style terminatesome flags and this new style flag at the same time is also undefined.')
     parser.add_argument('-q', '--forceterminate', action='store_true',
                         help='For terminaterunfarm, force termination without prompting user for confirmation. Defaults to False')
     parser.add_argument('-t', '--launchtime', type=str,
@@ -280,9 +286,23 @@ def main(args):
 
     if args.task == 'terminaterunfarm':
         runtime_conf = RuntimeConfig(args)
-        terminaterunfarm(runtime_conf, args.terminatesomef116,
-                         args.terminatesomef14,
-                         args.terminatesomef12, args.terminatesomem416,
+
+        terminate_some_dict = dict()
+        if args.terminatesome is not None:
+            for pair in args.terminatesome:
+                terminate_some_dict[pair[0]] = pair[1]
+
+        def old_style_terminate_args(instance_type, arg_val, arg_flag_str):
+            if arg_val != -1:
+                rootLogger.critical("WARNING: You are using the old-style " + arg_flag_str + " flag. See the new --terminatesome flag in help. The old-style flag will be removed in the next major FireSim release (1.15.X).")
+                terminate_some_dict[instance_type] = arg_val
+
+        old_style_terminate_args('f1.16xlarge', args.terminatesomef116, '--terminatesomef116')
+        old_style_terminate_args('f1.4xlarge', args.terminatesomef14, '--terminatesomef14')
+        old_style_terminate_args('f1.2xlarge', args.terminatesomef12, '--terminatesomef12')
+        old_style_terminate_args('m4.16xlarge', args.terminatesomem416, '--terminatesomem416')
+
+        terminaterunfarm(runtime_conf, terminate_some_dict,
                          args.forceterminate)
 
     if args.task in ['launchrunfarm', 'infrasetup', 'boot', 'kill', 'runworkload', 'runcheck']:

--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -159,9 +159,11 @@ class FireSimServerNode(FireSimNode):
 
     def __init__(self, server_hardware_config=None, server_link_latency=None,
                  server_bw_max=None, server_profile_interval=None,
-                 trace_enable=None, trace_select=None, trace_start=None, trace_end=None, trace_output_format=None, autocounter_readrate=None,
-                 zerooutdram=None, disable_asserts=None,
-                 print_start=None, print_end=None, print_cycle_prefix=None):
+                 trace_enable=None, trace_select=None, trace_start=None,
+                 trace_end=None, trace_output_format=None,
+                 autocounter_readrate=None, zerooutdram=None,
+                 disable_asserts=None, print_start=None, print_end=None,
+                 print_cycle_prefix=None, plusarg_passthrough=""):
         super(FireSimServerNode, self).__init__()
         self.server_hardware_config = server_hardware_config
         self.server_link_latency = server_link_latency
@@ -180,6 +182,7 @@ class FireSimServerNode(FireSimNode):
         self.print_cycle_prefix = print_cycle_prefix
         self.job = None
         self.server_id_internal = FireSimServerNode.SERVERS_CREATED
+        self.plusarg_passthrough = plusarg_passthrough
         FireSimServerNode.SERVERS_CREATED += 1
 
     def set_server_hardware_config(self, server_hardware_config):
@@ -252,7 +255,8 @@ class FireSimServerNode(FireSimNode):
             self.server_profile_interval, all_bootbins, self.trace_enable,
             self.trace_select, self.trace_start, self.trace_end, self.trace_output_format,
             self.autocounter_readrate, all_shmemportnames, self.zerooutdram, self.disable_asserts,
-            self.print_start, self.print_end, self.print_cycle_prefix)
+            self.print_start, self.print_end, self.print_cycle_prefix,
+            self.plusarg_passthrough)
 
         run(runcommand)
 
@@ -497,7 +501,9 @@ class FireSimSuperNodeServerNode(FireSimServerNode):
             slotno, all_macs, all_rootfses, all_linklatencies, all_maxbws,
             self.server_profile_interval, all_bootbins, self.trace_enable,
             self.trace_select, self.trace_start, self.trace_end, self.trace_output_format,
-            self.autocounter_readrate, all_shmemportnames, self.zerooutdram)
+            self.autocounter_readrate, all_shmemportnames, self.zerooutdram,
+            self.disable_asserts, self.print_start, self.print_end,
+            self.print_cycle_prefix, self.plusarg_passthrough)
 
         run(runcommand)
 

--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -395,7 +395,8 @@ class FireSimServerNode(FireSimNode):
 class FireSimSuperNodeServerNode(FireSimServerNode):
     """ This is the main server node for supernode mode. This knows how to
     call out to dummy server nodes to get all the info to launch the one
-    command line to run the FPGA sim that has N > 1 sims on one fpga."""
+    command line to run the sim that has N > 1 copies of the design in one
+    simulation instance (e.g. on one FPGA)."""
 
     def copy_back_job_results_from_run(self, slotno):
         """ This override is to call copy back job results for all the dummy nodes too. """

--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -274,7 +274,7 @@ class FireSimServerNode(FireSimNode):
             localcap = local("""mkdir -p {}""".format(job_dir), capture=True)
             rootLogger.debug("[localhost] " + str(localcap))
             rootLogger.debug("[localhost] " + str(localcap.stderr))
-            
+
             # add hw config summary per job
             localcap = local("""echo "{}" > {}/HW_CFG_SUMMARY""".format(str(self.server_hardware_config), job_dir), capture=True)
             rootLogger.debug("[localhost] " + str(localcap))

--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -199,8 +199,9 @@ class FireSimTopologyWithPasses:
             else:
                 assert False, "Mixed downlinks currently not supported."""
 
-    def mapping_use_one_8_fpga_host(self):
-        """ Just put everything on one host that has at least 8 fpgas."""
+    def mapping_use_one_8_slot_host(self):
+        """ Just put everything on one host that has at least 8 simulation slots
+        (e.g. 8 fpgas)."""
 
         switches = self.firesimtopol.get_dfs_order_switches()
         instance_type = self.run_farm.mapper_get_min_sim_host_inst_type_name(8)
@@ -354,12 +355,12 @@ class FireSimTopologyWithPasses:
         self.pass_create_topology_diagram()
 
     def pass_build_required_drivers(self):
-        """ Build all FPGA drivers. The method we're calling here won't actually
+        """ Build all simulation drivers. The method we're calling here won't actually
         repeat the build process more than once per run of the manager. """
         servers = self.firesimtopol.get_dfs_order_servers()
 
         for server in servers:
-            server.get_server_hardware_config().build_fpga_driver()
+            server.get_server_hardware_config().build_sim_driver()
 
     def pass_build_required_switches(self):
         """ Build all the switches required for this simulation. """

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -669,15 +669,17 @@ class InstanceDeployManager:
             self.load_nbd_module()
 
             # clear/flash fpgas
-            self.clear_fpgas()
-            self.flash_fpgas()
+            print("TODO: fix this")
+            #self.clear_fpgas()
+            #self.flash_fpgas()
 
             # re-load XDMA
             self.load_xdma()
 
             #restart (or start form scratch) ila server
-            self.kill_ila_server()
-            self.start_ila_server()
+            print("TODO: fix this")
+            #self.kill_ila_server()
+            #self.start_ila_server()
 
         if self.instance_assigned_switches():
             # all nodes could have a switch

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -224,6 +224,9 @@ class RuntimeHWConfig:
              prefix('set -o pipefail'):
             localcap = None
             with settings(warn_only=True):
+                # the local driver dir must already exist for the tee to always
+                # work
+                local("""mkdir -p {}""".format(self.get_local_driver_dir()))
                 buildlogfile = """{}firesim-manager-make-{}-temp-output-log""".format(self.get_local_driver_dir(), self.driver_build_target)
                 driverbuildcommand = """make DESIGN={} TARGET_CONFIG={} PLATFORM_CONFIG={} {}""" .format(design, target_config, platform_config, self.driver_build_target)
                 driverbuildcommand_full = driverbuildcommand + """ 2>&1 | tee {}""".format(buildlogfile)

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -97,7 +97,7 @@ class RuntimeHWConfig:
     def get_local_runtime_conf_path(self):
         """ return relative local path of the runtime conf used to run this sim. """
         my_deploytriplet = self.get_deploytriplet_for_config()
-        drivers_software_base = self.local_driver_base_dir + "/" + my_deploytriplet + "/"
+        drivers_software_base = LOCAL_DRIVERS_GENERATED_SRC + "/" + my_deploytriplet + "/"
         my_runtimeconfig = self.customruntimeconfig
         if my_runtimeconfig is None:
             runtime_conf_local = drivers_software_base + self.get_local_runtimeconf_binaryname()

--- a/deploy/runtools/user_topology.py
+++ b/deploy/runtools/user_topology.py
@@ -104,7 +104,7 @@ class UserTopologies(object):
             useful for performing the mapping."""
 
             # map the fat tree onto one switch host instance (for core switches)
-            # and two 8-fpga instances
+            # and two 8-sim-slot (e.g. 8-fpga) instances
             # (e.g., two pods of aggr/edge/4sims per f1.16xlarge)
 
             switch_inst_type = fsim_topol_with_passes.run_farm.mapper_get_default_switch_host_inst_type_name()
@@ -113,8 +113,8 @@ class UserTopologies(object):
             for core in coreswitches:
                 switch_inst.add_switch(core)
 
-            eight_fpga_host_type = fsim_topol_with_passes.run_farm.mapper_get_min_sim_host_inst_type_name(8)
-            sim_hosts = [fsim_topol_with_passes.run_farm.mapper_alloc_instance(eight_fpga_host_type) for _ in range(2)]
+            eight_sim_host_type = fsim_topol_with_passes.run_farm.mapper_get_min_sim_host_inst_type_name(8)
+            sim_hosts = [fsim_topol_with_passes.run_farm.mapper_alloc_instance(eight_sim_host_type) for _ in range(2)]
 
             for aggrsw in aggrswitches[:4]:
                 sim_hosts[0].add_switch(aggrsw)
@@ -167,7 +167,7 @@ class UserTopologies(object):
         midswitches[1].add_downlinks([servers[1]])
 
     def small_hierarchy_8sims(self):
-        self.custom_mapper = 'mapping_use_one_8_fpga_host'
+        self.custom_mapper = 'mapping_use_one_8_slot_host'
         self.roots = [FireSimSwitchNode()]
         midlevel = [FireSimSwitchNode() for x in range(4)]
         servers = [[FireSimServerNode() for x in range(2)] for x in range(4)]
@@ -176,7 +176,7 @@ class UserTopologies(object):
             midlevel[swno].add_downlinks(servers[swno])
 
     def small_hierarchy_2sims(self):
-        self.custom_mapper = 'mapping_use_one_8_fpga_host'
+        self.custom_mapper = 'mapping_use_one_8_slot_host'
         self.roots = [FireSimSwitchNode()]
         midlevel = [FireSimSwitchNode() for x in range(1)]
         servers = [[FireSimServerNode() for x in range(2)] for x in range(1)]

--- a/deploy/runtools/user_topology.py
+++ b/deploy/runtools/user_topology.py
@@ -94,7 +94,7 @@ class UserTopologies(object):
             """ In a custom mapper, you have access to the firesim topology with passes,
             where you can access the run_farm instance objects via the
 
-            fsim_topol_with_passes.mapper_* functions.
+            fsim_topol_with_passes.run_farm.mapper_* functions.
 
             To map, call add_switch or add_simulation on run farm instance
             objs in the aforementioned arrays.

--- a/deploy/sample-backup-configs/sample_config_build_recipes.ini
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.ini
@@ -17,6 +17,7 @@ TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHigh
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
+metasim_customruntimeconfig=None
 
 # NB: This has a faster host-clock frequency than the NIC-based design, because
 # its uncore runs at half rate relative to the tile.
@@ -26,7 +27,7 @@ TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConf
 PLATFORM_CONFIG=F140MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
+metasim_customruntimeconfig=None
 
 # Single-core, BOOM-based recipes
 [firesim-boom-singlecore-nic-l2-llc4mb-ddr3]
@@ -35,6 +36,7 @@ TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHigh
 PLATFORM_CONFIG=F65MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
+metasim_customruntimeconfig=None
 
 # NB: This has a faster host-clock frequency than the NIC-based design, because
 # its uncore runs at half rate relative to the tile.
@@ -44,7 +46,7 @@ TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConf
 PLATFORM_CONFIG=F75MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
+metasim_customruntimeconfig=None
 
 # Single-core, CVA6-based recipes
 [firesim-cva6-singlecore-no-nic-l2-llc4mb-ddr3]
@@ -53,7 +55,7 @@ TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks
 PLATFORM_CONFIG=F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
+metasim_customruntimeconfig=None
 
 # Single-core, Rocket-based recipes with Gemmini
 [firesim-rocket-singlecore-gemmini-no-nic-l2-llc4mb-ddr3]
@@ -62,7 +64,7 @@ TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks
 PLATFORM_CONFIG=F30MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
+metasim_customruntimeconfig=None
 
 # RAM Optimizations enabled by adding _MCRams PLATFORM_CONFIG string
 [firesim-boom-singlecore-no-nic-l2-llc4mb-ddr3-ramopts]
@@ -71,7 +73,7 @@ TARGET_CONFIG=DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConf
 PLATFORM_CONFIG=MCRams_F90MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
-
+metasim_customruntimeconfig=None
 
 # Supernode configurations -- multiple instances of an SoC in a single simulator
 [firesim-supernode-rocket-singlecore-nic-l2-lbp]
@@ -80,6 +82,7 @@ TARGET_CONFIG=WithNIC_SupernodeFireSimRocketConfig
 PLATFORM_CONFIG=F85MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
+metasim_customruntimeconfig=None
 
 # MIDAS Examples -- BUILD SUPPORT ONLY; Can't launch driver correctly on runfarm
 [midasexamples-gcd]
@@ -89,3 +92,5 @@ TARGET_CONFIG=NoConfig
 PLATFORM_CONFIG=DefaultF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
+metasim_customruntimeconfig=None
+

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -6,11 +6,6 @@
 runfarmtag=mainrunfarm
 always_expand_runfarm=yes
 
-#f1_16xlarges=1
-#m4_16xlarges=0
-#f1_4xlarges=0
-#f1_2xlarges=0
-
 launch_instances_timeout_minutes=60
 
 runinstancemarket=ondemand
@@ -40,7 +35,7 @@ netbandwidth=200
 profileinterval=-1
 
 # This references a section from config_hwdb.ini for fpga-accelerated simulation
-# or from build_recipes.ini for metasimulation
+# or from config_build_recipes.ini for metasimulation
 # In homogeneous configurations, use this to set the hardware config deployed
 # for all simulators
 defaulthwconfig=firesim-rocket-quadcore-nic-l2-llc4mb-ddr3

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -15,13 +15,22 @@ spotmaxprice=ondemand
 [runfarminstances]
 # specify counts of instances you want in your run farm, in the format:
 # instance_type_name=count
+
+# fpga-sim instances
 f1.16xlarge=1
-m4.16xlarge=0
 f1.4xlarge=0
 f1.2xlarge=0
 
+# switch-sim-only instances
+m4.16xlarge=0
+
+# metasim instances
+z1d.3xlarge=0
+z1d.6xlarge=0
+z1d.12xlarge=0
+
 [metasimulation]
-metasimulation_enabled=yes
+metasimulation_enabled=no
 # vcs or verilator. use vcs-debug or verilator-debug for waveform generation
 metasimulation_host_simulator=verilator
 
@@ -39,6 +48,10 @@ profileinterval=-1
 # In homogeneous configurations, use this to set the hardware config deployed
 # for all simulators
 defaulthwconfig=firesim-rocket-quadcore-nic-l2-llc4mb-ddr3
+
+# Advanced: Specify any extra plusargs you would like to provide when booting
+# the simulator.
+plusarg_passthrough=""
 
 [tracing]
 enable=no

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -17,6 +17,11 @@ runinstancemarket=ondemand
 spotinterruptionbehavior=terminate
 spotmaxprice=ondemand
 
+[metasimulation]
+metasimulation_enabled=yes
+metasimulation_host_simulator=verilator
+metasimulation_waveform_enabled=no
+
 [targetconfig]
 #Set topology=no_net_config to run without a network simulation
 topology=example_8config

--- a/deploy/sample-backup-configs/sample_config_runtime.ini
+++ b/deploy/sample-backup-configs/sample_config_runtime.ini
@@ -6,10 +6,10 @@
 runfarmtag=mainrunfarm
 always_expand_runfarm=yes
 
-f1_16xlarges=1
-m4_16xlarges=0
-f1_4xlarges=0
-f1_2xlarges=0
+#f1_16xlarges=1
+#m4_16xlarges=0
+#f1_4xlarges=0
+#f1_2xlarges=0
 
 launch_instances_timeout_minutes=60
 
@@ -17,10 +17,18 @@ runinstancemarket=ondemand
 spotinterruptionbehavior=terminate
 spotmaxprice=ondemand
 
+[runfarminstances]
+# specify counts of instances you want in your run farm, in the format:
+# instance_type_name=count
+f1.16xlarge=1
+m4.16xlarge=0
+f1.4xlarge=0
+f1.2xlarge=0
+
 [metasimulation]
 metasimulation_enabled=yes
+# vcs or verilator. use vcs-debug or verilator-debug for waveform generation
 metasimulation_host_simulator=verilator
-metasimulation_waveform_enabled=no
 
 [targetconfig]
 #Set topology=no_net_config to run without a network simulation
@@ -31,7 +39,8 @@ switchinglatency=10
 netbandwidth=200
 profileinterval=-1
 
-# This references a section from config_build_recipes.ini
+# This references a section from config_hwdb.ini for fpga-accelerated simulation
+# or from build_recipes.ini for metasimulation
 # In homogeneous configurations, use this to set the hardware config deployed
 # for all simulators
 defaulthwconfig=firesim-rocket-quadcore-nic-l2-llc4mb-ddr3

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -173,8 +173,6 @@ $(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -lfpga_mgmt
 $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	mkdir -p $(OUTPUT_DIR)/build
 	cp $(header) $(OUTPUT_DIR)/build/
-	# The manager expects to find the default conf in output/ by this name
-	cp -f $(GENERATED_DIR)/$(CONF_NAME) $(OUTPUT_DIR)/runtime.conf
 	$(MAKE) -C $(simif_dir) f1 PLATFORM=f1 DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
 	GEN_DIR=$(OUTPUT_DIR)/build OUT_DIR=$(OUTPUT_DIR) DRIVER="$(DRIVER_CC)" \
 	TOP_DIR=$(chipyard_dir)


### PR DESCRIPTION
This PR adds manager support for deploying metasimulations (verilator/vcs) to ec2 instances.

As a user, you just set `metasimulation_enabled=yes` in `config_runtime.ini`
and indicate the correct counts of `z1d.Nxlarge` instances in `config_runtime.ini`.
Everything else is identical to deploying fpga sims. You still do the usual
`firesim launchrunfarm/infrasetup/runworkload/terminaterunfarm` sequence and
every option the manager supports to configure fpga sims should automatically
work too.

# Motivations:

* single definition of your config in build recipes
* single definition of your workload via firemarshal
* (obvious one) use many host instances when you have too many/too large metasims to run on one host
* easy to run -debug and non-debug vcs/verilator runs at the same time
* networked designs can now easily do vcs/verilator server sim using C++ switch model
* CI can (in theory, not added in this PR) exercise large parts of the manager without involving FPGAs at all

# Summary of changes in this PR:

* The manager can now run metasims. The overall approach with these changes is to minimize the difference between code-paths followed for fpga sim vs. metasim.
* Includes various changes to simplify future multi-platform support that arose as a result of trying to minimize differences between metasim/fpga sim
    * No more hard-coded per-instance-type python classes. We now have arbitrary instance type support in all commands, e.g., new `--terminatesome=inst_type:count` flag
    * Topology mapping no longer cares about specific instance types, only the max number of fpgas (or supported metasims) a machine has
    * All `config_*.ini` changes and flag changes are backwards compatible and deprecation warnings have been added
        * The only somewhat-"user" facing API without backwards compatibility is specification of user topologies that use custom mappers.
* Manager now supports plusarg passthrough (closes #656)
* Fixes long-standing issue with not being able to print driver build progress from manager with `tee` and `cat` (fabric still cannot simultaneously capture and print `local()` calls, AFAIK)


# UI / API Impact:

* `config_runtime.ini` has a new section:

        [metasimulation]
        # turns metasim on/off
        metasimulation_enabled={yes,no}
        # select metasim host simulator
        metasimulation_host_simulator={verilator,verilator-debug,vcs,vcs-debug}


* `config_runtime.ini`: `defaulthwconfig` points to an entry from `config_hwdb.ini` for fpga runs (as before) or a `config_build_recipes.ini` entry for metasim runs (and this is noted in the inline comment on `defaulthwconfig`)

* `config_runtime.ini`: has a new `plusarg_passthrough=""` field in `[targetconfig]`

* `config_runtime.ini`: `f1_16xlarges=`, `f1_2xlarges=`, `...` are moved into their own section:

        [runfarminstances]
        f1.16xlarge=N
        f1.2xlarge=N
        [any instance type is supported, assuming it's allowed in run farm definition]

    * Right now, what is "allowed" is defined in three dicts at the top of `RunFarm` in `run_farm.py`. All other manager code now does not care about specific instance names. e.g. If an `f1.256xlarge` instance were released, the only place it needs to be added is the 3 dicts at the top of `RunFarm` and in the `[runfarminstances]` section.

    * I assume it's up to the where-to-run PR to factor "what kinds of instances are allowed" into a config file, so I didn't re-do it here. Presumably things like metasims supported per-machine/instance and fpgas per-machine/instance should also end up in such a file. Changing this on-the-fly, i.e. not in manager python code, is very useful for metasims in particular.

* `config_build_recipes.ini`: build recipes get a new field, `metasim_customruntimeconfig=None`, which can point to a custom runtime config used for metasim

* `--terminatesome{f116,f14,f12,m116}=count` flags to the manager are all deprecated. The user can instead specify an arbitrary number of: `--terminatesome=INST_TYPE:count` flags.


# Remaining TODOs:

* add documentation (pending review / merge with where-to-run PR)
* configurable number of sims per node (need to work with where-to-run PR)
    * relatedly, how to expose instances' disk size as a config option, which is particularly problematic now with metasim waveforms.
* spike-dasm support
* (maybe) xsim fpga-level sim support? It's probably easier to just add it to the manager so it can easily run in CI, instead of scripting it up some other way.

# Related PRs / Issues

* @abejgonzalez will factor out where-to-run changes from local-fpga so we can compare diffs and resolve
* Closes #656, plusarg passthrough

# Verilog / AGFI Compatibility

N/A

# Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

# Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
