### PR TITLE
Rename `mod` to `target` in `SynthPrintfAnnotation` annotation

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
+++ b/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
@@ -66,7 +66,7 @@ private[passes] class PrintSynthesis extends firrtl.Transform {
     def portRT(p: Port): ReferenceTarget = ModuleTarget(c.main, c.main).ref(p.name)
     def portClockRT(p: Port): ReferenceTarget = portRT(p).field("clock")
 
-    val modToAnnos = printfAnnos.groupBy(_.mod)
+    val modToAnnos = printfAnnos.groupBy(_.target)
     val topWiringAnnos = mutable.ArrayBuffer[Annotation]()
 
     def onModule(m: DefModule): DefModule = m match {
@@ -88,9 +88,9 @@ private[passes] class PrintSynthesis extends firrtl.Transform {
                   WSubField(WRef(wire), s"args_${idx}"),
                   arg)})
 
-        val printBundleTarget = associatedAnno.mod.ref(printName)
+        val printBundleTarget = associatedAnno.target.ref(printName)
         val clockTarget = clk match {
-          case WRef(name,_,_,_) => associatedAnno.mod.ref(name)
+          case WRef(name,_,_,_) => associatedAnno.target.ref(name)
           case o => ???
         }
         topWiringAnnos += BridgeTopWiringAnnotation(printBundleTarget, clockTarget)

--- a/sim/midas/targetutils/src/main/scala/midas/annotations.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/annotations.scala
@@ -45,16 +45,16 @@ private[midas] class ReferenceTargetRenamer(renames: RenameMap) {
 
 private [midas] case class SynthPrintfAnnotation(
     args: Seq[Seq[ReferenceTarget]], // These aren't currently used; here for future proofing
-    mod: ModuleTarget,
+    target: ModuleTarget,
     format: String,
     name: Option[String]) extends firrtl.annotations.Annotation {
 
   def update(renames: RenameMap): Seq[firrtl.annotations.Annotation] = {
     val renamer = new ReferenceTargetRenamer(renames)
     val renamedArgs = args.map(_.flatMap(renamer(_)))
-    val renamedMod = renames.get(mod).getOrElse(Seq(mod)).collect({ case mt: ModuleTarget => mt })
+    val renamedMod = renames.get(target).getOrElse(Seq(target)).collect({ case mt: ModuleTarget => mt })
     assert(renamedMod.size == 1) // To implement: handle module duplication or deletion
-    Seq(this.copy(args = renamedArgs, mod = renamedMod.head ))
+    Seq(this.copy(args = renamedArgs, target = renamedMod.head ))
   }
 }
 
@@ -62,7 +62,7 @@ private [midas] case class SynthPrintfAnnotation(
 private[midas] case class ChiselSynthPrintfAnnotation(
     format: String,
     args: Seq[Bits],
-    mod: BaseModule,
+    target: BaseModule,
     name: Option[String]) extends ChiselAnnotation {
   def getTargetsFromArg(arg: Bits): Seq[ReferenceTarget] = {
     // To named throughs an exception on literals right now, so dumbly catch everything
@@ -74,7 +74,7 @@ private[midas] case class ChiselSynthPrintfAnnotation(
   }
 
   def toFirrtl() = SynthPrintfAnnotation(args.map(getTargetsFromArg),
-                                         mod.toNamed.toTarget, format, name)
+                                         target.toNamed.toTarget, format, name)
 }
 
 // For now, this needs to be invoked on the arguments to printf, not on the printf itself


### PR DESCRIPTION
Renamed the `mod` field to `target` to allow CIRCT to move the annotation from the `CircuitOp` to the `FModuleOp` which contains the annotated `PrintFOp`.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

`SynthPrintfAnnotation` is private to firesim.

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
