### PR TITLE
[Docs] Add a role :gh-file-ref: to simplify Github.com file references

### DIFF
--- a/docs/Advanced-Usage/Generating-Different-Targets.rst
+++ b/docs/Advanced-Usage/Generating-Different-Targets.rst
@@ -118,8 +118,8 @@ resides in ``sim/``.  These projects are:
 1. **firesim** (Default): rocket chip-based targets. These include targets with
    either BOOM or rocket pipelines, and should be your starting point if you're
    building an SoC with the Rocket Chip generator.
-2. **midasexamples**: the `Golden Gate example designs
-   <https://github.com/firesim/firesim/tree/dev/sim/src/main/scala/midasexamples>`_, a set of simple chisel
+2. **midasexamples**: the Golden Gate example designs. Located at
+   :gh-file-ref:`sim/src/main/scala/midasexamples`, these are a set of simple chisel
    circuits like GCD, that demonstrate how to use Golden Gate.  These are useful test
    cases for bringing up new Golden Gate features.
 3. **fasedtests**: designs to do integration testing of FASED memory-system timing models.

--- a/docs/Developer-Docs/GoldenGate-and-Driver-Development.rst
+++ b/docs/Developer-Docs/GoldenGate-and-Driver-Development.rst
@@ -46,17 +46,17 @@ them on Scala changes (but not driver changes). Out of ``sim/``::
 
 Key Files & Locations
 ---------------------
-- `sim/firesim-lib/src/test/scala/TestSuiteCommon.scala <https://github.com/firesim/firesim/blob/ |version| /sim/firesim-lib/src/test/scala/TestSuiteCommon.scala>`_
+- :gh-file-ref:`sim/firesim-lib/src/test/scala/TestSuiteCommon.scala`
    Base ScalaTest class for all tests that use FireSim's make build system
-- `sim/src/test/scala/midasexamples/TutorialSuite.scala <https://github.com/firesim/firesim/blob/ |version| /sim/src/test/scala/midasexamples/TutorialSuite.scala>`_
+- :gh-file-ref:`sim/src/test/scala/midasexamples/TutorialSuite.scala`
    Extension of TestSuiteCommon for most integration tests + concrete subclasses
-- `sim/src/main/cc/midasexamples/ <https://github.com/firesim/firesim/blob/ |version| /sim/src/main/cc/midasexamples/>`_
+- :gh-file-ref:`sim/src/main/cc/midasexamples/`
    C++ sources for target-specific drivers
-- `sim/src/main/cc/midasexamples/Driver.cc <https://github.com/firesim/firesim/blob/ |version| /sim/src/main/cc/midasexamples/Driver.cc>`_
+- :gh-file-ref:`sim/src/main/cc/midasexamples/Driver.cc`
    driver main; where target-specific drivers are registered
-- `sim/src/main/cc/midasexamples/simif_peek_poke.h <https://github.com/firesim/firesim/blob/ |version| /sim/src/main/cc/midasexamples/simif_peek_poke.h>`_
+- :gh-file-ref:`sim/src/main/cc/midasexamples/simif_peek_poke.h`
    A common driver to extend for simple tests
-- `sim/src/scala/midasexamples/ <https://github.com/firesim/firesim/tree/ |version| /sim/src/main/scala/midasexamples>`_
+- :gh-file-ref:`sim/src/main/scala/midasexamples/`
    Where top-level Chisel modules (targets) are defined
 
 Defining a New Test
@@ -103,11 +103,11 @@ under ``WithAllUnitTests`` class are run from ScalaTest and in CI.
 Key Files & Locations
 ---------------------
 
-- `sim/midas/src/main/scala/midas/SynthUnitTests.scala <https://github.com/firesim/firesim/blob/ |version| /sim/midas/src/main/scala/midas/SynthUnitTests.scala>`_
+- :gh-file-ref:`sim/midas/src/main/scala/midas/SynthUnitTests.scala`
    Synthesizable unit test modules are registered here.
-- `sim/midas/src/main/cc/unittest/Makefrag: <https://github.com/firesim/firesim/blob/ |version| /sim/midas/src/main/cc/unittest/Makefrag>`_
+- :gh-file-ref:`sim/midas/src/main/cc/unittest/Makefrag`
    Make recipes for building and running the tests.
-- `sim/firesim-lib/src/test/scala/TestSuiteCommon.scala <https://github.com/firesim/firesim/blob/ |version| /sim/firesim-lib/src/test/scala/TestSuiteCommon.scala>`_
+- :gh-file-ref:`sim/firesim-lib/src/test/scala/TestSuiteCommon.scala`
    ScalaTest wrappers for running synthesizable unittests
 
 Defining a New Test
@@ -143,9 +143,9 @@ to ``midas``, as in step 2 above.
 Key Files & Locations
 ---------------------
 
-- `sim/midas/src/test/scala/midas <https://github.com/firesim/firesim/tree/ |version| /sim/midas/src/test/scala/midas>`_
+- :gh-file-ref:`sim/midas/src/test/scala/midas`
    Location of GoldenGate ScalaTests
-- `sim/midas/targetutils/src/test/scala <https://github.com/firesim/firesim/tree/ |version| /sim/midas/targetutils/src/test/scala>`_
+- :gh-file-ref:`sim/midas/targetutils/src/test/scala`
    Location of targetutils ScalaTests
 
 Defining A New Test

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==1.8.5
 Pygments==2.7.4
 sphinx-autobuild
 sphinx_rtd_theme==0.2.5b1
+requests==2.26.0


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Provides a `docutil` role to make it a little easier to inline references to files and trees on github.com. The role also checks that the URL doesn't produce a 404, which adds a little extra build time but also helps find dead links when the role is first used and when files change in the repo. 

#### Related PRs / Issues

Addresses the major criticism of #1004 

#### UI / API Impact

None.
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

No change.
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
