### PR TITLE
Propagate manager tags to child instances

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -359,6 +359,20 @@ def launch_instances(instancetype: str, count: int, instancemarket: str, spotint
 
     first_subnet_wraparound = None
 
+    # append the tags from the manager to the launched instance
+    extra_tags = get_localhost_instance_tags()
+    extra_tags.pop('Name', None)
+    # only for ci, avoid naming child launched instances "ci-manager"
+    # to avoid ci erroring on finding multiple "manager" instances
+    for k in extra_tags.keys():
+        if "ci-manager" in k:
+            del extra_tags[k]
+    if tags is None:
+        tags = extra_tags
+    else:
+        tags.update(extra_tags)
+    rootLogger.debug(tags)
+
     while len(instances) < count:
         chosensubnet = subnets[startsubnet].subnet_id
         try:


### PR DESCRIPTION
In CI there are some cases where instances launched from a specific manager are not shut down. This PR addresses this by propagating all tags associated with the manager (except for tags that have the word `ci-manager` in the name) to child instances spawned from that manager. This should allow the "cull instances" CI job to remove leftover instances.

#### Related PRs / Issues

N/A

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
