### PR TITLE
Move C++ implementation of bridge streams out of bridge drivers.

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -9,27 +9,23 @@
 # If you are using an older version of FireSim, you will need to generate your
 # own images.
 
-firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-02d92ba19f0ccc4d8
-    deploy_triplet_override: null
-    custom_runtime_config: null
-
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-09628426dfa714976
+    agfi: agfi-01c17c53630fe044f
     deploy_triplet_override: null
     custom_runtime_config: null
-
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0dfa5d15a4becb5db
+    agfi: agfi-0c3c86fab1a7e6c26
     deploy_triplet_override: null
     custom_runtime_config: null
-
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-081255e6e4e2d3fcb
+    agfi: agfi-05153730f5919b6ab
     deploy_triplet_override: null
     custom_runtime_config: null
-
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-080285efd8520fb27
+    agfi: agfi-00ee1c6185af3e983
+    deploy_triplet_override: null
+    custom_runtime_config: null
+firesim_supernode_rocket_singlecore_nic_l2_lbp:
+    agfi: agfi-0b81b05e4107813a1
     deploy_triplet_override: null
     custom_runtime_config: null

--- a/sim/firesim-lib/src/main/cc/bridges/dromajo.h
+++ b/sim/firesim-lib/src/main/cc/bridges/dromajo.h
@@ -21,9 +21,8 @@ class dromajo_t: public bridge_driver_t
             int tval_width,
             int num_traces,
             DROMAJOBRIDGEMODULE_struct * mmio_addrs,
-            long dma_addr,
-            const unsigned int stream_count_address,
-            const unsigned int stream_full_address
+            int stream_idx,
+            int stream_depth
             );
         ~dromajo_t();
 
@@ -39,7 +38,7 @@ class dromajo_t: public bridge_driver_t
 
         int invoke_dromajo(uint8_t* buf);
         int beats_available_stable();
-        void process_tokens(int num_beats);
+        size_t process_tokens(int num_beats, size_t minimum_batch_beats);
         void flush();
 
         // in bytes

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.h
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.h
@@ -10,15 +10,28 @@
 #define MAX_BANDWIDTH 200
 
 #ifdef SIMPLENICBRIDGEMODULE_struct_guard
+
+#define INSTANTIATE_SIMPLENIC(FUNC,IDX) \
+    SIMPLENICBRIDGEMODULE_ ## IDX ## _substruct_create; \
+    FUNC(new simplenic_t( \
+        this, \
+        args, \
+        SIMPLENICBRIDGEMODULE_ ## IDX ## _substruct, \
+        IDX, \
+        SIMPLENICBRIDGEMODULE_ ## IDX ## _to_cpu_stream_idx, \
+        SIMPLENICBRIDGEMODULE_ ## IDX ## _to_cpu_stream_depth, \
+        SIMPLENICBRIDGEMODULE_ ## IDX ## _from_cpu_stream_idx, \
+        SIMPLENICBRIDGEMODULE_ ## IDX ## _from_cpu_stream_depth)); \
+
 class simplenic_t: public bridge_driver_t
 {
     public:
         simplenic_t(simif_t* sim, std::vector<std::string> &args,
             SIMPLENICBRIDGEMODULE_struct *addrs, int simplenicno,
-            const unsigned int stream_to_cpu_count_address,
-            long               stream_to_cpu_dma_address,
-            const unsigned int stream_from_cpu_count_address,
-            long               stream_from_cpu_dma_address);
+            const int stream_to_cpu_idx,
+            const int stream_to_cpu_depth,
+            const int stream_from_cpu_idx,
+            const int stream_from_cpu_depth);
         ~simplenic_t();
 
         virtual void init();
@@ -55,10 +68,10 @@ class simplenic_t: public bridge_driver_t
         // only for TOKENVERIFY
         uint64_t timeelapsed_cycles = 0;
 
-        const unsigned int stream_to_cpu_count_address;
-        long               stream_to_cpu_dma_address;
-        const unsigned int stream_from_cpu_count_address;
-        long               stream_from_cpu_dma_address;
+        const int stream_to_cpu_idx;
+        const int stream_to_cpu_depth;
+        const int stream_from_cpu_idx;
+        const int stream_from_cpu_depth;
 };
 #endif // SIMPLENICBRIDGEMODULE_struct_guard
 

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.h
@@ -17,9 +17,8 @@
         this, \
         args, \
         TRACERVBRIDGEMODULE_ ## IDX ## _substruct, \
-        TRACERVBRIDGEMODULE_ ## IDX ## _to_cpu_stream_dma_address, \
-        TRACERVBRIDGEMODULE_ ## IDX ## _to_cpu_stream_count_address, \
-        TRACERVBRIDGEMODULE_ ## IDX ## _to_cpu_stream_full_address, \
+        TRACERVBRIDGEMODULE_ ## IDX ## _to_cpu_stream_idx, \
+        TRACERVBRIDGEMODULE_ ## IDX ## _to_cpu_stream_depth, \
         TRACERVBRIDGEMODULE_ ## IDX ## _max_core_ipc, \
         TRACERVBRIDGEMODULE_ ## IDX ## _clock_domain_name, \
         TRACERVBRIDGEMODULE_ ## IDX ## _clock_multiplier, \
@@ -33,9 +32,8 @@ class tracerv_t: public bridge_driver_t
         tracerv_t(simif_t *sim,
                   std::vector<std::string> &args,
                   TRACERVBRIDGEMODULE_struct * mmio_addrs,
-                  const unsigned int dma_address,
-                  const unsigned int stream_count_address,
-                  const unsigned int stream_full_address,
+                  const int stream_idx,
+                  const int stream_depth,
                   const unsigned int max_core_ipc,
                   const char* const  clock_domain_name,
                   const unsigned int clock_multiplier,
@@ -51,9 +49,8 @@ class tracerv_t: public bridge_driver_t
 
     private:
         TRACERVBRIDGEMODULE_struct * mmio_addrs;
-        const unsigned int dma_address;
-        const unsigned int stream_count_address;
-        const unsigned int stream_full_address;
+        const int stream_idx;
+        const int stream_depth;
         const int max_core_ipc;
         ClockInfo clock_info;
 
@@ -83,7 +80,7 @@ class tracerv_t: public bridge_driver_t
         std::string dwarf_file_name;
         bool fireperf = false;
 
-        void process_tokens(int num_beats);
+        size_t process_tokens(int num_beats, int minium_batch_beats);
         int beats_available_stable();
         void flush();
 };

--- a/sim/midas/src/main/cc/bridges/bridge_driver.h
+++ b/sim/midas/src/main/cc/bridges/bridge_driver.h
@@ -6,11 +6,14 @@
 #include "simif.h"
 
 // DOC include start: Bridge Driver Interface
-// Bridge Drivers are the CPU-hosted component of a Target-to-Host Bridge. A
-// Bridge Driver interacts with their accompanying FPGA-hosted BridgeModule
-// using MMIO (via read() and write() methods) or CPU-mastered DMA (via pull()
-// and push()).
-
+/**
+ * @brief Base class for Bridge Drivers
+ *
+ * Bridge Drivers are the CPU-hosted component of a Target-to-Host Bridge. A
+ * Bridge Driver interacts with their accompanying FPGA-hosted BridgeModule
+ * using MMIO (via read() and write() methods) or bridge streams (via pull()
+ * and push()).
+ */
 class bridge_driver_t
 {
 public:
@@ -43,14 +46,14 @@ protected:
     return sim->read(addr);
   }
 
-  ssize_t pull(size_t addr, char *data, size_t size) {
-    return sim->pull(addr, data, size);
+  size_t pull(unsigned stream_idx, void *data, size_t size, size_t minimum_batch_size) {
+    return sim->pull(stream_idx, data, size, minimum_batch_size);
   }
 
-  ssize_t push(size_t addr, char *data, size_t size) {
+  size_t push(unsigned stream_idx, void *data, size_t size, size_t minimum_batch_size) {
     if (size == 0)
       return 0;
-    return sim->push(addr, data, size);
+    return sim->push(stream_idx, data, size, minimum_batch_size);
   }
 
 private:

--- a/sim/midas/src/main/cc/bridges/cpu_managed_stream.cc
+++ b/sim/midas/src/main/cc/bridges/cpu_managed_stream.cc
@@ -1,0 +1,80 @@
+#include "cpu_managed_stream.h"
+
+#include <iostream>
+#include <assert.h>
+
+/**
+ * @brief Enqueues as much as num_bytes of data into the associated stream
+ *
+ * @param src Source from which to copy data to enqueue
+ * @param num_bytes Desired number of bytes to enqueue
+ * @param required_bytes Minimum number of bytes to enqueue. If fewer bytes
+ *        would be enqueued, this method enqueues none and returns 0.
+ * @return size_t
+ */
+size_t StreamFromCPU::push(void* src, size_t num_bytes, size_t required_bytes) {
+  assert(num_bytes >= required_bytes);
+
+  // Similarly to above, the legacy implementation of DMA does not correctly
+  // implement non-multiples of 512b. The FPGA-side queue will take on the
+  // high-order bytes of the final beat in the transaction, and the strobe is
+  // not respected. So put the assertion here and discuss what to do next.
+  assert((num_bytes % DMA_BEAT_BYTES) == 0);
+
+  auto num_beats = num_bytes / DMA_BEAT_BYTES;
+  auto threshold_beats = required_bytes / DMA_BEAT_BYTES;
+
+  assert(threshold_beats <= this->fpga_buffer_size());
+  auto space_available = this->fpga_buffer_size() - this->mmio_read(this->count_addr());
+
+  if ((space_available == 0) || (space_available < threshold_beats)) {
+    return 0;
+  }
+
+  auto push_beats = std::min(space_available, num_beats);
+  auto push_bytes = push_beats * DMA_BEAT_BYTES;
+  auto bytes_written = pcis_write(this->dma_addr(), (char*) src, push_bytes);
+  assert(bytes_written == push_bytes);
+
+  return bytes_written;
+}
+
+/**
+ * @brief Dequeues as much as num_bytes of data from the associated bridge stream.
+ *
+ * @param dest  Buffer into which to copy dequeued stream data
+ * @param num_bytes  Bytes of data to dequeue
+ * @param required_bytes  Minimum number of bytes to dequeue. If fewer bytes would
+ *        be dequeued, dequeue none and return 0.
+ * @return size_t Number of bytes successfully dequeued
+ */
+size_t StreamToCPU::pull(void* dest, size_t num_bytes, size_t required_bytes) {
+  assert(num_bytes >= required_bytes);
+
+  // The legacy code is clearly broken for requests that aren't a
+  // multiple of 512b since DMA_SIZE is fixed to the full width of the AXI4 IF.
+  // The high-order bytes of the final word will be copied into the destination
+  // buffer (potentially an overflow, bug 1), and since reads are destructive, will not be visible
+  // to future pulls (bug 2). So i've put this assertion here for now...
+
+  // Due to the destructive nature of reads, if we wish to support reads that
+  // aren't a multiple of 512b, we'll need to keep a little buffer around for
+  // the remainder, and prepend this to the destination buffer.
+  assert((num_bytes % DMA_BEAT_BYTES) == 0);
+
+  auto num_beats = num_bytes / DMA_BEAT_BYTES;
+  auto threshold_beats = required_bytes / DMA_BEAT_BYTES;
+
+  assert(threshold_beats <= this->fpga_buffer_size());
+  auto count = this->mmio_read(this->count_addr());
+
+  if ((count == 0) || (count < threshold_beats)) {
+    return 0;
+  }
+
+  auto pull_beats = std::min(count, num_beats);
+  auto pull_bytes = pull_beats * DMA_BEAT_BYTES;
+  auto bytes_read = this->pcis_read(this->dma_addr(), (char*) dest, pull_bytes);
+  assert(bytes_read == pull_bytes);
+  return bytes_read;
+}

--- a/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
+++ b/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
@@ -1,0 +1,107 @@
+// See LICENSE for license details.
+
+#ifndef __CPU_MANAGED_STREAM_H
+#define __CPU_MANAGED_STREAM_H
+
+#include <string>
+#include <functional>
+/**
+ * @brief Parameters emitted for a CPU-managed stream emitted by Golden Gate.
+ *
+ * This will be replaced by a protobuf-derived class, and re-used across both Scala and C++.
+ */
+typedef struct CPUManagedStreamParameters {
+  std::string stream_name;
+  uint64_t dma_addr;
+  uint64_t count_addr;
+  uint32_t fpga_buffer_size;
+
+  CPUManagedStreamParameters(
+    std::string stream_name,
+    uint64_t dma_addr,
+    uint64_t count_addr,
+    int fpga_buffer_size) :
+      stream_name(stream_name),
+      dma_addr(dma_addr),
+      count_addr(count_addr),
+      fpga_buffer_size(fpga_buffer_size) {};
+} CPUManagedStreamParameters;
+
+/**
+ * @brief Base class for CPU-managed streams
+ *
+ * Streams implemented with the CPUManagedStreamingEngine have a common set of
+ * parameters, and use MMIO to measure FPGA-queue occupancy. This base class
+ * captures that.
+ *
+ * Children of this class implement the host-independent control for streams.
+ * Generally, this consists of doing an MMIO read to FPGA-side queue capacity,
+ * to determine if a stream request can be served. Host implementations
+ * instantiate these classes with callbacks to implement MMIO and DMA/PCIS/PCIM
+ * for their platform.
+ *
+ */
+class CPUManagedStream {
+  public:
+    CPUManagedStream(
+      CPUManagedStreamParameters params,
+      std::function<uint32_t(size_t)> mmio_read_func) :
+        params(params), mmio_read_func(mmio_read_func) {};
+
+  private:
+    CPUManagedStreamParameters params;
+    std::function<uint32_t(size_t)> mmio_read_func;
+
+  public:
+    size_t mmio_read(size_t addr) { return mmio_read_func(addr); };
+    // Accessors to avoid directly operating on params
+    int fpga_buffer_size() { return params.fpga_buffer_size; };
+    uint64_t dma_addr() { return params.dma_addr; };
+    uint64_t count_addr() { return params.count_addr; };
+};
+
+/**
+ * @brief Implements streams sunk by the driver (sourced by the FPGA)
+ *
+ * Extends CPUManagedStream to provide a pull method, which moves data from the
+ * FPGA into a user-provided buffer. IO over a CPU-mastered AXI4 IF is implemented
+ * with pcis_read, and is provided by the host-platform.
+ *
+ */
+class StreamToCPU : public CPUManagedStream {
+  public:
+    StreamToCPU(
+      CPUManagedStreamParameters params,
+      std::function<uint32_t(size_t)> mmio_read,
+      std::function<size_t(size_t,char*,size_t)> pcis_read
+    ) : CPUManagedStream(params, mmio_read), pcis_read(pcis_read) {};
+
+    size_t pull(void* dest, size_t num_bytes, size_t required_bytes);
+
+  private:
+    std::function<size_t(size_t,char*,size_t)> pcis_read;
+};
+
+
+/**
+ * @brief Implements streams sourced by the driver (sunk by the FPGA)
+ *
+ * Extends CPUManagedStream to provide a push method, which moves data to the
+ * FPGA out of a user-provided buffer. IO over a CPU-mastered AXI4 IF is implemented
+ * with pcis_write, and is provided by the host-platform.
+ */
+class StreamFromCPU : public CPUManagedStream {
+  public:
+    StreamFromCPU(
+      CPUManagedStreamParameters params,
+      std::function<uint32_t(size_t)> mmio_read,
+      std::function<size_t(size_t,char*,size_t)> pcis_write
+    ) : CPUManagedStream(params, mmio_read), pcis_write(pcis_write) {};
+
+    size_t push(void* src, size_t num_bytes, size_t required_bytes);
+
+  private:
+    std::function<size_t(size_t,char*,size_t)> pcis_write;
+};
+
+#endif // __CPU_MANAGED_STREAM_H

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.cc
@@ -1,5 +1,6 @@
 #ifdef PRINTBRIDGEMODULE_struct_guard
 
+#include <iostream>
 #include <iomanip>
 
 #include "synthesized_prints.h"
@@ -15,8 +16,8 @@ synthesized_prints_t::synthesized_prints_t(
   const char* const*  format_strings,
   const unsigned int* argument_counts,
   const unsigned int* argument_widths,
-  unsigned int dma_address,
-  unsigned int stream_count_address,
+  unsigned int stream_idx,
+  unsigned int stream_depth,
   const char* const  clock_domain_name,
   const unsigned int clock_multiplier,
   const unsigned int clock_divisor,
@@ -30,8 +31,8 @@ synthesized_prints_t::synthesized_prints_t(
     format_strings(format_strings),
     argument_counts(argument_counts),
     argument_widths(argument_widths),
-    dma_address(dma_address),
-    stream_count_address(stream_count_address),
+    stream_idx(stream_idx),
+    stream_depth(stream_depth),
     clock_info(clock_domain_name, clock_multiplier, clock_divisor),
     printno(printno) {
   assert((token_bytes & (token_bytes - 1)) == 0);
@@ -57,7 +58,9 @@ synthesized_prints_t::synthesized_prints_t(
 
   // Choose a multiple of token_bytes for the batch size
   if (((beat_bytes * desired_batch_beats) % token_bytes) != 0 ) {
-    this->batch_beats = token_bytes / beat_bytes;
+    assert(token_bytes % beat_bytes == 0);
+    auto beats_per_token = token_bytes / beat_bytes;
+    this->batch_beats = (desired_batch_beats / beats_per_token) * beats_per_token;
   } else {
     this->batch_beats = desired_batch_beats;
   }
@@ -199,27 +202,30 @@ uint32_t decode_idle_cycles(char * buf, uint32_t mask) {
   return (((*((uint32_t*)buf)) & mask) >> 1);
 }
 
-// Iterates through the DMA flits (each is one token); checking if their are enabled prints
-void synthesized_prints_t::process_tokens(size_t beats) {
-  size_t batch_bytes = beats * beat_bytes;
+/**
+ * @brief Processes tokens at the head of a print bridge stream.
+ *
+ * @param beats The desired number of beats.
+ * @param minimum_batch_beats The minimum number of beats to process on this
+ *  invocation. Better amortizes stream bandwidth, set to 0 to drain the stream.
+ *
+ * @return * size_t The number of bytes processed.
+ */
+size_t synthesized_prints_t::process_tokens(size_t beats, size_t minimum_batch_beats) {
+  size_t maximum_batch_bytes = beats * beat_bytes;
+  size_t minimum_batch_bytes = minimum_batch_beats * beat_bytes;
 
   // See FireSim issue #208
   // This needs to be page aligned, as a DMA request that spans a page is
   // fractured into a pair, and for reasons unknown, first beat of the second
   // request is lost. Once aligned, qequests larger than a page will be fractured into
   // page-size (64-beat) requests and these seem to behave correctly.
-  alignas(4096) char buf[batch_bytes];
+  alignas(4096) char buf[maximum_batch_bytes];
 
-  uint32_t bytes_received = pull(dma_address, (char*)buf, batch_bytes);
-  if (bytes_received != batch_bytes) {
-    printf("ERR MISMATCH! on reading print tokens. Read %d bytes, wanted %d bytes.\n",
-           bytes_received, batch_bytes);
-    printf("errno: %s\n", strerror(errno));
-    exit(1);
-  }
+  uint32_t bytes_received = pull(stream_idx, (char*)buf, maximum_batch_bytes, minimum_batch_bytes);
 
   if (human_readable) {
-    for (size_t idx = 0; idx < batch_bytes; idx += token_bytes ) {
+    for (size_t idx = 0; idx < bytes_received; idx += token_bytes ) {
       if (has_enabled_print(&buf[idx])) {
         show_prints(&buf[idx]);
         current_cycle++;
@@ -228,8 +234,10 @@ void synthesized_prints_t::process_tokens(size_t beats) {
       }
     }
   } else {
-    printstream->write(buf, batch_bytes);
+    printstream->write(buf, bytes_received);
   }
+
+  return bytes_received;
 }
 
 // Returns true if the print at the current offset is enabled in this cycle
@@ -269,39 +277,39 @@ void synthesized_prints_t::show_prints(char * buf) {
 void synthesized_prints_t::tick() {
   // Pull batch_tokens from the FPGA if at least that many are avaiable
   // Assumes 1:1 token to dma-beat size
-  size_t beats_available = read(stream_count_address);
-  if (beats_available >= batch_beats) {
-      process_tokens(batch_beats);
-  }
+  process_tokens(batch_beats, batch_beats);
 }
 
-// This is a little hacky... however it'll probably work perfectly fine on the
-// FPGA as mmio read latency is 100+ ns.
-int synthesized_prints_t::beats_avaliable_stable() {
-  size_t prev_beats_available = 0;
-  size_t beats_avaliable = read(stream_count_address);
-  while (beats_avaliable > prev_beats_available) {
-    prev_beats_available = beats_avaliable;
-    beats_avaliable = read(stream_count_address);
-  }
-  return beats_avaliable;
-}
-
-// Pull in any remaining tokens and flush them to file
-// WARNING: may not function correctly if the simulator is actively running
+/**
+ * @brief Drains all available tokens on the print bridge stream
+ */
 void synthesized_prints_t::flush() {
-  // Wait for the system to settle
-  size_t beats_available = beats_avaliable_stable();
+  // This should not starve the rest of the simulator because eventually some
+  // other bridge in the system will need to be served and the stream will
+  // empty. It might be safer to put a bound on this though.
+  while(process_tokens(batch_beats, 0) != 0);
 
-  // If multiple tokens are being packed into a single DMA beat, force the widget
+  // If multiple tokens are being packed into a single stream beat, force the widget
   // to write out any incomplete beat
-  if  (token_bytes < beat_bytes) {
+  if (token_bytes < beat_bytes) {
     write(mmio_addrs->flushNarrowPacket, 1);
-    while (read(stream_count_address) != (beats_available + 1));
-    beats_available++;
-  }
 
-  if (beats_available) process_tokens(beats_available);
+    // On an FPGA reading from the stream will have enough latency that
+    // process_tokens will return non-zero on the first attempt, introducing no
+    // extra MMIO to wait for the flush to finish.
+    // However, in metasimulation the delay model for MMIO can be very short so
+    // repeatedly attempt to read from the stream until the narrow packet has
+    // been returned.
+    int max_attempts = (beat_bytes + token_bytes - 1) / token_bytes;
+    int attempts = 0;
+    while(process_tokens(batch_beats, 0) == 0) {
+      if (attempts >= max_attempts) {
+        std::cerr << "Printf narrow packet not flushed after " << max_attempts << " polls of stream." << std::endl;
+        exit(1);
+      }
+      attempts++;
+    }
+  }
   this->printstream->flush();
 }
 

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.h
@@ -25,8 +25,8 @@
         PRINTBRIDGEMODULE_ ## IDX ## _format_strings, \
         PRINTBRIDGEMODULE_ ## IDX ## _argument_counts, \
         PRINTBRIDGEMODULE_ ## IDX ## _argument_widths, \
-        PRINTBRIDGEMODULE_ ## IDX ## _to_cpu_stream_dma_address, \
-        PRINTBRIDGEMODULE_ ## IDX ## _to_cpu_stream_count_address, \
+        PRINTBRIDGEMODULE_ ## IDX ## _to_cpu_stream_idx, \
+        PRINTBRIDGEMODULE_ ## IDX ## _to_cpu_stream_depth, \
         PRINTBRIDGEMODULE_ ## IDX ## _clock_domain_name, \
         PRINTBRIDGEMODULE_ ## IDX ## _clock_multiplier, \
         PRINTBRIDGEMODULE_ ## IDX ## _clock_divisor, \
@@ -56,8 +56,8 @@ class synthesized_prints_t: public bridge_driver_t
                              const char* const*  format_strings,
                              const unsigned int* argument_counts,
                              const unsigned int* argument_widths,
-                             unsigned int dma_address,
-                             unsigned int stream_count_address,
+                             unsigned int stream_idx,
+                             unsigned int stream_depth,
                              const char* const  clock_domain_name,
                              const unsigned int clock_multiplier,
                              const unsigned int clock_divisor,
@@ -78,8 +78,8 @@ class synthesized_prints_t: public bridge_driver_t
         const char* const*  format_strings;
         const unsigned int* argument_counts;
         const unsigned int* argument_widths;
-        const unsigned int dma_address;
-        const unsigned int stream_count_address;
+        const unsigned int stream_idx;
+        const unsigned int stream_depth;
         ClockInfo clock_info;
         const int printno;
 
@@ -89,7 +89,7 @@ class synthesized_prints_t: public bridge_driver_t
         // This will be set based on the ratio of token_size : desired_batch_beats
         size_t batch_beats;
         // This will be modified to be a multiple of the token size
-        const size_t desired_batch_beats = 3072;
+        const size_t desired_batch_beats = stream_depth / 2;
 
         // Used to define the boundaries in the batch buffer at which we'll
         // initalize GMP types
@@ -115,7 +115,7 @@ class synthesized_prints_t: public bridge_driver_t
         std::vector<size_t> bit_offset;
 
         bool current_print_enabled(gmp_align_t* buf, size_t offset);
-        void process_tokens(size_t beats);
+        size_t process_tokens(size_t beats, size_t minimum_batch_beats);
         void show_prints(char * buf);
         void print_format(const char* fmt, print_vars_t* vars, print_vars_t* masks);
         // Returns the number of beats available, once two successive reads return the same value

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -21,6 +21,28 @@ double diff_secs(midas_time_t end, midas_time_t start);
 typedef std::map< std::string, size_t > idmap_t;
 typedef std::map< std::string, size_t >::const_iterator idmap_it_t;
 
+/** \class simif_t
+ *
+ *  @brief FireSim's main simulation class.
+ *
+ *  Historically this god class wrapped all of the features presented by FireSim
+ *  / MIDAS-derived simulators. Critically, it declares an interface for interacting with
+ *  the host-FPGA, which consist of methods for implementing 32b MMIO (read,
+ *  write), and latency-insensitive bridge streams (push, pull). Concrete
+ *  subclasses of simif_t must be written for metasimulation and each supported
+ *  host plaform. See simif_f1_t for an example.
+
+ *  simif_t also provides a few core functions that are tied to bridges and widgets that
+ *  must be present in all simulators:
+ *
+ *  - To track simulation time, it provides methods to interact with the
+ *    ClockBridge. This bridge is solely responsible for defining a schedule of
+ *    clock edges to simulate, and must be instantiated in all targets. See actual_tcycle() and hcycle().
+ *    Utilities to report performance are based off these measures of time.
+ *
+ *  - To read and write into FPGA DRAM, the LoadMem widget provides a
+ *    low-bandwidth side channel via MMIO. See read_mem, write_mem, zero_out_dram.
+ */
 class simif_t
 {
   public:
@@ -53,27 +75,69 @@ class simif_t
 
     // Host-platform interface. See simif_f1; simif_emul for implementation examples
 
-    // Performs platform-level initialization that for some reason or another
-    // cannot be done in the constructor. (For one, currently command line args
-    // are not passed to constructor).
+    /**
+     * Performs platform-level initialization that for some reason or another
+     * cannot be done in the constructor. (For one, currently command line args
+     * are not passed to constructor).
+     */
     virtual void host_init(int argc, char** argv) = 0;
-    // Does final platform-specific cleanup before destructors are called.
+
+    /**
+     *  Does final platform-specific cleanup before destructors are called.
+     */
     virtual int host_finish() = 0;
 
-    // Widget communication
-    // 32b MMIO, issued over the simulation control bus (AXI4-lite).
+    /** Bridge / Widget MMIO methods */
+
+    /**
+     * @brief 32b MMIO write, issued over the simulation control bus (AXI4-lite).
+     *
+     * @param addr The address to preform the 32b read in the MMIO address space..
+     */
     virtual void write(size_t addr, uint32_t data) = 0;
+
+    /**
+     * @brief 32b MMIO read, issued over the simulation control bus (AXI4-lite).
+     *
+     * @param addr The address to preform the 32b read in the MMIO address space..
+     * @returns A uint32_t capturing the read value.
+     */
     virtual uint32_t read(size_t addr) = 0;
 
-    // Bulk transfers / bridge streaming interfaces.
+    /** Bridge Stream Methods */
 
-    // Moves <bytes>B of data from a bridge FIFO at address <addr> (on the
-    // FPGA) to a buffer specified by <data>. FIFO addresses are emitted in the
-    // simulation header, and are in a distinct address space from MMIO.
-    virtual ssize_t pull(size_t addr, char *data, size_t size) = 0;
-    // Moves <bytes>B of data from the buffer <data> to a bridge FIFO at
-    // address <addr> (on the FPGA.
-    virtual ssize_t push(size_t addr, char *data, size_t size) = 0;
+    /**
+     * @brief Dequeues num_bytes of data from an FPGA-to-CPU stream
+     *
+     * Attempts to copy @num_bytes of data from the head of a bridge stream
+     * specified by @stream_idx into a destination buffer (@dest) in the
+     * process’s memory space. Non-blocking.
+     *
+     * @param stream_idx Stream index. Assigned at Golden Gate compile time
+     * @param dest Destination buffer into which to copy stream data. (Virtual address.)
+     * @param num_bytes Number of bytes to copy.
+     * @param required_bytes If pull would return less than this many bytes, it returns 0 instead.
+     *
+     * @returns Number of bytes copied. Can be less than requested.
+     *
+     */
+    virtual size_t pull(unsigned int stream_idx, void* dest, size_t num_bytes, size_t required_bytes) = 0;
+
+    /**
+     * @brief Enqueues num_bytes of data into a CPU-to-FPGA stream
+     *
+     * Attempts to copy @num_bytes of data from a source buffer (@src) to the
+     * tail of the CPU-to-FPGA bridge stream specified by @stream_idx.
+     *
+     * @param stream_idx Stream index. Assigned at Golden Gate compile time
+     * @param src Source buffer from which to copy stream data.
+     * @param num_bytes Number of bytes to copy.
+     * @param required_bytes If push would accept less than this many bytes, it accepts 0 instead.
+     * 
+     * @returns Number of bytes copied. Can be less than requested.
+     *
+     */
+    virtual size_t push(unsigned int stream_idx, void* src, size_t num_bytes, size_t required_bytes) = 0;
 
     // End host-platform interface.
 

--- a/sim/midas/src/main/cc/simif_emul.h
+++ b/sim/midas/src/main/cc/simif_emul.h
@@ -4,26 +4,30 @@
 #define __SIMIF_EMUL_H
 
 #include <memory>
+#include <vector>
 
 #include "simif.h"
 #include "mm.h"
 #include "mm_dramsim2.h"
 #include "emul/mmio.h"
+#include "bridges/cpu_managed_stream.h"
+
 
 // simif_emul_t is a concrete simif_t implementation for Software RTL simulators
 // The basis for MIDAS-level simulation
 class simif_emul_t : public virtual simif_t
 {
   public:
-    simif_emul_t() { }
+    simif_emul_t();
     virtual ~simif_emul_t();
     virtual void host_init(int argc, char** argv);
     virtual int  host_finish();
 
     virtual void write(size_t addr, uint32_t data);
     virtual uint32_t read(size_t addr);
-    virtual ssize_t pull(size_t addr, char* data, size_t size);
-    virtual ssize_t push(size_t addr, char* data, size_t size);
+
+    virtual size_t pull(unsigned int stream_idx, void* dest, size_t num_bytes, size_t threshold_bytes);
+    virtual size_t push(unsigned int stream_idx, void* src, size_t num_bytes, size_t threshold_bytes);
 
   private:
     // The maximum number of cycles the RTL simulator can advance before
@@ -33,6 +37,12 @@ class simif_emul_t : public virtual simif_t
     void advance_target();
     void wait_read(std::unique_ptr<mmio_t>& mmio, void *data);
     void wait_write(std::unique_ptr<mmio_t>& mmio);
+
+    size_t pcis_write(size_t addr, char *data, size_t size);
+    size_t pcis_read(size_t addr, char* data, size_t size);
+
+    std::vector<StreamToCPU> to_host_streams;
+    std::vector<StreamFromCPU> from_host_streams;
 };
 
 #endif // __SIMIF_EMUL_H

--- a/sim/midas/src/main/cc/simif_f1.h
+++ b/sim/midas/src/main/cc/simif_f1.h
@@ -2,6 +2,7 @@
 #define __SIMIF_F1_H
 
 #include "simif.h"    // from midas
+#include "bridges/cpu_managed_stream.h"
 
 #ifndef SIMULATION_XSIM
 #include <fpga_pci.h>
@@ -20,8 +21,8 @@ class simif_f1_t: public virtual simif_t
 
     virtual void write(size_t addr, uint32_t data);
     virtual uint32_t read(size_t addr);
-    virtual ssize_t pull(size_t addr, char* data, size_t size);
-    virtual ssize_t push(size_t addr, char* data, size_t size);
+    virtual size_t pull(unsigned int stream_idx, void* dest, size_t num_bytes, size_t threshold_bytes);
+    virtual size_t push(unsigned int stream_idx, void* src, size_t num_bytes, size_t threshold_bytes);
     uint32_t is_write_ready();
     void check_rc(int rc, char * infostr);
     void fpga_shutdown();
@@ -29,6 +30,13 @@ class simif_f1_t: public virtual simif_t
   private:
     char in_buf[CTRL_BEAT_BYTES];
     char out_buf[CTRL_BEAT_BYTES];
+
+    std::vector<StreamToCPU> to_host_streams;
+    std::vector<StreamFromCPU> from_host_streams;
+
+    size_t pcis_write(size_t addr, char *data, size_t size);
+    size_t pcis_read(size_t addr, char* data, size_t size);
+
 #ifdef SIMULATION_XSIM
     char * driver_to_xsim = "/tmp/driver_to_xsim";
     char * xsim_to_driver = "/tmp/xsim_to_driver";

--- a/sim/midas/src/main/scala/midas/widgets/PrintBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PrintBridge.scala
@@ -56,7 +56,7 @@ class PrintBridgeModule(resetPortName: String, printPorts: Seq[(firrtl.ir.Port, 
     extends BridgeModule[HostPortIO[PrintRecordBag]]()(p) with StreamToHostCPU {
 
   //  The fewest number of BRAMS that produces a memory that is 512b wide.(8 X 32Kb BRAM)
-  val toHostCPUQueueDepth = 6144 // 12 Ultrascale+ URAMs
+  override val toHostCPUQueueDepth = 6144 // 12 Ultrascale+ URAMs
 
   lazy val module = new BridgeModuleImp(this) {
     val io = IO(new WidgetIO())

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -224,69 +224,28 @@ firesim_top_t::firesim_top_t(int argc, char** argv)
 
 #ifdef SIMPLENICBRIDGEMODULE_struct_guard
     #ifdef SIMPLENICBRIDGEMODULE_0_PRESENT
-    SIMPLENICBRIDGEMODULE_0_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_0_substruct, 0,
-        SIMPLENICBRIDGEMODULE_0_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_0_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_0_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_0_from_cpu_stream_dma_address));
-
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,0)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_1_PRESENT
-    SIMPLENICBRIDGEMODULE_1_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_1_substruct, 1,
-        SIMPLENICBRIDGEMODULE_1_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_1_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_1_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_1_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,1)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_2_PRESENT
-    SIMPLENICBRIDGEMODULE_2_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_2_substruct, 2,
-        SIMPLENICBRIDGEMODULE_2_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_2_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_2_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_2_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,2)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_3_PRESENT
-    SIMPLENICBRIDGEMODULE_3_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_3_substruct, 3,
-        SIMPLENICBRIDGEMODULE_3_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_3_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_3_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_3_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,3)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_4_PRESENT
-    SIMPLENICBRIDGEMODULE_4_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_4_substruct, 4,
-        SIMPLENICBRIDGEMODULE_4_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_4_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_4_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_4_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,4)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_5_PRESENT
-    SIMPLENICBRIDGEMODULE_5_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_5_substruct, 5,
-        SIMPLENICBRIDGEMODULE_5_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_5_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_5_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_5_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,5)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_6_PRESENT
-    SIMPLENICBRIDGEMODULE_6_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_6_substruct, 6,
-        SIMPLENICBRIDGEMODULE_6_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_6_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_6_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_6_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,6)
     #endif
     #ifdef SIMPLENICBRIDGEMODULE_7_PRESENT
-    SIMPLENICBRIDGEMODULE_7_substruct_create;
-    add_bridge_driver(new simplenic_t(this, args, SIMPLENICBRIDGEMODULE_7_substruct, 7,
-        SIMPLENICBRIDGEMODULE_7_to_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_7_to_cpu_stream_dma_address,
-        SIMPLENICBRIDGEMODULE_7_from_cpu_stream_count_address,
-        SIMPLENICBRIDGEMODULE_7_from_cpu_stream_dma_address));
+    INSTANTIATE_SIMPLENIC(add_bridge_driver,7)
     #endif
 #endif
 


### PR DESCRIPTION
This implements the second part of plan to move the implementation of bridge streams behind the host interface. That plan is described in more detail in #996. This will be ready for review once i've propagated some of the scala changes back into the other PR. 

At a high level, this simply reflects in C++ the changes made in scala. Bridges now use `push` and `pull` to enqueue and dequeue bytes from their streams without needing to do `MMIO` which is tied to the underlying implementation of bridge streams. Streams are referenced using an index, which can be hidden from the bridge designer in the future by absorbing it into the bridge_driver interface. 

As we've discussed in our local-fpga support meetings,  the behavior of `push` and `pull` has been changed such that they may return fewer bytes than asked for. To make porting the existing code to the new interface easier, `push` and `pull` accept a `minimum_batch_size` parameter. If there are fewer bytes than this threshold, the implementations should early out and return 0. The doxygen blocks for these methods should explain the behavior of these functions (it is based off our working document).


TODO:
- [x] Move pertinent Scala changes back into #996.
- [x] Self review, providing context comments for seemingly unrelated changes. 
- [ ] Harmonize the type selection. uint64_t, size_t; unsigned, uin32_t, int usage is a bit of a mess right now. 
- [ ] Decide where to put reusable host sources (cpu_managed_stream.{cc/h}). I've dumped it in bridges for now.
   - Maybe a follow on PR since it'll require makefile changes. 

While working on this PR i ran some tech debt that should be easy to clean up and would remove some of the cognitive load of designing / understanding bridges: 
- Bridges have a bunch of different way of determining the width of a stream. Most derive from macros in the generated header, and use terms that expose the implementation.
  - Proposal: Move truly constant widths into a static header file. This would include things like `STREAM_WIDTH_BYTES` (replacing DMA_BEAT_BITS, DMA_BEAT_BYTES, PCIE_SZ_B, etc.. ), and `MMIO_WIDTH_BYTES`.
- Remove `data_t`, replacing it with `uint32_t`. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

#996 

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
