### PR TITLE
post-merge CI needs to source env changes from machine-launch-script.sh

### DIFF
--- a/.github/actions/machinelaunchscript/action.yml
+++ b/.github/actions/machinelaunchscript/action.yml
@@ -7,4 +7,6 @@ runs:
     - run: |
         sudo yum -y remove git git224 git224-core ius-release.noarch # remove any older git versions and collateral first
         cd scripts/ && /usr/bin/bash machine-launch-script.sh
+        source /etc/profile.d/conda.sh
+        env >> $GITHUB_ENV # persist the machine-launch-script env changes to other actions
       shell: bash

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -178,7 +178,7 @@ set -o pipefail
         # run conda-init and look at it's output to insert 'conda activate $CONDA_ENV_NAME' into the
         # block that conda-init will update if ever conda is installed to a different prefix and
         # this is rerun.
-        $SUDO "${CONDA_EXE}" init $DRY_RUN_OPTION "${conda_init_extra_args[@]}" bash |& \
+        $SUDO "${CONDA_EXE}" init $DRY_RUN_OPTION "${conda_init_extra_args[@]}" bash 2>&1 | \
             tee >(grep '^modified' | grep -v "$CONDA_INSTALL_PREFIX" | awk '{print $NF}' | \
             "${DRY_RUN_ECHO[@]}" $SUDO xargs -r sed -i -e "/<<< conda initialize <<</iconda activate $CONDA_ENV_NAME")
 

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -83,13 +83,25 @@ set -o pipefail
 
 {
 
-    if [[ ! -r /etc/os-release ]]; then
-        echo "::ERROR:: $0 depends on /etc/os-release for distro-specific setup and it doesn't exist here"
-        exit 1
+    # uname options are not portable so do what https://www.gnu.org/software/coreutils/faq/coreutils-faq.html#uname-is-system-specific
+    # suggests and iteratively probe the system type
+    if ! type uname >&/dev/null; then
+	echo "::ERROR:: need 'uname' command available to determine if we support this sytem"
+	exit 1
+    fi
+
+    if [[ "$(uname)" != "Linux" ]]; then
+        echo "::ERROR:: $0 only supports 'Linux' not '$(uname)'"
+	exit 1
     fi
 
     if [[ "$(uname -mo)" != "x86_64 GNU/Linux" ]]; then
         echo "::ERROR:: $0 only supports 'x86_64 GNU/Linux' not '$(uname -io)'"
+        exit 1
+    fi
+
+    if [[ ! -r /etc/os-release ]]; then
+        echo "::ERROR:: $0 depends on /etc/os-release for distro-specific setup and it doesn't exist here"
         exit 1
     fi
 


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

pre-merge GHA CI seems to be using completely different scripts than post-merge https://github.com/firesim/firesim/runs/6005045635?check_suite_focus=true. I can understand how this situation developed organically but it is a fairly stinky antipattern.  Rather than addressing the larger issue to make post-merge use the same scripts that are tested pre-merge, I'm just fixing the post-merge scripts.  I don't see how to make GH-A logout and log back in to the machine.  So, instead, I source the environment changes done by machine-launch-script.sh into the environment and cause them to persist via `env >> $GITHUB_ENV` as described in https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsenv. Looking into it more, that is just a file and it should accept the output of `env` just fine.

I also tweaked the way that `machine-launch-script.sh` introspects the system it is on to determine whether the system is supported (only Linux x86_64).  Just for grins, I Q/A'd the script on my macbook and the error messages were a tad nonsensical the way I had them before.  Shouldn't impact anyone running on a supported platform but the error messages on something unsupported will be better.


#### Related PRs / Issues

Hopefully fixes broken post-merge workflows that use actions/machinelaunchscript in a composite action.  i.e. https://github.com/firesim/firesim/runs/6005045635?check_suite_focus=true

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
