### PR TITLE
XDC-Driven Memory Hints for Xilinx FPGAs

### DIFF
--- a/docs/Advanced-Usage/Generating-Different-Targets.rst
+++ b/docs/Advanced-Usage/Generating-Different-Targets.rst
@@ -103,6 +103,55 @@ Limitations:
 
 .. _generating-different-targets:
 
+Target-Side FPGA Constraints
+----------------------------
+
+FireSim provides utilities to generate Xilinx Design Constraints (XDC) from
+string snippets in target's Chisel. Golden Gate collects these annotations and
+emits separate xdc files for synthesis and implementation.  See
+:ref:`fpga-build-files` for a complete listing of output files used in FPGA
+compilation.
+
+-----------------------------
+RAM Inference Hints
+-----------------------------
+
+Vivado generally does a reasonable job inferring embedded memories from
+FireSim-generated RTL, though there are some cases in which it must be coaxed. For example:
+
+* Due to insufficient BRAM resources, you may wish to use URAM for a memory that'd infer as BRAM.
+* If Vivado can't find pipeline registers to absorb into a URAM or none exist in the target, you may get an warning like::
+
+    [Synth 8-6057] Memory: "<memory>" defined in module: "<module>" implemented as Ultra-Ram
+    has no pipeline registers. It is recommended to use pipeline registers to achieve high
+    performance. 
+
+Since Golden Gate modifies the module hierarchy extensively, it's highly
+desirable to annotate these memories in the Chisel source so that their hints
+may move with the memory instance. This is a more robust alternative to
+relying on wildcard / glob matches from a static XDC specification.
+
+Chisel memories can be annotated *in situ* like so:
+
+.. literalinclude:: ../../sim/midas/targetutils/src/test/scala/RAMStyleHintSpec.scala
+    :language: scala
+    :start-after: DOC include start: Basic RAM Hint
+    :end-before: DOC include end: Basic RAM Hint
+
+Alternatively, you can "dot-in" (traverse public members of a Scala class
+hierarchy) to annotate a memory in a submodule. Here's an example:
+
+.. literalinclude:: ../../sim/midas/targetutils/src/test/scala/RAMStyleHintSpec.scala
+    :language: scala
+    :start-after: DOC include start: RAM Hint From Parent
+    :end-before: DOC include end: RAM Hint From Parent
+
+These annotations can be deployed anywhere: in the target, in bridge modules,
+and in internal FireSim RTL. The resulting constraints should appear the
+synthesis xdc file emitted by Golden Gate. For more information see the ScalaDoc
+for ``RAMStyleHint`` or read the source located at:
+:gh-file-ref:`sim/midas/targetutils/src/main/scala/midas/xdc/RAMStyleHint.scala`.
+
 Provided Target Designs
 -----------------------
 

--- a/docs/Golden-Gate/Output-Files.rst
+++ b/docs/Golden-Gate/Output-Files.rst
@@ -14,17 +14,21 @@ These are used in nearly all flows.
 * **<BASE>.const.h**: A target-specific header containing all necessary metadata to instantiate bridge drivers. This is linked into the simulator driver and meta-simulators (FPGA-level / MIDAS-level). Often referred to as "the header".
 * **<BASE>.runtime.conf**: Default plus args for generated FASED memory timing models. Most other bridges have their defaults baked into the driver.
 
-FPGA Synthesis Files
+.. _fpga-build-files:
+
+FPGA Build Files
 -------------------------------------
-These are additional files passed to the FPGA build directory.
+These are additional files passed to the FPGA build directory. 
 
 * **<BASE>.defines.vh**: Verilog macro definitions for FPGA synthesis.
 * **<BASE>.env.tcl**: Used a means to inject arbitrary TCL into the start of the build flow. Controls synthesis and implementation strategies, and sets the host_clock frequency before the clock generator (MCMM) is synthesized.
 * **<BASE>.ila_insert_vivado.tcl**: Synthesizes an ILA for the design. See :ref:`auto-ila` for more details about using ILAs in FireSim.
 * **<BASE>.ila_insert_{inst, ports, wires}.v**: Instantiated in the FPGA project via ```include`` directives to instantiate the generated ILA.
+* **<BASE>.synthesis.xdc**: Xilinx design constraints for synthesis derived from collected XDCAnnotations.
+* **<BASE>.implementation.xdc**: Xilinx design constraints for implementation derived from collected XDCAnnotations.
 
-Meta-simulation Files
+Metasimulation Files
 -------------------------------------
-These are additional sources used only in MIDAS-level simulators
+These are additional sources used only for compiling metasimulators.
 
 * **<BASE>.const.vh**: Verilog macros to define variable width fields.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,11 +30,18 @@ copyright = u'2018, Sagar Karandikar, Howard Mao, Donggyu Kim, David Biancolin, 
 author = u'Sagar Karandikar, Howard Mao, Donggyu Kim, David Biancolin, Alon Amid, and Berkeley Architecture Research'
 
 on_rtd = os.environ.get("READTHEDOCS") == "True"
+on_gha = os.environ.get("GITHUB_ACTIONS") == "true"
+
 if on_rtd:
     for item, value in os.environ.items():
         print("[READTHEDOCS] {} = {}".format(item, value))
 
+# Come up with a short version string for the build. This is doing a bunch of lifting:
+# - format doc text that self-references its version (see title page). This may be used in an ad-hoc
+#   way to produce references to things like ScalaDoc, etc...
+# - procedurally generate github URL references using via `gh-file-ref`
 if on_rtd:
+    logger.info("Running in a RTD Container")
     rtd_version = os.environ.get("READTHEDOCS_VERSION")
     if rtd_version == "latest":
         version = "main" # TODO: default to what "latest" points to
@@ -49,6 +56,12 @@ if on_rtd:
             version = "v?.?.?" # this should not occur as "stable" is always pointing to tagged version
     else:
         version = rtd_version # name of a branch
+elif on_gha:
+    # GitHub actions does a build of the docs to ensure they are free of warnings.
+    logger.info("Running under GitHub Actions Pipeline")
+    # Looking up a branch name or tag requires switching on the event type that triggered the workflow
+    # so just use the SHA of the commit instead.
+    version = os.environ.get("GITHUB_SHA")
 else:
     # When running locally, try to set version to a branch name that could be
     # used to reference files on GH that could be added or moved. This should match rtd_version when running

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,9 +50,15 @@ if on_rtd:
     else:
         version = rtd_version # name of a branch
 else:
-    # TODO: Note for local builds, this may produce github URLs that do not
-    # correctly resolve, if the local branch has added or renamed files
-    version = "main"
+    # When running locally, try to set version to a branch name that could be
+    # used to reference files on GH that could be added or moved. This should match rtd_version when running
+    # in a RTD build container
+    process = subprocess.Popen(["git", "rev-parse", "--abbrev-ref", "HEAD"], stdout=subprocess.PIPE)
+    output = process.communicate()[0].decode("utf-8").strip()
+    if process.returncode == 0:
+        version = output
+    else:
+        raise Exception("git rev-parse --abbrev-ref HEAD returned non-zero")
 
 logger.info(f"Setting |version| to {version}.")
 
@@ -246,7 +252,9 @@ def gh_file_ref_role(name, rawtext, text, lineno, inliner, options={}, content=[
     logger.info(f"Testing GitHub URL {url} exists...")
     status_code = requests.get(url).status_code
     if status_code != 200:
-        logger.error(f"[Line {lineno}] :{name}:`{text}` produces URL {url} returning status code {status_code}.")
+        message = f"[Line {lineno}] :{name}:`{text}` produces URL {url} returning status code {status_code}. " \
+                  "Ensure your path is correct and all commits that may have moved or renamed files have been pushed to github.com."
+        logger.error(message)
         sys.exit(1)
 
     docutils.parsers.rst.roles.set_classes(options)

--- a/sim/midas/src/main/scala/midas/core/CPUManagedStreamEngine.scala
+++ b/sim/midas/src/main/scala/midas/core/CPUManagedStreamEngine.scala
@@ -5,7 +5,7 @@ package midas.core
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.IO
+import chisel3.experimental.{IO, prefix}
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.diplomacy._
@@ -81,7 +81,7 @@ class CPUManagedStreamEngine(p: Parameters, val params: StreamEngineParameters) 
         channel: DecoupledIO[UInt],
         chParams: StreamSinkParameters,
         idx: Int,
-        addressSpaceBits: Int): StreamDriverParameters = {
+        addressSpaceBits: Int): StreamDriverParameters = prefix(chParams.name) {
 
       val streamName = chParams.name
       val grant = (dma.aw.bits.addr >> addressSpaceBits) === idx.U
@@ -137,7 +137,7 @@ class CPUManagedStreamEngine(p: Parameters, val params: StreamEngineParameters) 
         channel: DecoupledIO[UInt],
         chParams: StreamSourceParameters,
         idx: Int,
-        addressSpaceBits: Int): StreamDriverParameters = {
+        addressSpaceBits: Int): StreamDriverParameters = prefix(chParams.name) {
 
       val grant = (dma.ar.bits.addr >> addressSpaceBits) === idx.U
 

--- a/sim/midas/src/main/scala/midas/passes/SimulationMapping.scala
+++ b/sim/midas/src/main/scala/midas/passes/SimulationMapping.scala
@@ -94,7 +94,7 @@ private[passes] class SimulationMapping(targetName: String) extends firrtl.Trans
 
     // Generate the encapsulating simulator RTL
     lazy val shim = PlatformShim(innerState.annotations, portTypeMap)
-    val (chirrtl, elaboratedAnnos) = ElaborateChiselSubCircuit(LazyModule(shim).module)
+    val (chirrtl, elaboratedAnnos) = midas.targetutils.ElaborateChiselSubCircuit(LazyModule(shim).module)
 
     val transforms = Seq(
       Dependency[Fame1Instances],

--- a/sim/midas/targetutils/src/main/scala/midas/ElaborateChiselSubCircuit.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/ElaborateChiselSubCircuit.scala
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-package midas.passes
+package midas.targetutils
 
 import firrtl.{AnnotationSeq, Transform}
 import firrtl.ir.Circuit

--- a/sim/midas/targetutils/src/main/scala/midas/xdc/RAMStyleHint.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/xdc/RAMStyleHint.scala
@@ -1,0 +1,73 @@
+// See LICENSE for license details.
+
+package midas.targetutils.xdc
+
+import chisel3.experimental.{ChiselAnnotation}
+import firrtl.annotations.ReferenceTarget
+import midas.targetutils.xdc.{XDCFiles, XDCAnnotation}
+
+sealed trait RAMStyle
+
+/**
+  * Some rough guidance, based on Ultrascale+, is provided in the scala doc for
+  * each hint. Consult the Xilinx UGs for your target architecture and the
+  * synthesis UG (UG901).
+  */
+object RAMStyles {
+  /**
+    *  From UG901 (v2020.2): Instructs the tool to use the UltraScale+ URAM primitives.
+    *
+    *  URAMs are 288Kb, 72b wide, 4096 deep.
+    */
+  case object ULTRA extends RAMStyle
+
+  /**
+    *  From UG901 (v2020.2): Instructs the tool to infer RAMB type components
+    *
+    *  In Ultrascale+ (and older families), BRAMs are 36Kb, and have flexible aspect
+    *  ratio: 1b x 64K to 72b x 512
+    */
+  case object BRAM extends RAMStyle
+
+  /** From UG901 (v2020.2): Instructs the tool to infer registers instead of RAMs. */
+  case object REGISTERS extends RAMStyle
+
+  /** From UG901 (v2020.2): Instructs the tool to infer the LUT RAMs. */
+  case object DISTRIBUTED extends RAMStyle
+
+  /** Introduced in v2020.2. From UG901 (v2020.2):
+    *
+    * Instructs the tool to infer a combination of RAM types designed to minimize the
+    * amount of space that is unused.
+    *
+    * Note: This should probably be avoided for non-emulation-class
+    * FPGAs (e.g., VU19P), which tend to have rich embedded memory resources, as
+    * these designs tend to be under heavy LUT pressure. Here sparsely using
+    * BRAM / URAM resources insead of a space-optimal hybrid is desirable.
+    */
+  case object MIXED extends RAMStyle
+}
+
+object RAMStyleHint {
+  // _reg suffix is applied to memory cells by Vivado, the glob manages
+  // duplication for multibit memories.
+  private [midas] def propertyTemplate(style: RAMStyle): String =
+    s"set_property RAM_STYLE ${style} [get_cells {}_reg*]"
+
+  private def annotate(style: RAMStyle, rT: =>ReferenceTarget): Unit = {
+    chisel3.experimental.annotate(new ChiselAnnotation {
+      def toFirrtl = XDCAnnotation(
+        XDCFiles.Synthesis,
+        propertyTemplate(style),
+        rT)
+    })
+  }
+
+  /**
+    * Annotates a chisel3 Mem indicating it should be implemented with a particular
+    * Xilinx RAM structure.
+    */
+  def apply(mem: chisel3.MemBase[_], style: RAMStyle): Unit = {
+    annotate(style, mem.toTarget)
+  }
+}

--- a/sim/midas/targetutils/src/main/scala/midas/xdc/RAMStyleHint.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/xdc/RAMStyleHint.scala
@@ -2,9 +2,8 @@
 
 package midas.targetutils.xdc
 
-import chisel3.experimental.{ChiselAnnotation}
+import chisel3.experimental.ChiselAnnotation
 import firrtl.annotations.ReferenceTarget
-import midas.targetutils.xdc.{XDCFiles, XDCAnnotation}
 
 sealed trait RAMStyle
 

--- a/sim/midas/targetutils/src/test/scala/RAMStyleHintSpec.scala
+++ b/sim/midas/targetutils/src/test/scala/RAMStyleHintSpec.scala
@@ -1,0 +1,119 @@
+// See LICENSE for license details.
+
+package midas.targetutils
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import chisel3._
+import firrtl.annotations.ModuleTarget
+
+class RAMStyleHintSpec extends AnyFlatSpec with ElaborationUtils {
+  import midas.targetutils.xdc._
+  class MemoryModuleIO(addrBits: Int, dataBits: Int) extends Bundle {
+    val readAddress  = Input(UInt(addrBits.W))
+    val readEnable   = Input(Bool())
+    val readData     = Output(UInt(dataBits.W))
+
+    val writeAddress = Input(UInt(addrBits.W))
+    val writeData    = Input(UInt(dataBits.W))
+    val writeEnable  = Input(Bool())
+  }
+
+  abstract class BaseMemoryModule(style: Option[RAMStyle]) extends Module {
+    // Arbitrarily selected.
+    val dataBits = 64
+    val addrBits = 16
+    val io = IO(new MemoryModuleIO(addrBits, dataBits))
+
+    def mem: MemBase[_]
+    style.foreach { RAMStyleHint(mem, _) }
+
+    def expectedAnnotation: XDCAnnotation =
+      XDCAnnotation(
+        XDCFiles.Synthesis,
+        RAMStyleHint.propertyTemplate(style.get),
+        ModuleTarget(this.instanceName, this.instanceName).ref(mem.instanceName)
+      )
+  }
+
+
+  class SyncReadMemModule(style: Option[RAMStyle]) extends BaseMemoryModule(style) {
+    // Lazy so this is elaborated  before annotator executes
+    lazy val mem = SyncReadMem(1 << addrBits, UInt(dataBits.W))
+    io.readData := mem.read(io.readAddress, io.readEnable)
+    when(io.writeEnable) { mem(io.writeAddress) := io.writeData }
+  }
+
+  // This uses a combinational-read chisel memory, but could be infered as a BRAM
+  // due to the pipelining of the data read out. So the check annotator still accepts these.
+  class CombReadMemModule(style: Option[RAMStyle]) extends BaseMemoryModule(style) {
+    lazy val mem = Mem(1 << addrBits, UInt(dataBits.W))
+    when(io.readEnable)  { io.readData          := RegNext(mem(io.readAddress)) }
+    when(io.writeEnable) { mem(io.writeAddress) := io.writeData }
+  }
+
+  def checkSingleTargetModule(gen: =>BaseMemoryModule): Unit = {
+    // Lazy, so that we may introspect on the elaborated module class
+    lazy val mod = gen
+    val annos = elaborate(mod)._2.collect { case a: XDCAnnotation => a }
+    assert(annos.size == 1)
+    assert(annos.head == mod.expectedAnnotation)
+  }
+
+  behavior of "RAMStyleHint"
+
+  // Sanity check that stuff passes through elaboration. 
+  it should "correctly annotate a chisel3.SyncReadMem as BRAM" in {
+    checkSingleTargetModule(new SyncReadMemModule(Some(RAMStyles.BRAM)))
+  }
+
+  it should "correctly annotate a chisel3.SyncReadMem as URAM" in {
+    checkSingleTargetModule(new SyncReadMemModule(Some(RAMStyles.ULTRA)))
+  }
+
+  it should "correctly annotate a chisel3.Mem as URAM" in {
+    checkSingleTargetModule(new CombReadMemModule(Some(RAMStyles.ULTRA)))
+  }
+
+  it should "correctly annotate a chisel3.Mem as BRAM" in {
+    checkSingleTargetModule(new CombReadMemModule(Some(RAMStyles.BRAM)))
+  }
+
+  class WrapperModule extends Module {
+    val a = IO(new MemoryModuleIO(64, 16))
+    val b = IO(new MemoryModuleIO(64, 16))
+
+    val modA = Module(new SyncReadMemModule(None))
+    val modB = Module(new SyncReadMemModule(None))
+    modA.io <> a
+    modB.io <> b
+
+    RAMStyleHint(modA.mem, RAMStyles.ULTRA)
+    RAMStyleHint(modB.mem, RAMStyles.BRAM)
+
+    private def expectedAnnotation(mod: SyncReadMemModule, style: RAMStyle) = XDCAnnotation(
+        XDCFiles.Synthesis,
+        RAMStyleHint.propertyTemplate(style),
+        ModuleTarget(this.instanceName, this.instanceName).instOf(mod.instanceName, mod.getClass().getSimpleName()).ref(mod.mem.instanceName)
+    )
+    def expectedAnnos = Seq(
+      expectedAnnotation(modA, RAMStyles.ULTRA),
+      expectedAnnotation(modB, RAMStyles.BRAM),
+    )
+  }
+
+  it should "not trivially break deduplication" in {
+    lazy val mod = new WrapperModule()
+    val annos = elaborateAndLower(mod)
+
+    val dedupResultAnnos = annos.collect { case a: firrtl.transforms.DedupedResult => a }
+    assert(dedupResultAnnos.size == 2)
+
+    val xdcAnnos = annos.collect { case a: XDCAnnotation => a }
+    assert(xdcAnnos.size == 2)
+    mod.expectedAnnos.foreach {
+      anno => assert(xdcAnnos.contains(anno))
+    }
+  }
+}


### PR DESCRIPTION
This will be needed to support local FPGA work as it removes duplication of constraint files across different platforms. 

You deploy this like so:
```
import midas.targetutils.xdc.{RAMStyleHint, RAMStyles} 

val myMem = SyncReadMem(<params>)
RAMStyleHint(myMem, RAMStyles.ULTRA) // For a URAM-based implementation
```

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

Expands. Makes it possible to coax vivado into using URAMs without changing the directives.

#### Verilog / AGFI Compatibility

No -- however I'll regenerate AGFIs when i deploy these in the StreamEngine.
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
