### PR TITLE
[ci] Run ScalaDoc builds on PRs to main and stable/backport branches

### DIFF
--- a/.github/workflows/firesim-publish-scala-doc.yml
+++ b/.github/workflows/firesim-publish-scala-doc.yml
@@ -1,11 +1,17 @@
 name: firesim-publish-scala-doc
 
 on:
+  # On pushes to these branches / tags publish the scala doc to GH pages.
   push:
     branches:
       - main
     tags:
       - '[0-9]*.[0-9]*.[0-9]*'
+  # On PRs to stable or main, check that the docs build correctly without publishing
+  pull_request:
+    branches:
+      - main
+      - '1.[0-9]*.x'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -19,8 +25,27 @@ env:
   LC_ALL: "en_US.UTF-8"
 
 jobs:
+  change-filters:
+    name: filter-jobs-on-changes
+    runs-on: ubuntu-18.04
+    # Queried by downstream jobs to determine if they should run.
+    outputs:
+      needs-scala-doc: ${{ steps.filter.outputs.scala-docs }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            scala-docs:
+              - '**/build.sbt'
+              - '**/*.scala'
+
   publish-scala-doc:
     name: publish-scala-doc
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-scala-doc == 'true'
     runs-on: ubuntu-18.04
     container:
       image: firesim/firesim-ci:v1.3
@@ -31,4 +56,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/repo-setup
       - uses: ./.github/actions/build-scala-doc
-      - uses: ./.github/actions/push-scaladoc-to-ghpages
+      - name: "Push ScalaDoc to remote"
+        if: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/push-scaladoc-to-ghpages


### PR DESCRIPTION
This ensures that most of the scaladoc build runs on PRs. If we decide to enable post-merge CI we could publish from the manager instead. 

Lets merge this before #1024, so that it may be tested in PR against main. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

Resolves #1019. 

<!-- List any related issues here -->

#### UI / API Impact

None

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

NC

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
