### PR TITLE
Use thin client for CI + Use sbt script by default

### DIFF
--- a/.github/scripts/run-sbt-command.py
+++ b/.github/scripts/run-sbt-command.py
@@ -16,7 +16,7 @@ def run_sbt_command(target_project, command):
     """
 
     with cd(manager_fsim_dir), prefix('source env.sh'):
-        run("make -C sim sbt SBT_COMMAND={} TARGET_PROJECT={}".format(command, target_project))
+        run(f"make -C sim sbt SBT_COMMAND={command} TARGET_PROJECT={target_project} ENABLE_SBT_THIN_CLIENT=1")
 
 if __name__ == "__main__":
     set_fabric_firesim_pem()

--- a/.github/scripts/run-scala-test.py
+++ b/.github/scripts/run-scala-test.py
@@ -16,7 +16,7 @@ def run_scala_test(target_project, test_name):
     with cd(manager_fsim_dir), prefix('source env.sh'):
         # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
         with settings(warn_only=True):
-            rc = run("make -C sim testOnly TARGET_PROJECT={} SCALA_TEST={} &> scala-test.full.log".format(target_project, test_name)).return_code
+            rc = run(f"make -C sim testOnly TARGET_PROJECT={target_project} SCALA_TEST={test_name} ENABLE_SBT_THIN_CLIENT=1 &> scala-test.full.log").return_code
             if rc != 0:
                 run("cat scala-test.full.log")
                 raise Exception("Running scala test failed")

--- a/.github/scripts/run-scala-test.py
+++ b/.github/scripts/run-scala-test.py
@@ -15,10 +15,14 @@ def run_scala_test(target_project, test_name):
     """
     with cd(manager_fsim_dir), prefix('source env.sh'):
         # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
+
+        # Use a custom command instead of the make target so that we can pass
+        # an extra argument to ScalaTest to dispatch secondary SBT calls to a
+        # running sbt server (which avoids constainly relaunching the JVM).
+        sbt_command = f"testOnly {test_name} -- -Denable-thin-client=true"
         with settings(warn_only=True):
-            rc = run(f"make -C sim testOnly TARGET_PROJECT={target_project} SCALA_TEST={test_name} ENABLE_SBT_THIN_CLIENT=1 &> scala-test.full.log").return_code
+            rc = run(f"""make -C sim TARGET_PROJECT={target_project} sbt SBT_COMMAND="{sbt_command}" """).return_code
             if rc != 0:
-                run("cat scala-test.full.log")
                 raise Exception("Running scala test failed")
 
 if __name__ == "__main__":

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -53,7 +53,7 @@ override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 SBT_CLIENT_FLAG = --client
 endif
 
-SBT ?= java $(JAVA_OPTS) -jar $(rocketchip_dir)/sbt-launch.jar $(SBT_OPTS) $(SBT_CLIENT_FLAG)
+SBT ?= sbt $(SBT_CLIENT_FLAG)
 
 define run_scala_main
 	cd $(base_dir) && $(SBT) ";project $(1); runMain $(2) $(3)"


### PR DESCRIPTION
Fixes #1015 

#### Related PRs / Issues

Fixes #1015. The `sbt` native script is used by default so that the thin client properly manages return codes (otherwise if you use the `sbt-launch.jar` way, you will always get a `0` return code).

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
