### PR TITLE
Small CI cleanup

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -53,16 +53,6 @@ def get_manager_instance(tag_value):
     else:
         return None
 
-def get_manager_instance_id(tag_value):
-    """ Looks up the manager instance ID using the CI workflow run's unique tag"""
-
-    manager = get_manager_instance(tag_value)
-    if manager is None:
-        print("No manager instance running with tag matching the assigned workflow id\n")
-        sys.exit(1)
-    else:
-        return manager['InstanceId']
-
 def get_manager_ip(tag_value):
     """ Looks up the manager IP using the CI workflow run's unique tag"""
 

--- a/.github/scripts/launch-manager-instance.py
+++ b/.github/scripts/launch-manager-instance.py
@@ -31,7 +31,7 @@ def main():
     manager_instance = get_manager_instance(ci_workflow_run_id)
 
     print("Instance ready.")
-    print(instance_metadata_str(get_manager_instance(ci_workflow_run_id)))
+    print(instance_metadata_str(manager_instance))
     sys.stdout.flush()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Taken from #1016. Remove an unused CI function and dedup an extra CI function call. Doesn't cause any issues right now but figured this was a small cleanup.

#### Related PRs / Issues

#1016

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
