### PR TITLE
CI: Catch bad manager initialization in workflow control flow

### DIFF
--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -99,8 +99,7 @@ jobs:
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
       - name: Catch potentially orphaned manager
-        # Only catch cancelled jobs since the workflow monitor and try / catch in initialize manager
-        # will managed on-failure behavior
+        # Only catch cancelled jobs since the workflow monitor and try / catch in initialize manager should capture on-failure behavior
         if: ${{ cancelled() }}
         run: .github/scripts/change-workflow-instance-states.py ${{ github.run_id }} terminate ${{ github.token }}
 

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -99,7 +99,8 @@ jobs:
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
       - name: Catch potentially orphaned manager
-        # Only catch cancelled jobs since the workflow monitor and try / catch in initialize manager should capture on-failure behavior
+        # Only catch cancelled jobs since the workflow monitor and try / catch
+        # in initialize manager should capture on-failure behavior
         if: ${{ cancelled() }}
         run: .github/scripts/change-workflow-instance-states.py ${{ github.run_id }} terminate ${{ github.token }}
 

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -82,6 +82,9 @@ jobs:
         run: ./.github/scripts/launch-manager-instance.py
       - name: Setup N Github Actions Runners on AWS instance
         run: ./.github/scripts/setup-manager-self-hosted.py
+      - name: Catch potentially orphaned manager
+        if: ${{ failure() || cancelled() }}
+        run: .github/scripts/change-workflow-instance-states.py ${{ github.run_id }} terminate ${{ github.token }}
 
   setup-manager:
     name: setup-manager
@@ -95,6 +98,11 @@ jobs:
           max-runtime-hours: 10
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
+      - name: Catch potentially orphaned manager
+        # Only catch cancelled jobs since the workflow monitor and try / catch in initialize manager
+        # will managed on-failure behavior
+        if: ${{ cancelled() }}
+        run: .github/scripts/change-workflow-instance-states.py ${{ github.run_id }} terminate ${{ github.token }}
 
   build-default-workloads:
     # Conditionally build rootfs images only if deploying to FPGA to save CI resources


### PR DESCRIPTION
This massages the jobs associated with manager initialization so that any failure that occurs before the workflow monitor is brought up is caught and the instance can be brought down. 

There are a bunch of try-catch blocks in the python itself that tries to do the same, but this is more comprehensive. 


<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
