### PR TITLE
Fix CI FPGA sim timeout issue + Use Python3 formatting in `run_linux_poweroff` CI script

### DIFF
--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -10,7 +10,7 @@ from ci_variables import ci_workflow_run_id
 def run_linux_poweroff():
     """ Runs Linux poweroff workloads """
 
-    with prefix('cd {} && source sourceme-f1-manager.sh'.format(manager_fsim_dir)):
+    with prefix(f"cd {manager_fsim_dir} && source sourceme-f1-manager.sh"):
         run("cd sw/firesim-software && ./marshal -v build br-base.json && ./marshal -v install br-base.json")
         run("cd deploy/workloads/ && make linux-poweroff")
 
@@ -22,33 +22,33 @@ def run_linux_poweroff():
             """
             log_tail_length = 100
             # rename runfarm tag with a unique tag based on the ci workflow
-            with prefix('export FIRESIM_RUNFARM_PREFIX={}'.format(ci_workflow_run_id)):
+            with prefix(f"export FIRESIM_RUNFARM_PREFIX={ci_workflow_run_id}"):
                 rc = 0
                 with settings(warn_only=True):
                     # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
                     # pty=False needed to avoid issues with screen -ls stalling in fabric
-                    rc = run("timeout {} ./deploy/workloads/run-workload.sh {} --withlaunch &> {}.log".format(timeout, workload, workload), pty=False).return_code
-                    print(" Printing last {} lines of log. See {}.log for full info.".format(log_tail_length, workload))
-                    run("tail -n {} {}.log".format(log_tail_length, workload))
+                    rc = run(f"timeout {timeout} ./deploy/workloads/run-workload.sh {workload} --withlaunch &> {workload}.log", pty=False).return_code
+                    print(f" Printing last {log_tail_length} lines of log. See {workload}.log for full info.")
+                    run(f"tail -n {log_tail_length} {workload}.log")
 
                     # This is a janky solution to the fact the manager does not
                     # return a non-zero exit code or some sort of result summary.
                     # The expectation here is that the PR author will manually
                     # check these output files for correctness until it can be
                     # done programmatically..
-                    print(" Printing last {} lines of all output files. See results-workload for more info.".format(log_tail_length))
-                    run("cd deploy/results-workload/ && tail -n{} $(ls | tail -n1)/*/*".format(log_tail_length))
+                    print(f"Printing last {log_tail_length} lines of all output files. See results-workload for more info.")
+                    run(f"cd deploy/results-workload/ && tail -n{log_tail_length} $(ls | tail -n1)/*/*")
 
                 if rc != 0:
                     # need to confirm that instance is off
-                    print("Workload {} failed. Terminating runfarm.".format(workload))
-                    run("firesim terminaterunfarm -q -c {}".format(workload))
+                    print(f"Workload {workload} failed. Terminating runfarm.")
+                    run(f"firesim terminaterunfarm -q -c {workload}")
                     sys.exit(rc)
                 else:
-                    print("Workload {} successful.".format(workload))
+                    print(f"Workload {workload} successful.")
 
-        run_w_timeout("{}/deploy/workloads/linux-poweroff-all-no-nic.yaml".format(manager_fsim_dir), "30m")
-        run_w_timeout("{}/deploy/workloads/linux-poweroff-nic.yaml".format(manager_fsim_dir), "30m")
+        run_w_timeout(f"{manager_fsim_dir}/deploy/workloads/linux-poweroff-all-no-nic.yaml", "30m")
+        run_w_timeout(f"{manager_fsim_dir}/deploy/workloads/linux-poweroff-nic.yaml", "30m")
 
 if __name__ == "__main__":
     set_fabric_firesim_pem()

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -37,7 +37,7 @@ def run_linux_poweroff():
                     # check these output files for correctness until it can be
                     # done programmatically..
                     print(f"Printing last {log_tail_length} lines of all output files. See results-workload for more info.")
-                    run(f"cd deploy/results-workload/ && tail -n{log_tail_length} $(ls | tail -n1)/*/*")
+                    run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then tail -n{log_tail_length} $LAST_DIR/*/*; fi""")
 
                 if rc != 0:
                     # need to confirm that instance is off


### PR DESCRIPTION
This fixes a timeout issue introduced by printing workload outputs. If there is no output folder, do not try to print things. Otherwise, gibberish is dumped to the screen infinitely which hangs GH-A.

You can reproduce the issue by having an empty directory and running `tail -n10 $(ls | tail -n1)/*/*` within it.

#### Related PRs / Issues

Fixes #1012.

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
