### PR TITLE
add bash-completion and install argcomplete global into it

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -253,6 +253,7 @@ set -o pipefail
     CONDA_PACKAGE_SPECS+=( autoconf automake libtool )
     # other misc deps
     CONDA_PACKAGE_SPECS+=(
+        bash-completion \
         sbt \
         ca-certificates \
         mosh \
@@ -343,7 +344,9 @@ set -o pipefail
 
 
     argcomplete_extra_args=()
-    if [[ "$INSTALL_TYPE" != system ]]; then
+    if [[ "$INSTALL_TYPE" == system ]]; then
+	argcomplete_extra_args=( --dest "${CONDA_ENV_BIN}/../share/bash-completion/completions" )
+    else
         # if we're aren't installing into a system directory, then initialize argcomplete
         # with --user so that it goes into the home directory
         argcomplete_extra_args=( --user )

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -345,7 +345,10 @@ set -o pipefail
 
     argcomplete_extra_args=()
     if [[ "$INSTALL_TYPE" == system ]]; then
-	argcomplete_extra_args=( --dest "${CONDA_ENV_BIN}/../share/bash-completion/completions" )
+        BASH_COMPLETION_COMPAT_DIR="${CONDA_ENV_BIN}/../etc/bash_completion.d"
+        "${DRY_RUN_ECHO[@]}" $SUDO mkdir -p "${BASH_COMPLETION_COMPAT_DIR}"
+        argcomplete_extra_args=( --dest "${BASH_COMPLETION_COMPAT_DIR}" )
+
     else
         # if we're aren't installing into a system directory, then initialize argcomplete
         # with --user so that it goes into the home directory


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->
fixes #1039 

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

Should make bash-completion work in the conda environment.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
