### PR TITLE
Remove the data_t type alias + unused macros in generated header

### DIFF
--- a/sim/midas/src/main/cc/bridges/bridge_driver.h
+++ b/sim/midas/src/main/cc/bridges/bridge_driver.h
@@ -35,11 +35,11 @@ public:
   // DOC include end: Bridge Driver Interface
 
 protected:
-  void write(size_t addr, data_t data) {
+  void write(size_t addr, uint32_t data) {
     sim->write(addr, data);
   }
 
-  data_t read(size_t addr) {
+  uint32_t read(size_t addr) {
     return sim->read(addr);
   }
 

--- a/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
+++ b/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
@@ -36,8 +36,8 @@
 constexpr int HISTOGRAM_SIZE = 1024;
 constexpr int BIN_SIZE = 36;
 constexpr int RANGE_COUNT_SIZE = 48;
-constexpr data_t BIN_H_MASK = (1L << (BIN_SIZE - 32)) - 1;
-constexpr data_t RANGE_H_MASK = (1L << (RANGE_COUNT_SIZE - 32)) - 1;
+constexpr uint32_t BIN_H_MASK = (1L << (BIN_SIZE - 32)) - 1;
+constexpr uint32_t RANGE_H_MASK = (1L << (RANGE_COUNT_SIZE - 32)) - 1;
 
 class AddrRangeCounter: public FpgaModel {
   public:

--- a/sim/midas/src/main/cc/bridges/fpga_model.h
+++ b/sim/midas/src/main/cc/bridges/fpga_model.h
@@ -33,24 +33,23 @@ public:
 protected:
   AddressMap addr_map;
 
-  void write(size_t addr, data_t data) {
+  void write(size_t addr, uint32_t data) {
     sim->write(addr, data);
   }
 
-  data_t read(size_t addr) {
+  uint32_t read(size_t addr) {
     return sim->read(addr);
   }
 
-  void write(std::string reg, data_t data){
+  void write(std::string reg, uint32_t data){
     sim->write(addr_map.w_addr(reg), data);
   }
 
-  data_t read(std::string reg){
+  uint32_t read(std::string reg){
     return sim->read(addr_map.r_addr(reg));
   }
 
-  uint64_t read64(std::string msw, std::string lsw, data_t upper_word_mask) {
-    assert(sizeof(data_t) == 4);
+  uint64_t read64(std::string msw, std::string lsw, uint32_t upper_word_mask) {
     uint64_t data = ((uint64_t) (read(msw) & upper_word_mask)) << 32;
     return data | read(lsw);
   }

--- a/sim/midas/src/main/cc/simif.cc
+++ b/sim/midas/src/main/cc/simif.cc
@@ -55,15 +55,15 @@ void simif_t::init(int argc, char** argv) {
 
 uint64_t simif_t::actual_tcycle() {
     write(this->clock_bridge_mmio_addrs->tCycle_latch, 1);
-    data_t cycle_l = read(this->clock_bridge_mmio_addrs->tCycle_0);
-    data_t cycle_h = read(this->clock_bridge_mmio_addrs->tCycle_1);
+    uint32_t cycle_l = read(this->clock_bridge_mmio_addrs->tCycle_0);
+    uint32_t cycle_h = read(this->clock_bridge_mmio_addrs->tCycle_1);
     return (((uint64_t) cycle_h) << 32) | cycle_l;
 }
 
 uint64_t simif_t::hcycle() {
     write(this->clock_bridge_mmio_addrs->hCycle_latch, 1);
-    data_t cycle_l = read(this->clock_bridge_mmio_addrs->hCycle_0);
-    data_t cycle_h = read(this->clock_bridge_mmio_addrs->hCycle_1);
+    uint32_t cycle_l = read(this->clock_bridge_mmio_addrs->hCycle_0);
+    uint32_t cycle_h = read(this->clock_bridge_mmio_addrs->hCycle_1);
     return (((uint64_t) cycle_h) << 32) | cycle_l;
 }
 
@@ -92,16 +92,16 @@ void simif_t::load_mem(std::string filename) {
   fprintf(stdout, "[loadmem] done\n");
 }
 
-// NB: mpz_t variables may not export <size> <data_t> beats, if initialized with an array of zeros.
+// NB: mpz_t variables may not export <size> <uint32_t> beats, if initialized with an array of zeros.
 void simif_t::read_mem(size_t addr, mpz_t& value) {
   write(this->loadmem_mmio_addrs->R_ADDRESS_H, addr >> 32);
   write(this->loadmem_mmio_addrs->R_ADDRESS_L, addr & ((1ULL << 32) - 1));
   const size_t size = MEM_DATA_CHUNK;
-  data_t data[size];
+  uint32_t data[size];
   for (size_t i = 0 ; i < size ; i++) {
     data[i] = read(this->loadmem_mmio_addrs->R_DATA);
   }
-  mpz_import(value, size, -1, sizeof(data_t), 0, 0, data);
+  mpz_import(value, size, -1, sizeof(uint32_t), 0, 0, data);
 }
 
 void simif_t::write_mem(size_t addr, mpz_t& value) {
@@ -109,13 +109,13 @@ void simif_t::write_mem(size_t addr, mpz_t& value) {
   write(this->loadmem_mmio_addrs->W_ADDRESS_L, addr & ((1ULL << 32) - 1));
   write(this->loadmem_mmio_addrs->W_LENGTH, 1);
   size_t size;
-  data_t* data = (data_t*)mpz_export(NULL, &size, -1, sizeof(data_t), 0, 0, value);
+  uint32_t* data = (uint32_t*)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
   for (size_t i = 0 ; i < MEM_DATA_CHUNK ; i++) {
     write(this->loadmem_mmio_addrs->W_DATA, i < size ? data[i] : 0);
   }
 }
 
-#define MEM_DATA_CHUNK_BYTES (MEM_DATA_CHUNK*sizeof(data_t))
+#define MEM_DATA_CHUNK_BYTES (MEM_DATA_CHUNK*sizeof(uint32_t))
 #define ceil_div(a, b) (((a) - 1) / (b) + 1)
 
 void simif_t::write_mem_chunk(size_t addr, mpz_t& value, size_t bytes) {
@@ -124,7 +124,7 @@ void simif_t::write_mem_chunk(size_t addr, mpz_t& value, size_t bytes) {
   size_t num_beats = ceil_div(bytes, MEM_DATA_CHUNK_BYTES);
   write(this->loadmem_mmio_addrs->W_LENGTH, num_beats);
   size_t size;
-  data_t* data = (data_t*)mpz_export(NULL, &size, -1, sizeof(data_t), 0, 0, value);
+  uint32_t* data = (uint32_t*)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
   for (size_t i = 0 ; i < num_beats * MEM_DATA_CHUNK ; i++) {
     write(this->loadmem_mmio_addrs->W_DATA, i < size ? data[i] : 0);
   }

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -62,8 +62,8 @@ class simif_t
 
     // Widget communication
     // 32b MMIO, issued over the simulation control bus (AXI4-lite).
-    virtual void write(size_t addr, data_t data) = 0;
-    virtual data_t read(size_t addr) = 0;
+    virtual void write(size_t addr, uint32_t data) = 0;
+    virtual uint32_t read(size_t addr) = 0;
 
     // Bulk transfers / bridge streaming interfaces.
 

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -136,15 +136,15 @@ void simif_emul_t::wait_read(std::unique_ptr<mmio_t>& mmio, void *data) {
   while(!mmio->read_resp(data)) advance_target();
 }
 
-void simif_emul_t::write(size_t addr, data_t data) {
+void simif_emul_t::write(size_t addr, uint32_t data) {
   size_t strb = (1 << CTRL_STRB_BITS) - 1;
   static_assert(CTRL_AXI4_SIZE == 2, "AXI4-lite control interface has unexpected size");
   master->write_req(addr, CTRL_AXI4_SIZE, 0, &data, &strb);
   wait_write(master);
 }
 
-data_t simif_emul_t::read(size_t addr) {
-  data_t data;
+uint32_t simif_emul_t::read(size_t addr) {
+  uint32_t data;
   master->read_req(addr, CTRL_AXI4_SIZE, 0);
   wait_read(master, &data);
   return data;

--- a/sim/midas/src/main/cc/simif_emul.h
+++ b/sim/midas/src/main/cc/simif_emul.h
@@ -20,8 +20,8 @@ class simif_emul_t : public virtual simif_t
     virtual void host_init(int argc, char** argv);
     virtual int  host_finish();
 
-    virtual void write(size_t addr, data_t data);
-    virtual data_t read(size_t addr);
+    virtual void write(size_t addr, uint32_t data);
+    virtual uint32_t read(size_t addr);
     virtual ssize_t pull(size_t addr, char* data, size_t size);
     virtual ssize_t push(size_t addr, char* data, size_t size);
 

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -35,7 +35,6 @@ abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
     sb.append("#include <stdint.h>\n")
     sb.append("#include <stdbool.h>\n")
     sb.append(genStatic("TARGET_NAME", CStrLit(target)))
-    sb.append(genMacro("PLATFORM_TYPE", s"V${this.getClass.getSimpleName}"))
     sb.append(genMacro("data_t", "uint32_t"))
     top.module.genHeader(sb)
     sb.append("\n// Simulation Constants\n")

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -35,7 +35,6 @@ abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
     sb.append("#include <stdint.h>\n")
     sb.append("#include <stdbool.h>\n")
     sb.append(genStatic("TARGET_NAME", CStrLit(target)))
-    sb.append(genMacro("data_t", "uint32_t"))
     top.module.genHeader(sb)
     sb.append("\n// Simulation Constants\n")
     top.module.headerConsts map { case (name, value) =>

--- a/sim/src/main/cc/firesim/systematic_scheduler.h
+++ b/sim/src/main/cc/firesim/systematic_scheduler.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 // Maximum step size in MIDAS's master is capped to width of the simulation bus
-constexpr uint64_t MAX_MIDAS_STEP = (1LL << sizeof(data_t) * 8) - 1;
+constexpr uint64_t MAX_MIDAS_STEP = (1LL << sizeof(uint32_t) * 8) - 1;
 
 // Schedules a series of tasks that must run a specific cycles on the FPGA, but
 // may be associated with multiple bridges / touch non-bridge simulator

--- a/sim/src/main/cc/midasexamples/MultiRegfile.h
+++ b/sim/src/main/cc/midasexamples/MultiRegfile.h
@@ -70,8 +70,8 @@ protected:
     for (size_t i = 0; i < multireg_n_copies; i++) {
       for (size_t w_idx = 0; w_idx < multireg_n_writes; w_idx++) {
         if (rand() % 2) {
-          data_t rand_data = rand();
-          data_t rand_addr = rand() % mem_depth;
+          uint32_t rand_data = rand();
+          uint32_t rand_addr = rand() % mem_depth;
           auto mem_slot = std::make_pair(i, rand_addr);
           while (history.count(mem_slot) && history[mem_slot].second == cycle_num) {
             // already written this cycle => would be undefined write collision
@@ -86,7 +86,7 @@ protected:
         }
       }
       for (size_t r_idx = 0; r_idx < multireg_n_reads; r_idx++) {
-        data_t rand_addr = rand() % mem_depth;
+        uint32_t rand_addr = rand() % mem_depth;
         prev_reads[std::make_pair(i, r_idx)] = rand_addr;
         poke(multireg_r_addr_ios[i][r_idx], rand_addr);
       }
@@ -94,7 +94,7 @@ protected:
     step(1);
     for (size_t i = 0; i < multireg_n_copies; i++) {
       for (size_t r_idx = 0; r_idx < multireg_n_reads; r_idx++) {
-        data_t prev_addr = prev_reads[std::make_pair(i, r_idx)];
+        uint32_t prev_addr = prev_reads[std::make_pair(i, r_idx)];
         auto mem_slot = std::make_pair(i, prev_addr);
         if (history.count(mem_slot)) {
           auto w_op = history[mem_slot];
@@ -105,6 +105,6 @@ protected:
     }
   }
 
-  std::map< std::pair<size_t, data_t>, std::pair<data_t, size_t> > history;
-  std::map< std::pair<size_t, size_t>, data_t > prev_reads;
+  std::map< std::pair<size_t, uint32_t>, std::pair<uint32_t, size_t> > history;
+  std::map< std::pair<size_t, size_t>, uint32_t > prev_reads;
 };

--- a/sim/src/main/cc/midasexamples/Regfile.h
+++ b/sim/src/main/cc/midasexamples/Regfile.h
@@ -37,8 +37,8 @@ private:
   void do_iteration(size_t cycle_num) {
     for (size_t w_idx = 0; w_idx < reg_n_writes; w_idx++) {
       if (rand() % 2) {
-        data_t rand_data = rand();
-        data_t rand_addr = rand() % mem_depth;
+        uint32_t rand_data = rand();
+        uint32_t rand_addr = rand() % mem_depth;
         while (history.count(rand_addr) && history[rand_addr].second == cycle_num) {
           // already written this cycle => would be undefined write collision
           rand_addr = rand() % mem_depth;
@@ -52,13 +52,13 @@ private:
       }
     }
     for (size_t r_idx = 0; r_idx < reg_n_reads; r_idx++) {
-      data_t rand_addr = rand() % mem_depth;
+      uint32_t rand_addr = rand() % mem_depth;
       prev_reads[r_idx] = rand_addr;
       poke(reg_r_addr_ios[r_idx], rand_addr);
     }
     step(1);
     for (size_t r_idx = 0; r_idx < reg_n_reads; r_idx++) {
-      data_t prev_addr = prev_reads[r_idx];
+      uint32_t prev_addr = prev_reads[r_idx];
       if (history.count(prev_addr)) {
         expect(reg_r_data_ios[r_idx], history[prev_addr].first);
       }
@@ -67,6 +67,6 @@ private:
 
  private:
 
-  std::map< data_t, std::pair<data_t, size_t> > history;
-  std::map< size_t, data_t > prev_reads;
+  std::map< uint32_t, std::pair<uint32_t, size_t> > history;
+  std::map< size_t, uint32_t > prev_reads;
 };

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.cc
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.cc
@@ -13,7 +13,7 @@ void simif_peek_poke_t::target_reset(int pulse_length) {
   poke(reset, 0);
 }
 
-static const size_t data_t_chunks = sizeof(data_t) / sizeof(uint32_t);
+static const size_t uint32_t_chunks = sizeof(uint32_t) / sizeof(uint32_t);
 
 void simif_peek_poke_t::step(uint32_t n, bool blocking) {
   if (n == 0) return;
@@ -23,7 +23,7 @@ void simif_peek_poke_t::step(uint32_t n, bool blocking) {
   t += n;
 }
 
-void simif_peek_poke_t::poke(size_t id, data_t value, bool blocking) {
+void simif_peek_poke_t::poke(size_t id, uint32_t value, bool blocking) {
   if (blocking && !wait_on_ready(10.0)) {
     if (log) {
       std::string fmt = "* FAIL : POKE on %s.%s has timed out. %s : FAIL\n";
@@ -36,7 +36,7 @@ void simif_peek_poke_t::poke(size_t id, data_t value, bool blocking) {
   write(INPUT_ADDRS[id], value);
 }
 
-data_t simif_peek_poke_t::peek(size_t id, bool blocking) {
+uint32_t simif_peek_poke_t::peek(size_t id, bool blocking) {
   if (blocking && !wait_on_ready(10.0)) {
     if (log) {
       std::string fmt = "* FAIL : PEEK on %s.%s has timed out. %s : FAIL\n";
@@ -48,18 +48,18 @@ data_t simif_peek_poke_t::peek(size_t id, bool blocking) {
   bool peek_may_be_unstable = blocking && !wait_on_stable_peeks(0.1);
   if (log && peek_may_be_unstable)
     fprintf(stderr, "* WARNING : The following peek is on an unstable value!\n");
-  data_t value = read(((unsigned int*) OUTPUT_ADDRS)[id]);
+  uint32_t value = read(((unsigned int*) OUTPUT_ADDRS)[id]);
   if (log)
     fprintf(stderr, "* PEEK %s.%s -> 0x%x *\n", TARGET_NAME, (const char*) OUTPUT_NAMES[id], value);
   return value;
 }
 
-data_t simif_peek_poke_t::sample_value(size_t id) {
+uint32_t simif_peek_poke_t::sample_value(size_t id) {
   return peek(id, false);
 }
 
-bool simif_peek_poke_t::expect(size_t id, data_t expected) {
-  data_t value = peek(id);
+bool simif_peek_poke_t::expect(size_t id, uint32_t expected) {
+  uint32_t value = peek(id);
   bool pass = value == expected;
   if (log) {
     fprintf(stderr, "* EXPECT %s.%s -> 0x%x ?= 0x%x : %s\n",
@@ -82,19 +82,19 @@ void simif_peek_poke_t::poke(size_t id, mpz_t& value) {
     free(v_str);
   }
   size_t size;
-  data_t* data = (data_t*)mpz_export(NULL, &size, -1, sizeof(data_t), 0, 0, value);
+  uint32_t* data = (uint32_t*)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
   for (size_t i = 0 ; i < INPUT_CHUNKS[id] ; i++) {
-    write(INPUT_ADDRS[id]+ (i * sizeof(data_t)), i < size ? data[i] : 0);
+    write(INPUT_ADDRS[id]+ (i * sizeof(uint32_t)), i < size ? data[i] : 0);
   }
 }
 
 void simif_peek_poke_t::peek(size_t id, mpz_t& value) {
   const size_t size = (const size_t)OUTPUT_CHUNKS[id];
-  data_t data[size];
+  uint32_t data[size];
   for (size_t i = 0 ; i < size ; i++) {
-    data[i] = read((size_t)OUTPUT_ADDRS[id] + (i * sizeof(data_t)) );
+    data[i] = read((size_t)OUTPUT_ADDRS[id] + (i * sizeof(uint32_t)) );
   }
-  mpz_import(value, size, -1, sizeof(data_t), 0, 0, data);
+  mpz_import(value, size, -1, sizeof(uint32_t), 0, 0, data);
   if (log) {
     char* v_str = mpz_get_str(NULL, 16, value);
     fprintf(stderr, "* PEEK %s.%s -> 0x%s *\n", TARGET_NAME, (const char*)OUTPUT_NAMES[id], v_str);

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.h
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.h
@@ -30,15 +30,15 @@ class simif_peek_poke_t: public virtual simif_t
     // If using blocking steps, this will be ~equivalent to actual_tcycle()
     uint64_t cycles(){ return t; };
 
-    void poke(size_t id, data_t value, bool blocking = true);
+    void poke(size_t id, uint32_t value, bool blocking = true);
     void poke(size_t id, mpz_t& value);
     void target_reset(int pulse_length = 5);
 
-    data_t peek(size_t id, bool blocking = true);
+    uint32_t peek(size_t id, bool blocking = true);
     void peek(size_t id, mpz_t& value);
-    data_t sample_value(size_t id);
+    uint32_t sample_value(size_t id);
 
-    bool expect(size_t id, data_t expected);
+    bool expect(size_t id, uint32_t expected);
     bool expect(size_t id, mpz_t& expected);
     bool expect(bool pass, const char *s);
 


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

I'm unsure of the origins of `data_t` but it was probably a hold over from FPGA-zynq to potentially encode different MMIO widths on different platforms. Instead, under the new proposed interface, we're just going to call out the widths explicitly. Different widths can be added to the interface, with say `read64` e.g., as we deem fit, and can be implemented by the host layer as necessary.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

No bridges actually use `data_t`.
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

No. 
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
