### PR TITLE
Ensure FPGA Backend passes run before final optimizations

### DIFF
--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
@@ -54,14 +54,16 @@ class GoldenGateCompilerPhase extends Phase {
 
     // Lower simulator RTL and run user-requested host-transforms
     val hostLoweringCompiler = new Compiler(
-      Seq(
+      targets = Seq(
           Dependency(midas.passes.AutoILATransform),
           Dependency(midas.passes.HostClockWiring),
           Dependency[firrtl.passes.memlib.SeparateWriteClocks],
           Dependency[firrtl.passes.memlib.SetDefaultReadUnderWrite],
-          Dependency[firrtl.transforms.SimplifyMems],
-      ) ++
-      p(HostTransforms),Forms.VerilogOptimized)
+          Dependency[firrtl.transforms.SimplifyMems]
+        ) ++
+        Forms.LowForm ++
+        p(HostTransforms),
+      currentState = Forms.LowForm)
     logger.info("Post-GG Host Transformation Ordering\n")
     logger.info(hostLoweringCompiler.prettyPrint("  "))
     val loweredSimulator = hostLoweringCompiler.execute(simulator)
@@ -70,7 +72,7 @@ class GoldenGateCompilerPhase extends Phase {
     // emitter to run last in a seperate compiler.
     val emitter = new Compiler(
         Seq(Dependency(midas.passes.WriteXDCFile), Dependency[firrtl.SystemVerilogEmitter]),
-        Forms.VerilogOptimized)
+        Forms.LowForm)
     logger.info("Final Emission Transformation Ordering\n")
     logger.info(emitter.prettyPrint("  "))
 


### PR DESCRIPTION
This ensures they materialize the changes we want in the output verilog. There are probably better ways to fix this upstream, but this has the desired effect now. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None.
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

Should not change the memory map. Will improve BRAM inference.

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
