### PR TITLE
hide blowfish deprecation warning until 2022-08-31

### DIFF
--- a/deploy/firesim
+++ b/deploy/firesim
@@ -10,7 +10,17 @@ from time import strftime, gmtime
 import logging
 import random
 import argcomplete # type: ignore
-from fabric.api import local, hide, warn_only, env, execute, parallel # type: ignore
+
+from datetime import date
+import warnings
+from cryptography.utils import CryptographyDeprecationWarning
+with warnings.catch_warnings():
+    if date.today() < date(2022, 8, 31):
+        # get rid of deprecation warnings until 2022-08-31
+        # hopefully paramiko-ng bumps before then
+        warnings.filterwarnings('ignore', category=CryptographyDeprecationWarning)
+    from fabric.api import local, hide, warn_only, env, execute, parallel # type: ignore
+
 import string
 from inspect import signature
 from warnings import warn


### PR DESCRIPTION
#### Related PRs / Issues

N/A

#### UI / API Impact

Hides `CryptographyDeprecationWarning: Blowfish has been deprecated` warning from users that prints on every manager run. It has no practical effect anyway. The warning will become visible again after 2022-08-31 if the problem is not fixed by then.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
