### PR TITLE
Fix machine-launch-script.sh git version for 1.13.x release series.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog follows the format defined here: https://keepachangelog.com/en/1.0.0/
 
+## [1.13.5] - 2022-06-13
+Critical fix to git package version in machine-launch-script.sh, only required for newly launched manager instances.
+
+### Fixed
+*  Bump git version specified in machine-launch-script.sh from git224 (no longer available) to git236. #1081
+
 ## [1.13.4] - 2022-04-06
 Critical fix to libdwarf submodule URL. Fix boto3 pagination in manager. Fix synth assert stop-printf pair detection.
 

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -32,7 +32,7 @@ sudo yum -y install dtc
 sudo yum -y remove git
 sudo yum -y install epel-release
 sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
-sudo yum -y install git224
+sudo yum -y install git236
 
 # install verilator
 git clone http://git.veripool.org/git/verilator


### PR DESCRIPTION
git224 is no longer available, git236 is the replacement. This is irrelevant to 1.14.x and future as this has been replaced with a conda-installed git.

#### Related PRs / Issues

CC: @SeahK

#### UI / API Impact

Machine launch script on stable is broken, now it should be fixed.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
