### PR TITLE
Cleanup config initialization

### DIFF
--- a/deploy/build-farm-recipes/aws_ec2.yaml
+++ b/deploy/build-farm-recipes/aws_ec2.yaml
@@ -29,3 +29,4 @@ args:
     spot_max_price: ondemand
     # default location of build directory on build host
     default_build_dir: /home/centos/firesim-build
+    # managerinit arg end

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -37,7 +37,7 @@ from buildtools.bitbuilder import F1BitBuilder
 from util.streamlogger import StreamLogger
 from util.filelineswap import file_line_swap
 
-from typing import Dict, Callable, Type, Optional, TypedDict, get_type_hints
+from typing import Dict, Callable, Type, Optional, TypedDict, get_type_hints, Tuple, List
 
 PLATFORM_LIST = [_.name for _ in Path(__file__).parent.parent.joinpath('platforms').iterdir()]
 
@@ -144,7 +144,19 @@ def managerinit(args: argparse.Namespace):
 
     rootLogger.info("Adding default overrides to config files")
     if args.platform == 'f1':
-        keyword = "managerinit arg start"
+        def get_indexes(lines: List[str], keyword_start: str, keyword_end: str)-> Tuple[int, int]:
+            start_arg_idx = None
+            end_arg_idx = None
+            for i, l in enumerate(lines):
+                if keyword_start in l:
+                    start_arg_idx = i + 1
+                if keyword_end in l:
+                    end_arg_idx = i
+
+            assert start_arg_idx is not None, f"""Unable to find "{keyword_start}" in input lines"""
+            assert end_arg_idx is not None, f"""Unable to find "{keyword_end}" in input lines"""
+
+            return start_arg_idx, end_arg_idx
 
         runfarm_default_file = "run-farm-recipes/aws_ec2.yaml"
         with open(runfarm_default_file, "r") as f:
@@ -152,13 +164,8 @@ def managerinit(args: argparse.Namespace):
         start_lines = [f"base_recipe: {runfarm_default_file}\n"]
         start_lines += ["recipe_arg_overrides:\n"]
 
-        arg_idx = None
-        for i, l in enumerate(rf_recipe_lines):
-            if keyword in l:
-                arg_idx = i + 1
-        assert arg_idx is not None
-
-        rf_recipe_lines = ["  " + l for l in start_lines] + rf_recipe_lines[arg_idx:]
+        start_arg_idx, end_arg_idx = get_indexes(rf_recipe_lines, "managerinit arg start", "managerinit arg end")
+        rf_recipe_lines = ["  " + l for l in start_lines] + rf_recipe_lines[start_arg_idx:end_arg_idx]
 
         file_line_swap(
             "config_runtime.yaml",
@@ -173,13 +180,8 @@ def managerinit(args: argparse.Namespace):
         start_lines = [f"base_recipe: {buildfarm_default_file}\n"]
         start_lines += ["recipe_arg_overrides:\n"]
 
-        arg_idx = None
-        for i, l in enumerate(bf_recipe_lines):
-            if keyword in l:
-                arg_idx = i + 1
-        assert arg_idx is not None
-
-        bf_recipe_lines = ["  " + l for l in start_lines] + bf_recipe_lines[arg_idx:]
+        start_arg_idx, end_arg_idx = get_indexes(bf_recipe_lines, "managerinit arg start", "managerinit arg end")
+        bf_recipe_lines = ["  " + l for l in start_lines] + bf_recipe_lines[start_arg_idx:end_arg_idx]
 
         file_line_swap(
             "config_build.yaml",

--- a/deploy/run-farm-recipes/aws_ec2.yaml
+++ b/deploy/run-farm-recipes/aws_ec2.yaml
@@ -30,6 +30,7 @@ args:
       - z1d.3xlarge: 0
       - z1d.6xlarge: 0
       - z1d.12xlarge: 0
+    # managerinit arg end
 
     # REQUIRED: List of host "specifications", i.e. re-usable collections of
     # host parameters.


### PR DESCRIPTION
This prevents up the `run-farm-host-spec` section of the `aws_ec2.yaml` runtime yaml recipe from being emitted when doing `firesim managerinit`.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
