### PR TITLE
Merge 1.13.x to main to get clean bump to 1.14.x series

### DIFF
--- a/.github/actions/machinelaunchscript/action.yml
+++ b/.github/actions/machinelaunchscript/action.yml
@@ -5,6 +5,11 @@ runs:
   using: "composite"
   steps:
     - run: |
+        # Mark the github workspace as a safe directory so we can run arbitrary
+        # git commands during build-setup.sh.
+        # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
+        # and https://github.com/actions/checkout/issues/760 for the workaround
+        git config --global --add safe.directory $(pwd)
         sudo yum -y remove git git224 git224-core ius-release.noarch # remove any older git versions and collateral first
         # The EC2 developer AMI provides libmpc and the prebuilt toolchain
         # links against it.  Install it here so we can build-setup.sh --fast
@@ -12,9 +17,4 @@ runs:
         sudo yum install -y libmpc
         cd scripts/ && /usr/bin/bash machine-launch-script.sh
         source /etc/profile.d/conda.sh
-        # Mark the github workspace as a safe directory so we can run arbitrary
-        # git commands during build-setup.sh.
-        # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
-        # and https://github.com/actions/checkout/issues/760 for the workaround
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
       shell: bash

--- a/.github/workflows/firesim-publish-scala-doc.yml
+++ b/.github/workflows/firesim-publish-scala-doc.yml
@@ -53,6 +53,10 @@ jobs:
       env:
         JVM_MEMORY: 3500M # Default JVM maximum heap limit
     steps:
+      - run: |
+          sudo yum -y remove git git224 git224-core ius-release.noarch # remove any older git versions and collateral first from docker image
+          sudo yum -y install https://repo.ius.io/ius-release-el7.rpm # re-install for now
+          sudo yum -y install git236 # install working git version (must match machine-launch)
       - uses: actions/checkout@v2
       - uses: ./.github/actions/repo-setup
       - uses: ./.github/actions/build-scala-doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 This changelog follows the format defined here: https://keepachangelog.com/en/1.0.0/
 
+## [1.13.6] - 2022-06-15
+Last of the 1.13.x release series. CI fixes only, no user facing changes since 1.13.5
+
+### Fixed
+*  CI fixes (scala doc push) related to git version.
+
+## [1.13.5] - 2022-06-13
+Critical fix to git package version in machine-launch-script.sh, only required for newly launched manager instances.
+
+### Fixed
+*  Bump git version specified in machine-launch-script.sh from git224 (no longer available) to git236. #1081
+
+## [1.13.4] - 2022-04-06
+Critical fix to libdwarf submodule URL. Fix boto3 pagination in manager. Fix synth assert stop-printf pair detection.
+
+### Fixed
+*  update libdwarf submodule url #988
+*  Fix synthesized assertions stop-printf pair detection #999 
+*  Use pagination for boto3 calls in the manager #991 
+
 ## [1.13.3] - 2022-03-01
 More small updates to AMI string in deploy area.
 


### PR DESCRIPTION
#### Related PRs / Issues

N/A

#### UI / API Impact

Allows for clean bump from 1.13.6 -> 1.14.0

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
