### PR TITLE
VitisShell: Use XPM xpm_cdc_sync_rst for reset synchronizer

### DIFF
--- a/sim/midas/src/main/scala/midas/platform/VitisShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/VitisShim.scala
@@ -44,24 +44,7 @@ class VitisShim(implicit p: Parameters) extends PlatformShim {
     firesimMMCM.io.reset   := ap_rst.asAsyncReset
 
     val hostClock = firesimMMCM.io.clk_out1
-
-    /** Synchronizes an active high asynchronous reset.
-      */
-    def resetSync(areset: AsyncReset, clock: Clock, length: Int = 3): Bool = {
-      withClockAndReset(clock, areset) {
-        val sync_regs = Seq.fill(length)(RegInit(true.B))
-        sync_regs.foldLeft(false.B) { case (prev, curr) =>
-          XDC(XDCFiles.Synthesis, "set_property ASYNC_REG TRUE [get_cells {}_reg]", curr)
-          curr := prev
-          curr
-        }
-      }
-    }
-
-    // Synchronize asyncReset passed to kernel
-    val hostAsyncReset = (ap_rst || !firesimMMCM.io.locked).asAsyncReset
-    val hostSyncReset  = resetSync(hostAsyncReset, hostClock)
-
+    val hostSyncReset = ResetSynchronizer(ap_rst || !firesimMMCM.io.locked, hostClock, initValue = true)
     top.module.reset := hostSyncReset
     top.module.clock := hostClock
 

--- a/sim/midas/src/main/scala/midas/platform/VitisShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/VitisShim.scala
@@ -43,7 +43,7 @@ class VitisShim(implicit p: Parameters) extends PlatformShim {
     firesimMMCM.io.clk_in1 := ap_clk
     firesimMMCM.io.reset   := ap_rst.asAsyncReset
 
-    val hostClock = firesimMMCM.io.clk_out1
+    val hostClock     = firesimMMCM.io.clk_out1
     val hostSyncReset = ResetSynchronizer(ap_rst || !firesimMMCM.io.locked, hostClock, initValue = true)
     top.module.reset := hostSyncReset
     top.module.clock := hostClock

--- a/sim/midas/src/main/scala/midas/platform/xilinx/ResetSynchronizer.scala
+++ b/sim/midas/src/main/scala/midas/platform/xilinx/ResetSynchronizer.scala
@@ -4,39 +4,43 @@ import chisel3._
 import midas.stage.GoldenGateOutputFileAnnotation
 
 object ResetSynchronizer {
-  /**
-    * Black box wrapper for an XPM reset synchronizer
-    * See: https://docs.xilinx.com/r/en-US/ug974-vivado-ultrascale-libraries/XPM_CDC_SYNC_RST
+
+  /** Black box wrapper for an XPM reset synchronizer See:
+    * https://docs.xilinx.com/r/en-US/ug974-vivado-ultrascale-libraries/XPM_CDC_SYNC_RST
     */
-  private class xpm_cdc_sync_rst(stages: Int, initValue: Boolean) extends BlackBox(
-    Map(
-      "DEST_SYNC_FF" -> stages,
-      "INIT"         -> { if (true) 1 else 0 },
-      "INIT_SYNC_FF" -> { if (true) 1 else 0 }
-    )) {
+  private class xpm_cdc_sync_rst(stages: Int, initValue: Boolean)
+      extends BlackBox(
+        Map(
+          "DEST_SYNC_FF" -> stages,
+          "INIT"         -> { if (true) 1 else 0 },
+          "INIT_SYNC_FF" -> { if (true) 1 else 0 },
+        )
+      ) {
     val io = IO(new Bundle {
-      val dest_clk  = Input(Clock())
-      val dest_rst  = Output(Bool())
-      val src_rst   = Input(Bool())
+      val dest_clk = Input(Clock())
+      val dest_rst = Output(Bool())
+      val src_rst  = Input(Bool())
     })
   }
 
-  /**
-    * Synchronizes a reset to a destination clock using a Xilinx Parameterized
-    * Macro (XPM) for which Vivado will generate the correct timing and design
-    * constraints automatically.
+  /** Synchronizes a reset to a destination clock using a Xilinx Parameterized Macro (XPM) for which Vivado will
+    * generate the correct timing and design constraints automatically.
     *
-    * @param src_rst Input reset, could be AsyncReset, feel free to call toBool
-    * @param dest_clk The clock driving the synchronization registers
-    * @param initValue The value taken on by the sync registers at programming
+    * @param src_rst
+    *   Input reset, could be AsyncReset, feel free to call toBool
+    * @param dest_clk
+    *   The clock driving the synchronization registers
+    * @param initValue
+    *   The value taken on by the sync registers at programming
     */
   def apply(
-    src_rst: Bool,
-    dest_clk: Clock,
+    src_rst:   Bool,
+    dest_clk:  Clock,
     initValue: Boolean,
-    stages: Int = 4): Bool = {
+    stages:    Int = 4,
+  ): Bool = {
     val xpm_sync = Module(new xpm_cdc_sync_rst(stages, initValue))
-    xpm_sync.io.src_rst := src_rst
+    xpm_sync.io.src_rst  := src_rst
     xpm_sync.io.dest_clk := dest_clk
     xpm_sync.io.dest_rst
   }

--- a/sim/midas/src/main/scala/midas/platform/xilinx/ResetSynchronizer.scala
+++ b/sim/midas/src/main/scala/midas/platform/xilinx/ResetSynchronizer.scala
@@ -1,0 +1,43 @@
+package midas.platform.xilinx
+
+import chisel3._
+import midas.stage.GoldenGateOutputFileAnnotation
+
+object ResetSynchronizer {
+  /**
+    * Black box wrapper for an XPM reset synchronizer
+    * See: https://docs.xilinx.com/r/en-US/ug974-vivado-ultrascale-libraries/XPM_CDC_SYNC_RST
+    */
+  private class xpm_cdc_sync_rst(stages: Int, initValue: Boolean) extends BlackBox(
+    Map(
+      "DEST_SYNC_FF" -> stages,
+      "INIT"         -> { if (true) 1 else 0 },
+      "INIT_SYNC_FF" -> { if (true) 1 else 0 }
+    )) {
+    val io = IO(new Bundle {
+      val dest_clk  = Input(Clock())
+      val dest_rst  = Output(Bool())
+      val src_rst   = Input(Bool())
+    })
+  }
+
+  /**
+    * Synchronizes a reset to a destination clock using a Xilinx Parameterized
+    * Macro (XPM) for which Vivado will generate the correct timing and design
+    * constraints automatically.
+    *
+    * @param src_rst Input reset, could be AsyncReset, feel free to call toBool
+    * @param dest_clk The clock driving the synchronization registers
+    * @param initValue The value taken on by the sync registers at programming
+    */
+  def apply(
+    src_rst: Bool,
+    dest_clk: Clock,
+    initValue: Boolean,
+    stages: Int = 4): Bool = {
+    val xpm_sync = Module(new xpm_cdc_sync_rst(stages, initValue))
+    xpm_sync.io.src_rst := src_rst
+    xpm_sync.io.dest_clk := dest_clk
+    xpm_sync.io.dest_rst
+  }
+}


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

The pure-chisel implementation used the 1.14 release is underconstrained -- this change replaces it with an XPM (Xilinx Programmable Macro) that implements the same functionality (though it is structurally different) but comes with the added benefit that Vivado automatically applies the correct design and timing constraints. See the [UG](https://docs.xilinx.com/r/en-US/ug974-vivado-ultrascale-libraries/XPM_CDC_SYNC_RST) for a description of the primitive. 

@timsnyder-siv did the original investigation and tested out this change, here i'm converting what he's done to Chisel. 

I've confirmed that i can build a xclbin and Vivado does not issue the critical warnings it did previously.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

No change to AGFIs, only to Vitis-based designs. 

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
