### PR TITLE
Fixed shebang in build-libdwarf.sh and build-libelf.sh scripts

### DIFF
--- a/scripts/build-libdwarf.sh
+++ b/scripts/build-libdwarf.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build-libelf.sh
+++ b/scripts/build-libelf.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 if [ $# -ne 1 ]; then


### PR DESCRIPTION
scripts/build-libdwarf.sh and scripts/build-libelf.sh have `#!/bin/sh` shebangs and this shell does not allow the used variable substitution and export syntax. Changing it to bash allow build-setup.sh to run through.