### PR TITLE
Make bug report system info copy pastable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,8 +20,8 @@ body:
       description: Repository version for reproducibility
       placeholder: Version + Hash
       value: |
-        Release: 1.13.0
-        Hash: a6a6a6
+        <!-- copy/paste the output of `git describe --tags --long` below -->
+        
     validations:
       required: true
 
@@ -31,7 +31,9 @@ body:
       description: OS setup for reproducibility
       placeholder: OS information
       value: |
-        Ex: Output of `uname -a` and `lsb_release -a`
+        ```
+        <!-- copy/paste the output of `uname -a; lsb_release -a` below -->
+        ```
     validations:
       required: true
 
@@ -41,7 +43,7 @@ body:
       description: Any other setup relevant
       placeholder: Other setup
       value: |
-        Ex: Prior steps taken / Documentation Followed / etc...
+        <!-- Ex: Prior steps taken / Documentation Followed / etc... -->
     validations:
       required: false
 


### PR DESCRIPTION
Make it easier to fill in the bug report by giving users commands they can copy&paste into their shell and copy&paste the results back into the bug report.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

Only impacts github bug template.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

No verilog/AGFI impact.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
