### PR TITLE
Add a lightweight issue template for devs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/internal-feature---bug-tracking.md
+++ b/.github/ISSUE_TEMPLATE/internal-feature---bug-tracking.md
@@ -1,0 +1,10 @@
+---
+name: Internal Feature / Bug Tracking
+about: 'Used by developers only to track internal issues and goals. '
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
The existing templates are good for external bug + feature reports, but onerous to use for internal issue tracking IMO. This just adds an out. 
