### PR TITLE
ci: Move check docs generated components out of setup-manager

### DIFF
--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -97,8 +97,6 @@ jobs:
         uses: ./.github/actions/initialize-manager
         with:
           max-runtime-hours: 10
-      - name: Check docs components that require manual re-generation (e.g. config_runtime.yaml example, help output)
-        run: ./.github/scripts/check-docs-generated-components.py
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
       - name: Catch potentially orphaned manager
@@ -157,6 +155,17 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Scalafmt on FireSim Scala main sources
         run: .github/scripts/run-scalafmt-check.py
+
+  run-check-docs-generated-components:
+    name: run-check-docs-generated-components
+    needs: [setup-manager]
+    runs-on: ${{ github.run_id }}
+    env:
+      TERM: xterm-256-color
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check docs components that require manual re-generation (e.g. config_runtime.yaml example, help output)
+        run: ./.github/scripts/check-docs-generated-components.py
 
   run-test-groupA:
     name: run-test-groupA

--- a/docs/Running-Simulations-Tutorial/DOCS_EXAMPLE_config_runtime.yaml
+++ b/docs/Running-Simulations-Tutorial/DOCS_EXAMPLE_config_runtime.yaml
@@ -96,6 +96,7 @@ host_debug:
     # continues simulation.
     disable_synth_asserts: no
 
+# DOCREF START: Synthesized Prints
 synth_print:
     # Start and end cycles for outputting synthesized prints.
     # They are given in terms of the base clock and will be converted
@@ -104,3 +105,4 @@ synth_print:
     end: -1
     # When enabled (=yes), prefix print output with the target cycle at which the print was triggered
     cycle_prefix: yes
+# DOCREF END: Synthesized Prints


### PR DESCRIPTION
This check should not bring down all of the CI jobs that depend on setting up the manager, so I've moved it into a separate job. This will unblock other PRs, which can be merged even with the failing check.

Aside: I think it might be better to do the generation during the docs build instead of relying on this mechanism, but I understand that is more work. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
