### PR TITLE
autocounter.cc fixup split multiline string

### DIFF
--- a/sim/midas/src/main/cc/bridges/autocounter.cc
+++ b/sim/midas/src/main/cc/bridges/autocounter.cc
@@ -59,7 +59,7 @@ autocounter_t::autocounter_t(
             // TODO: Fix this in the bridge by not sampling with a fixed frequency
             if (this->clock_info.to_base_cycles(this->readrate) != this->readrate_base_clock) {
                 fprintf(stderr,
-"[AutoCounter] Warning: requested sample rate of %" PRIu64 " [base] cycles does not map to a whole number\n\
+"[AutoCounter] Warning: requested sample rate of %PRIu64 [base] cycles does not map to a whole number\n\
 of cycles in clock domain: %s, (%d/%d) of base clock.\n\
 See the AutoCounter documentation on Reset And Timing Considerations for discussion.\n",
                        this->readrate_base_clock,


### PR DESCRIPTION
gcc 4.8 on centos7 is confused by this construct.  I'm not sure if the newer gcc in conda has that problem or not.

We may want to add a config to CI that includes all of the possible bridges in the driver and increase our coverage of at least being able to compile all of the driver code.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

No impact.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

No impact.

### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [X] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [X] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [X] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
