### PR TITLE
unpin make and bump chipyard for marshal

### DIFF
--- a/.github/scripts/build-default-workloads.py
+++ b/.github/scripts/build-default-workloads.py
@@ -10,12 +10,10 @@ def build_default_workloads():
     with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
          prefix('cd deploy/workloads'):
 
-        # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
-        with settings(warn_only=True):
-            rc = run("marshal -v build br-base.json &> br-base.full.log").return_code
-            if rc != 0:
-                run("cat br-base.full.log")
-                raise Exception("Building br-base.json failed to run")
+        # Better support very parallel builds under marshal (1024 on FPGA developer AMI)
+        # See https://github.com/firesim/firesim/pull/1132
+        with prefix('ulimit -n 4096'):
+            run("marshal -v build br-base.json")
 
         run("make linux-poweroff")
         run("make allpaper")

--- a/.github/scripts/build-default-workloads.py
+++ b/.github/scripts/build-default-workloads.py
@@ -10,7 +10,7 @@ def build_default_workloads():
     with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
          prefix('cd deploy/workloads'):
 
-	run("cat /proc/self/limits && marshal -v build br-base.json")
+        run("cat /proc/self/limits && marshal -v build br-base.json")
 
         run("make linux-poweroff")
         run("make allpaper")

--- a/.github/scripts/build-default-workloads.py
+++ b/.github/scripts/build-default-workloads.py
@@ -10,10 +10,7 @@ def build_default_workloads():
     with prefix('cd {} && source ./env.sh'.format(manager_fsim_dir)), \
          prefix('cd deploy/workloads'):
 
-        # Better support very parallel builds under marshal (1024 on FPGA developer AMI)
-        # See https://github.com/firesim/firesim/pull/1132
-        with prefix('ulimit -n 4096'):
-            run("ulimit -n && marshal -v build br-base.json")
+	run("cat /proc/self/limits && marshal -v build br-base.json")
 
         run("make linux-poweroff")
         run("make allpaper")

--- a/.github/scripts/build-default-workloads.py
+++ b/.github/scripts/build-default-workloads.py
@@ -13,7 +13,7 @@ def build_default_workloads():
         # Better support very parallel builds under marshal (1024 on FPGA developer AMI)
         # See https://github.com/firesim/firesim/pull/1132
         with prefix('ulimit -n 4096'):
-            run("marshal -v build br-base.json")
+            run("ulimit -n && marshal -v build br-base.json")
 
         run("make linux-poweroff")
         run("make allpaper")

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -22,10 +22,11 @@ def run_linux_poweroff_vitis():
             # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
             with prefix('cd sw/firesim-software'):
                 run("./init-submodules.sh")
+                run("echo 'jlevel: 16' >> ./marshal-config.yaml")
 
                 # build outputs.yaml (use this workload since firemarshal can guestmount)
                 with settings(warn_only=True):
-                    rc = run("./marshal -v build test/outputs.yaml &> outputs.full.log").return_code
+                    rc = run("nice ./marshal -v build test/outputs.yaml &> outputs.full.log").return_code
                     if rc != 0:
                         run("cat outputs.full.log")
                         raise Exception("Building test/outputs.yaml failed to run")

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -36,10 +36,6 @@ def initialize_manager_hosted():
 
     # Catch any exception that occurs so that we can gracefully teardown
     try:
-        # Better support very parallel builds under marshal (1024 on FPGA developer AMI)
-        # See https://github.com/firesim/firesim/pull/1132
-        run("ulimit -n 4096")
-        
         # get the runner version based off the latest tag on the github runner repo
         RUNNER_VERSION = local("git ls-remote --refs --tags https://github.com/actions/runner.git | cut --delimiter='/' --fields=3 | tr '-' '~' | sort --version-sort | tail --lines=1", capture=True)
         RUNNER_VERSION = RUNNER_VERSION.replace("v", "")

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -36,6 +36,10 @@ def initialize_manager_hosted():
 
     # Catch any exception that occurs so that we can gracefully teardown
     try:
+        # Better support very parallel builds under marshal (1024 on FPGA developer AMI)
+        # See https://github.com/firesim/firesim/pull/1132
+        run("ulimit -n 4096")
+        
         # get the runner version based off the latest tag on the github runner repo
         RUNNER_VERSION = local("git ls-remote --refs --tags https://github.com/actions/runner.git | cut --delimiter='/' --fields=3 | tr '-' '~' | sort --version-sort | tail --lines=1", capture=True)
         RUNNER_VERSION = RUNNER_VERSION.replace("v", "")

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -21,6 +21,11 @@ def wait_machine_launch_complete():
             if rc != 0:
                 run("cat /machine-launchstatus.log")
                 raise Exception("machine-launch-script.sh failed to run")
+	# increase file descriptor limit system wide
+	sudo("echo '* hard nofile 16384' >> /etc/security/limits.conf")
+	sudo("echo '* soft nofile 16384' >> /etc/security/limits.conf")
+
+
     except BaseException as e:
         traceback.print_exc(file=sys.stdout)
         terminate_workflow_instances(ci_personal_api_token, ci_workflow_run_id)

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -21,9 +21,9 @@ def wait_machine_launch_complete():
             if rc != 0:
                 run("cat /machine-launchstatus.log")
                 raise Exception("machine-launch-script.sh failed to run")
-	# increase file descriptor limit system wide
-	sudo("echo '* hard nofile 16384' >> /etc/security/limits.conf")
-	sudo("echo '* soft nofile 16384' >> /etc/security/limits.conf")
+        # increase file descriptor limit system wide
+        sudo("echo '* hard nofile 16384' >> /etc/security/limits.conf")
+        sudo("echo '* soft nofile 16384' >> /etc/security/limits.conf")
 
 
     except BaseException as e:

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -252,8 +252,7 @@ set -o pipefail
     # firemarshal deps
     CONDA_PACKAGE_SPECS+=( rsync psutil doit=0.35.0 gitpython humanfriendly e2fsprogs ctags bison flex expat )
     # cross-compile glibc 2.28+ deps
-    # current version of buildroot won't build with make 4.3 https://github.com/firesim/FireMarshal/issues/236
-    CONDA_PACKAGE_SPECS+=( make!=4.3 )
+    CONDA_PACKAGE_SPECS+=( make )
     # build-libelf wants autoconf
     CONDA_PACKAGE_SPECS+=( autoconf automake libtool )
     # other misc deps


### PR DESCRIPTION
bumps firemarshal to pickup https://github.com/firesim/FireMarshal/pull/237

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

https://github.com/firesim/FireMarshal/pull/237

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

Will result in gnu make v4.3 being installed and it has a fairly large change in behavior documented in https://savannah.gnu.org/bugs/?57676

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

Shouldn't impact Verilog or AGFI compatability.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
