### PR TITLE
Pass Vitis FPGA platform from yaml

### DIFF
--- a/deploy/bit-builder-recipes/vitis.yaml
+++ b/deploy/bit-builder-recipes/vitis.yaml
@@ -13,4 +13,6 @@
 #     <K/V pairs of args>
 
 bit_builder_type: VitisBitBuilder
-args: null
+args:
+    # REQUIRED: vitis fpga platform
+    device: xilinx_u250_gen3x16_xdma_3_1_202020_1

--- a/platforms/f1/build-bitstream.sh
+++ b/platforms/f1/build-bitstream.sh
@@ -1,9 +1,44 @@
 #!/bin/bash
 
-set -e
+# This script is called by FireSim's bitbuilder to create a xclbin
 
-CL_DIR=$1
-shift # get rid of $1 arg or else hdk_setup.sh will fail
+# exit script if any command fails
+set -e
+set -o pipefail
+
+usage() {
+    echo "usage: ${0} [OPTIONS]"
+    echo ""
+    echo "Options"
+    echo "   --cl_dir : Custom logic directory to build AWS F1 bitstream from"
+    echo "   --help   : Display this message"
+    exit "$1"
+}
+
+CL_DIR=""
+
+# getopts does not support long options, and is inflexible
+# ensure $1 arg is empty or else hdk_setup.sh will fail
+while [ "$1" != "" ];
+do
+    case $1 in
+        --help)
+            usage 1 ;;
+        --cl_dir )
+            shift
+            CL_DIR=$1 ;;
+        * )
+            echo "invalid option $1"
+            usage 1 ;;
+    esac
+    shift
+done
+
+if [ -z "$CL_DIR" ] ; then
+    echo "no cl directory specified"
+    usage 1
+fi
+
 AWS_FPGA_DIR=$CL_DIR/../../../..
 
 # setup hdk

--- a/platforms/vitis/build-bitstream.sh
+++ b/platforms/vitis/build-bitstream.sh
@@ -2,10 +2,51 @@
 
 # This script is called by FireSim's bitbuilder to create a xclbin
 
+# exit script if any command fails
 set -e
+set -o pipefail
 
-CL_DIR=$1
+usage() {
+    echo "usage: ${0} [OPTIONS]"
+    echo ""
+    echo "Options"
+    echo "   --build_dir : Build directory to run make command from"
+    echo "   --device    : Vitis FPGA platform string"
+    echo "   --help      : Display this message"
+    exit "$1"
+}
+
+BUILD_DIR=""
+DEVICE=""
+
+# getopts does not support long options, and is inflexible
+while [ "$1" != "" ];
+do
+    case $1 in
+        --help)
+            usage 1 ;;
+        --build_dir )
+            shift
+            BUILD_DIR=$1 ;;
+        --device )
+            shift
+            DEVICE=$1 ;;
+        * )
+            echo "invalid option $1"
+            usage 1 ;;
+    esac
+    shift
+done
+
+if [ -z "$BUILD_DIR" ] ; then
+    echo "no build directory specified"
+    usage 1
+fi
+
+if [ -z "$DEVICE" ] ; then
+    echo "no device specified"
+    usage 1
+fi
 
 # run build
-cd $CL_DIR
-make bitstream
+make -C $BUILD_DIR DEVICE=$DEVICE bitstream


### PR DESCRIPTION
Small PR that does the following:

- Cleans up the `build-bitstream.sh` scripts to parse arguments with proper errors. 
- Adds `device` to the `vitis.yaml` bit builder so that users can support different FPGAs than U250's (IIRC we only support U250 + U280s). Since I don't have a U280, this is untested. 

A couple of things to discuss:

- Do we want to add a `device` K/V pair to the HWDB to tell users what XCLBIN corresponds to what platform? I would imagine that the XCLBIN tells the FPGA platform (i.e. `device`) string if you "describe" it with `xclbinutil`.

This PR should help set up passing other args to the bitstream builds from the Python/manager side.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
