### PR TITLE
Allowed bridge parameters to be serialized

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/AssertionSynthesis.scala
+++ b/sim/midas/src/main/scala/midas/passes/AssertionSynthesis.scala
@@ -14,7 +14,7 @@ import firrtl.Utils.{zero, to_flip, BoolType}
 import freechips.rocketchip.config.{Parameters, Field}
 
 import Utils._
-import midas.widgets.{BridgeIOAnnotation, AssertBridgeRecord, AssertBridgeModule}
+import midas.widgets.{BridgeIOAnnotation, AssertBridgeRecord, AssertBridgeModule, AssertBridgeParameters}
 import midas.passes.fame.{FAMEChannelConnectionAnnotation, WireChannel}
 import midas.stage.phases.ConfigParametersAnnotation
 import midas.targetutils.{ExcludeInstanceAssertsAnnotation, GlobalResetConditionSink}
@@ -240,7 +240,7 @@ private[passes] class AssertionSynthesis extends firrtl.Transform {
         val assertMessages = asserts.map(formattedMessages(_))
         val bridgeAnno = BridgeIOAnnotation(
           target = portRT,
-          widget = (p: Parameters) => new AssertBridgeModule(assertPortName, resetPortName, assertMessages)(p),
+          widget = (p: Parameters) => new AssertBridgeModule(AssertBridgeParameters(assertPortName, resetPortName, assertMessages))(p),
           channelNames = Seq(resetPortName, assertPortName)
         )
         assertAnnos ++= Seq(resetConditionAnno, assertFCCA, resetFCCA, bridgeAnno)

--- a/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
@@ -218,7 +218,7 @@ class AutoCounterTransform extends Transform with AutoCounterConsts {
         target = topMT.ref(topWiringPrefix),
         // We need to pass the name of the trigger port so each bridge can
         // disambiguate between them and connect to the correct one in simulation mapping
-        widget = (p: Parameters) => new AutoCounterBridgeModule(eventMetadata, triggerPortName, globalResetName)(p),
+        widget = (p: Parameters) => new AutoCounterBridgeModule(AutoCounterParameters(eventMetadata, triggerPortName, globalResetName))(p),
         channelNames = (triggerFCCA +: globalResetFCCA +: fccas).map(_.globalName)
       )
       Seq(bridgeAnno, triggerSinkAnno, triggerFCCA, globalResetFCCA, globalResetSink) ++ fccas

--- a/sim/midas/src/main/scala/midas/widgets/AssertBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AssertBridge.scala
@@ -18,8 +18,13 @@ class AssertBridgeRecord(assertPortName: String, resetPortName: String, numAsser
   override def cloneType = new AssertBridgeRecord(assertPortName, resetPortName, numAsserts).asInstanceOf[this.type]
 }
 
-class AssertBridgeModule(assertPortName: String, resetPortName: String, assertMessages: Seq[String])(implicit p: Parameters)
+case class AssertBridgeParameters(assertPortName: String, resetPortName: String, assertMessages: Seq[String])
+
+class AssertBridgeModule(params: AssertBridgeParameters)(implicit p: Parameters)
     extends BridgeModule[HostPortIO[AssertBridgeRecord]]()(p) {
+
+  val AssertBridgeParameters(assertPortName, resetPortName, assertMessages) = params
+
   lazy val module = new BridgeModuleImp(this) {
     val numAsserts = assertMessages.size
     val io = IO(new WidgetIO())

--- a/sim/midas/src/main/scala/midas/widgets/AutoCounterBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AutoCounterBridge.scala
@@ -62,11 +62,15 @@ class AutoCounterBundle(
   override def cloneType = new AutoCounterBundle(eventMetadata, triggerName, resetPortName).asInstanceOf[this.type]
 }
 
-class AutoCounterBridgeModule(
-    eventMetadata: Seq[EventMetadata],
-    triggerName: String,
-    resetPortName: String)(implicit p: Parameters)
+case class AutoCounterParameters(eventMetadata: Seq[EventMetadata], triggerName: String, resetPortName: String)
+
+class AutoCounterBridgeModule(key: AutoCounterParameters)(implicit p: Parameters)
     extends BridgeModule[HostPortIO[AutoCounterBundle]]()(p) with AutoCounterConsts {
+
+  val eventMetadata = key.eventMetadata
+  val triggerName = key.triggerName
+  val resetPortName = key.resetPortName
+
   lazy val module = new BridgeModuleImp(this) {
     val io = IO(new WidgetIO())
     val hPort = IO(HostPort(new AutoCounterBundle(eventMetadata, triggerName, resetPortName)))

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -74,10 +74,17 @@ case class ClockBridgeAnnotation(val target: ModuleTarget, clocks: Seq[RationalC
     BridgeIOAnnotation(
       target.copy(module = target.circuit).ref(port),
       channelMapping.toMap,
-      widget = Some((p: Parameters) => new ClockBridgeModule(clocks)(p))
+      widget = Some((p: Parameters) => new ClockBridgeModule(ClockParameters(clocks))(p))
     )
   }
 }
+
+/**
+ * Parameters to construct a clock bridge from. Aggregates information about all the output clocks.
+ *
+ * @param clocks Clock information for each output clock.
+ */
+case class ClockParameters(clocks: Seq[RationalClock])
 
 /**
   * The default target-side clock bridge. Generates a vector of
@@ -151,11 +158,12 @@ class ClockTokenVector(numClocks: Int) extends Bundle with HasChannels with Cloc
   *
   * Target and host time measurements provided by simif_t are facilitated with MMIO to this bridge
   *
-  * @param clockInfo Clock frequency information for each target clock
+  * @param params Structure describing the clocks of the clock bridge.
   *
   */
-class ClockBridgeModule(clockInfo: Seq[RationalClock])(implicit p: Parameters)
+class ClockBridgeModule(params: ClockParameters)(implicit p: Parameters)
     extends BridgeModule[ClockTokenVector] {
+  val clockInfo = params.clocks
   lazy val module = new BridgeModuleImp(this) {
   val io = IO(new WidgetIO())
   val hPort = IO(new ClockTokenVector(clockInfo.size))


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Bridge annotations can now can be serialized and constructed using `widgetConstructorKey`.
Instead of passing multiple arguments and requiring a lambda in the annotation, parameters are 
now wrapped in a case class that can be instantiated using the `widgetConstructorKey` mechanism.

#### Related PRs / Issues

<!-- List any related issues here -->

None.

#### UI / API Impact

None.

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

No changes.

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
