### PR TITLE
add config_build_recipes.yaml to run_yamls pytest fixture

### DIFF
--- a/deploy/tests/test_yaml_api.py
+++ b/deploy/tests/test_yaml_api.py
@@ -129,11 +129,13 @@ class RunTmpYamlSet(TmpYamlSet):
 
     Attributes:
     """
+    recipes: TmpYaml
     hwdb: TmpYaml
     run: TmpYaml
     non_existent_file: Path
 
     def write(self):
+        self.recipes.write()
         self.hwdb.write()
         self.run.write()
 
@@ -144,7 +146,7 @@ class RunTmpYamlSet(TmpYamlSet):
         # whether `firesim managerinit` has been run
         # https://github.com/firesim/firesim/pull/1145#issuecomment-1194392085
         return ['-b', fspath(self.non_existent_file),
-                '-r', fspath(self.non_existent_file),
+                '-r', fspath(self.recipes.path),
                 '-a', fspath(self.hwdb.path),
                 '-c', fspath(self.run.path)]
 
@@ -187,8 +189,8 @@ def scy_runtime(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
     return TmpYaml(tmp_path, sample_backup_configs / 'sample_config_runtime.yaml')
 
 @pytest.fixture()
-def run_yamls(scy_hwdb: TmpYaml, scy_runtime: TmpYaml, non_existent_file: Path) -> RunTmpYamlSet:
-    return RunTmpYamlSet(scy_hwdb, scy_runtime, non_existent_file)
+def run_yamls(scy_build_recipes: TmpYaml, scy_hwdb: TmpYaml, scy_runtime: TmpYaml, non_existent_file: Path) -> RunTmpYamlSet:
+    return RunTmpYamlSet(scy_build_recipes, scy_hwdb, scy_runtime, non_existent_file)
 
 @pytest.fixture()
 def firesim_parse_args():


### PR DESCRIPTION
Addition of config_build_recipes.yaml use by RuntimeConfig in #1076 broke
the pytests for config checking but somehow, it passed in the PR check.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

Addresses broken tests portion of  for #1142 but doesn't do anything to address how this got through PR with 'passing' checks.
<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

Isn't user visible, only updates pytests to reflect the need for `config_build_recipes.yaml` during `runworkload` and other "run" tasks.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

Doesn't impact Verilog.  Manager tests only.

### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [X] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [X] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [X] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [X] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
