### PR TITLE
ci: don't filter out python tests

### DIFF
--- a/.github/scripts/run-manager-pytests.py
+++ b/.github/scripts/run-manager-pytests.py
@@ -8,6 +8,7 @@ def run_manager_pytests():
     """ Runs all manager pytests """
 
     with cd(manager_fsim_dir), prefix('source env.sh'):
+        run("git rev-parse HEAD")
         run("cd deploy && python3 -m pytest")
 
 if __name__ == "__main__":

--- a/.github/scripts/run-manager-pytests.py
+++ b/.github/scripts/run-manager-pytests.py
@@ -8,7 +8,6 @@ def run_manager_pytests():
     """ Runs all manager pytests """
 
     with cd(manager_fsim_dir), prefix('source env.sh'):
-        run("git rev-parse HEAD")
         run("cd deploy && python3 -m pytest")
 
 if __name__ == "__main__":

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -37,7 +37,6 @@ jobs:
     # Queried by downstream jobs to determine if they should run.
     outputs:
       needs-manager: ${{ steps.filter.outputs.all_count != steps.filter.outputs.skip-manager_count }}
-      needs-manager-python-only: ${{ steps.filter.outputs.python-manager }}
 
     steps:
       - uses: actions/checkout@v2
@@ -59,14 +58,6 @@ jobs:
               - '**/*.md'
               - '**/.gitignore'
               - '.github/ISSUE_TEMPLATE/**'
-
-            # Python-specific manager filter
-            python-manager:
-              - 'deploy/firesim'
-              - 'deploy/awstools/**'
-              - 'deploy/buildtools/**'
-              - 'deploy/runtools/**'
-              - 'deploy/util/**'
 
   setup-self-hosted-manager:
     name: setup-self-hosted-manager
@@ -123,8 +114,7 @@ jobs:
 
   run-manager-pytests:
     name: run-manager-pytests
-    needs: [setup-manager, change-filters]
-    if: needs.change-filters.outputs.needs-manager-python-only == 'true'
+    needs: [setup-manager]
     runs-on: ${{ github.run_id }}
     env:
       TERM: xterm-256-color
@@ -135,8 +125,7 @@ jobs:
 
   run-python-typecheck:
     name: run-python-typecheck
-    needs: [setup-manager, change-filters]
-    if: needs.change-filters.outputs.needs-manager-python-only == 'true'
+    needs: [setup-manager]
     runs-on: ${{ github.run_id }}
     env:
       TERM: xterm-256-color

--- a/deploy/tests/test_yaml_api.py
+++ b/deploy/tests/test_yaml_api.py
@@ -175,7 +175,7 @@ def scy_build_recipes(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
     return TmpYaml(tmp_path, sample_backup_configs / 'sample_config_build_recipes.yaml')
 
 @pytest.fixture()
-def build_yamls(scy_build, scy_build_recipes, scy_hwdb, non_existent_file) -> BuildTmpYamlSet:
+def build_yamls(scy_build: TmpYaml, scy_build_recipes: TmpYaml, scy_hwdb: TmpYaml, non_existent_file: Path) -> BuildTmpYamlSet:
     return BuildTmpYamlSet(scy_build, scy_build_recipes, scy_hwdb, non_existent_file)
 
 @pytest.fixture()
@@ -187,8 +187,8 @@ def scy_runtime(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
     return TmpYaml(tmp_path, sample_backup_configs / 'sample_config_runtime.yaml')
 
 @pytest.fixture()
-def run_yamls(scy_hwdb: TmpYaml, scy_runtime: TmpYaml) -> RunTmpYamlSet:
-    return RunTmpYamlSet(scy_hwdb, scy_runtime)
+def run_yamls(scy_hwdb: TmpYaml, scy_runtime: TmpYaml, non_existent_file: Path) -> RunTmpYamlSet:
+    return RunTmpYamlSet(scy_hwdb, scy_runtime, non_existent_file)
 
 @pytest.fixture()
 def firesim_parse_args():

--- a/deploy/tests/test_yaml_api.py
+++ b/deploy/tests/test_yaml_api.py
@@ -129,11 +129,13 @@ class RunTmpYamlSet(TmpYamlSet):
 
     Attributes:
     """
+    recipes: TmpYaml
     hwdb: TmpYaml
     run: TmpYaml
     non_existent_file: Path
 
     def write(self):
+        self.recipes.write()
         self.hwdb.write()
         self.run.write()
 
@@ -144,7 +146,7 @@ class RunTmpYamlSet(TmpYamlSet):
         # whether `firesim managerinit` has been run
         # https://github.com/firesim/firesim/pull/1145#issuecomment-1194392085
         return ['-b', fspath(self.non_existent_file),
-                '-r', fspath(self.non_existent_file),
+                '-r', fspath(self.recipes.path),
                 '-a', fspath(self.hwdb.path),
                 '-c', fspath(self.run.path)]
 
@@ -187,8 +189,8 @@ def scy_runtime(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
     return TmpYaml(tmp_path, sample_backup_configs / 'sample_config_runtime.yaml')
 
 @pytest.fixture()
-def run_yamls(scy_hwdb: TmpYaml, scy_runtime: TmpYaml, non_existent_file: Path) -> RunTmpYamlSet:
-    return RunTmpYamlSet(scy_hwdb, scy_runtime, non_existent_file)
+def run_yamls(scy_build_recipes: TmpYaml, scy_hwdb: TmpYaml, scy_runtime: TmpYaml, non_existent_file: Path) -> RunTmpYamlSet:
+    return RunTmpYamlSet(scy_build_recipes, scy_hwdb, scy_runtime, non_existent_file)
 
 @pytest.fixture()
 def firesim_parse_args():

--- a/deploy/tests/test_yaml_api.py
+++ b/deploy/tests/test_yaml_api.py
@@ -100,6 +100,7 @@ class BuildTmpYamlSet(TmpYamlSet):
     build: TmpYaml
     recipes: TmpYaml
     hwdb: TmpYaml
+    non_existent_file: Path
 
     def write(self):
         self.build.write()
@@ -108,9 +109,14 @@ class BuildTmpYamlSet(TmpYamlSet):
 
     @property
     def args(self):
+        # set configs that should not be read explicitly
+        # to the non_existent_file to avoid influence of
+        # whether `firesim managerinit` has been run
+        # https://github.com/firesim/firesim/pull/1145#issuecomment-1194392085
         return ['-b', fspath(self.build.path),
                 '-r', fspath(self.recipes.path),
                 '-a', fspath(self.hwdb.path),
+                '-c', fspath(self.non_existent_file)
                 ]
 
     @property
@@ -125,6 +131,7 @@ class RunTmpYamlSet(TmpYamlSet):
     """
     hwdb: TmpYaml
     run: TmpYaml
+    non_existent_file: Path
 
     def write(self):
         self.hwdb.write()
@@ -132,7 +139,13 @@ class RunTmpYamlSet(TmpYamlSet):
 
     @property
     def args(self):
-        return ['-a', fspath(self.hwdb.path),
+        # set configs that should not be read explicitly
+        # to the non_existent_file to avoid influence of
+        # whether `firesim managerinit` has been run
+        # https://github.com/firesim/firesim/pull/1145#issuecomment-1194392085
+        return ['-b', fspath(self.non_existent_file),
+                '-r', fspath(self.non_existent_file),
+                '-a', fspath(self.hwdb.path),
                 '-c', fspath(self.run.path)]
 
     @property
@@ -146,6 +159,14 @@ def sample_backup_configs() -> Path:
     return dir
 
 @pytest.fixture()
+def non_existent_file(tmp_path: Path) -> Path:
+    # tmp_path is builtin pytest fixture to get a per-test temporary directory that should be clean
+    # but we still make sure that it doesn't exist before giving it
+    file = tmp_path / 'GHOST_FILE'
+    file.exists().should.equal(False)
+    return file
+
+@pytest.fixture()
 def scy_build(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
     return TmpYaml(tmp_path, sample_backup_configs / 'sample_config_build.yaml')
 
@@ -154,8 +175,8 @@ def scy_build_recipes(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
     return TmpYaml(tmp_path, sample_backup_configs / 'sample_config_build_recipes.yaml')
 
 @pytest.fixture()
-def build_yamls(scy_build, scy_build_recipes, scy_hwdb) -> BuildTmpYamlSet:
-    return BuildTmpYamlSet(scy_build, scy_build_recipes, scy_hwdb)
+def build_yamls(scy_build, scy_build_recipes, scy_hwdb, non_existent_file) -> BuildTmpYamlSet:
+    return BuildTmpYamlSet(scy_build, scy_build_recipes, scy_hwdb, non_existent_file)
 
 @pytest.fixture()
 def scy_hwdb(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
@@ -168,14 +189,6 @@ def scy_runtime(tmp_path: Path, sample_backup_configs: Path) -> TmpYaml:
 @pytest.fixture()
 def run_yamls(scy_hwdb: TmpYaml, scy_runtime: TmpYaml) -> RunTmpYamlSet:
     return RunTmpYamlSet(scy_hwdb, scy_runtime)
-
-@pytest.fixture()
-def non_existent_file(tmp_path):
-    # tmp_path is builtin pytest fixture to get a per-test temporary directory that should be clean
-    # but we still make sure that it doesn't exist before giving it
-    file = tmp_path / 'GHOST_FILE'
-    file.exists().should.equal(False)
-    return file
 
 @pytest.fixture()
 def firesim_parse_args():


### PR DESCRIPTION
They run relatively quickly so there is little upside to selectively running them (see https://github.com/firesim/firesim/issues/1142). If we do want to filter on this we should be as permissive as possible. 

Somewhat relatedly, can we run these on a container instance? Python devs would get feedback sooner if we did that. Not a huge priority though. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

N/A

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

N/A
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
