### PR TITLE
Deinit Chipyard's FireSim submodule under FireSim-as-top

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -141,10 +141,10 @@ if [ "$IS_LIBRARY" = false ]; then
     git submodule update --init target-design/chipyard
     cd $RDIR/target-design/chipyard
 
-    # Prevent initialization of Chipyard's FireSim submodule so that
-    # fuzzy-finders, and IDEs don't get confused by source duplication.
-    git config submodule.sims/firesim.update none
     ./scripts/init-submodules-no-riscv-tools.sh --skip-validate
+    # Deinitialize Chipyard's FireSim submodule so that fuzzy finders, IDEs,
+    # etc., don't get confused by source duplication.
+    git submodule deinit sims/firesim
     cd $RDIR
 
     # Configure firemarshal to know where our firesim installation is.


### PR DESCRIPTION
This _should_ actually remove the duplication of FireSIm sources when running under firesim-as-top. Chipyard did not respect the config change. 

@nandor, FYI
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

#### UI / API Impact

Tooling will be less confused by duplication of FireSim sources.

#### Verilog / AGFI Compatibility

None

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
