### PR TITLE
ci: set MANAGER_FIRESIM_LOCATION in all workflows

### DIFF
--- a/.github/workflows/firesim-cull-instances.yml
+++ b/.github/workflows/firesim-cull-instances.yml
@@ -11,6 +11,7 @@ env:
   AWS-SECRET-ACCESS-KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS-DEFAULT-REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   FIRESIM_PEM: ${{ secrets.FIRESIM_PEM }}
+  MANAGER_FIRESIM_LOCATION: "~/firesim"
 
 jobs:
   cull-old-ci-instances:

--- a/.github/workflows/firesim-publish-scala-doc.yml
+++ b/.github/workflows/firesim-publish-scala-doc.yml
@@ -20,6 +20,7 @@ env:
   AWS-DEFAULT-REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   FIRESIM_PEM: ${{ secrets.FIRESIM_PEM }}
   FIRESIM-REPO-DEP-KEY: ${{ secrets.FIRESIM_REPO_DEP_KEY }}
+  MANAGER_FIRESIM_LOCATION: "~/firesim"
   LANG: "en_US.UTF-8" # required by SBT when it sees boost directories
   LANGUAGE: "en_US:en"
   LC_ALL: "en_US.UTF-8"


### PR DESCRIPTION
This fixes a bug-by-omission introduced in #1144. 

Maybe these workflows should just always run on pulls to main that touch `.github`. The cleanup workflow would have to NOP on pulls. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
