### PR TITLE
Annotate Printf statements instead of intercepting parameters. 

### DIFF
--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Printf-Synthesis.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Printf-Synthesis.rst
@@ -24,13 +24,9 @@ Enabling Printf Synthesis
 ----------------------------
 
 To synthesize a printf, you need to annotate the specific printfs you'd like to
-capture in your Chisel source code.  Presently, due to a limitation in Chisel
-and FIRRTL's annotation system, you need to annotate the arguments to the
-printf, not the printf itself, like so:
+capture in your Chisel source code like so::
 
-::
-
-    printf(midas.targetutils.SynthesizePrintf("x%d p%d 0x%x\n", rf_waddr, rf_waddr, rf_wdata))
+    midas.targetutils.SynthesizePrintf(printf("x%d p%d 0x%x\n", rf_waddr, rf_waddr, rf_wdata))
 
 Be judicious, as synthesizing many, frequently active printfs will slow down your simulator.
 

--- a/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
@@ -98,7 +98,7 @@ class AutoCounterTransform extends Transform with AutoCounterConsts {
         val printName = moduleNS.newName(suggestedPrintName)
         val printStmt = Print(NoInfo, printFormat, Seq(valueToPrint),
                               WRef(clock.ref), And(WRef(trigger), printEnable), printName)
-        addedAnnos += SynthPrintfAnnotation(Seq(Seq(mT.ref(valueToPrint.name))), mT, printFormat.string, Some(printName))
+        addedAnnos += SynthPrintfAnnotation(mT.ref(printName))
         addedStmts += printStmt
       }
 

--- a/sim/src/main/scala/midasexamples/GlobalResetConditionTests.scala
+++ b/sim/src/main/scala/midasexamples/GlobalResetConditionTests.scala
@@ -43,7 +43,7 @@ class AssertGlobalResetCondition(implicit p: Parameters) extends GlobalResetCond
 
 class PrintfGlobalResetCondition(implicit p: Parameters) extends GlobalResetConditionTester(
   (inReset: Bool) => {
-    when(inReset) { printf(SynthesizePrintf(s"This should not print. %b\n", inReset)) }
+    when(inReset) { SynthesizePrintf(printf(s"This should not print. %b\n", inReset)) }
 })
 
 class AutoCounterGlobalResetCondition(implicit p: Parameters) extends GlobalResetConditionTester(

--- a/sim/src/main/scala/midasexamples/PrintfModule.scala
+++ b/sim/src/main/scala/midasexamples/PrintfModule.scala
@@ -30,20 +30,17 @@ class PrintfModuleDUT(printfPrefix: String = "SYNTHESIZED_PRINT ") extends Modul
   // Printf format strings must be prefixed with "SYNTHESIZED_PRINT CYCLE: %d"
   // so they can be pulled out of RTL simulators log and sorted within a cycle
   // As the printf order will be different betwen RTL simulator and synthesized stream
-  printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d\n", cycle))
+  SynthesizePrintf(printf(s"${printfPrefix}CYCLE: %d\n", cycle))
 
   val wideArgument = VecInit(Seq.fill(33)(WireInit(cycle))).asUInt
-  printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d wideArgument: %x\n", cycle, wideArgument)) // argument width > DMA width
+  SynthesizePrintf(printf(s"${printfPrefix}CYCLE: %d wideArgument: %x\n", cycle, wideArgument)) // argument width > DMA width
 
   val childInst = Module(new PrintfModuleChild(printfPrefix))
   childInst.c := io.a
   childInst.cycle := cycle
 
-  printf(SynthesizePrintf("thi$!sn+taS/\neName", s"${printfPrefix}CYCLE: %d constantArgument: %x\n", cycle, 1.U(8.W)))
-  // Check character-type format specifier; restrict to printable range to play
-  // nice with our ScalaTest utilities
   val ch = Mux(cycle(7,0) > 32.U && cycle(7,0) < 127.U, cycle(7,0), 32.U(8.W))
-  printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d Char: %c\n", cycle, ch))
+  SynthesizePrintf(printf(s"${printfPrefix}CYCLE: %d Char: %c\n", cycle, ch))
 }
 
 class PrintfModuleChild(printfPrefix: String) extends MultiIOModule {
@@ -51,10 +48,10 @@ class PrintfModuleChild(printfPrefix: String) extends MultiIOModule {
   val cycle = IO(Input(UInt(16.W)))
 
   val lfsr = LFSR(16, c)
-  printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d LFSR: %x\n", cycle, lfsr))
+  SynthesizePrintf(printf(s"${printfPrefix}CYCLE: %d LFSR: %x\n", cycle, lfsr))
 
   //when (lsfr(0)) {
-  //  printf(SynthesizePrintf(p"SYNTHESIZED_PRINT CYCLE: ${cycle} LFSR is odd"))
+  //  SynthesizePrintf(printf(p"SYNTHESIZED_PRINT CYCLE: ${cycle} LFSR is odd"))
   //}
 }
 
@@ -68,7 +65,7 @@ class NarrowPrintfModuleDUT extends Module {
   val cycle = Reg(UInt(12.W))
   cycle := cycle + 1.U
   when(LFSR(16)(0) & LFSR(16)(0) & io.enable) {
-    printf(SynthesizePrintf("SYNTHESIZED_PRINT CYCLE: %d\n", cycle(5,0)))
+    SynthesizePrintf(printf("SYNTHESIZED_PRINT CYCLE: %d\n", cycle(5,0)))
   }
 }
 

--- a/sim/src/main/scala/midasexamples/TriggerPredicatedPrintf.scala
+++ b/sim/src/main/scala/midasexamples/TriggerPredicatedPrintf.scala
@@ -37,7 +37,7 @@ class TriggerPredicatedPrintfDUT(printfPrefix: String = "SYNTHESIZED_PRINT ")
     val sinkEnable = Wire(Bool())
     TriggerSink(sinkEnable)
     when (sinkEnable) {
-      printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d LFSR: %x\n", cycle, lfsr))
+      SynthesizePrintf(printf(s"${printfPrefix}CYCLE: %d LFSR: %x\n", cycle, lfsr))
     }
   }
 
@@ -56,7 +56,7 @@ class TriggerPredicatedPrintfDUT(printfPrefix: String = "SYNTHESIZED_PRINT ")
     *   when (sinkEnable) { <...> }
     */
   TriggerSink.whenEnabled(noSourceDefault = false.B) {
-    printf(SynthesizePrintf(s"${printfPrefix}CYCLE: %d\n", cycle))
+    SynthesizePrintf(printf(s"${printfPrefix}CYCLE: %d\n", cycle))
   }
   // DOC include end: TriggerSink.whenEnabled Usage
 

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -259,7 +259,7 @@ class PrintfCycleBoundsTestBase(startCycle: Int, endCycle: Int) extends Tutorial
       s"+print-start=${startCycle}",
       s"+print-end=${endCycle}"
     )) {
-  checkPrintCycles("synthprinttest.out0", startCycle, endCycle, linesPerCycle = 5)
+  checkPrintCycles("synthprinttest.out0", startCycle, endCycle, linesPerCycle = 4)
 }
 
 class PrintfCycleBoundsF1Test extends PrintfCycleBoundsTestBase(startCycle = 172, endCycle = 9377)
@@ -306,7 +306,7 @@ class MulticlockPrintF1Test extends TutorialSuite("MulticlockPrintfModule",
     stdoutPrefix = "SYNTHESIZED_PRINT_HALFRATE ",
     synthPrefix = "SYNTHESIZED_PRINT_HALFRATE ",
     // Corresponds to a single cycle of extra output.
-    synthLinesToDrop = 5)
+    synthLinesToDrop = 4)
 }
 
 class MulticlockAutoCounterF1Test extends TutorialSuite("MulticlockAutoCounterModule",


### PR DESCRIPTION
This fixes a longstanding hack in how printf synthesis targets were annotated. 

The old-style methods will need to be removed in Chipyard submodules after a bump to complete the deprecation process. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

Resolves #1052.

<!-- List any related issues here -->

#### UI / API Impact

Does change how printf synthesis is deployed in the target. Should be more intuitive now. 

#### Verilog / AGFI Compatibility

Default AGFIs do not use printf synthesis.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
