### PR TITLE
Change elfutils submodule URL to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/brendangregg/FlameGraph.git
 [submodule "sim/firesim-lib/src/main/cc/lib/elfutils"]
 	path = sim/firesim-lib/src/main/cc/lib/elfutils
-	url = git://sourceware.org/git/elfutils.git
+	url = https://sourceware.org/git/elfutils.git
 [submodule "sim/firesim-lib/src/main/cc/lib/libdwarf"]
 	path = sim/firesim-lib/src/main/cc/lib/libdwarf
 	url = https://github.com/davea42/libdwarf-code


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

I was unable to build FireSim locally while on a VPN that does not allow outgoing SSH connections. After changing this URL, `build-setup.sh` ran successfully. HTTPS source is available as seen [here](https://sourceware.org/git/elfutils.git#:~:text=https%3A//sourceware.org/git/elfutils.git).

#### Related PRs / Issues

None

#### UI / API Impact

None

#### Verilog / AGFI Compatibility

No change

### Contributor Checklist
None are really applicable

- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [ ] If applicable, did you apply the `Please Backport` label?

Don't think I have permissions to apply label.
Not sure if this should be backported.

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
