### PR TITLE
obey umask and default group in results-workload

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -322,6 +322,14 @@ class FireSimServerNode(FireSimNode):
         """
         assert self.has_assigned_host_instance(), "copy requires assigned host instance"
 
+        # rsync_project defaults to using -a and that will copy symlinks as links
+        # and preserve group ownership and permissions.
+        copy_back_extra_opts = ' '.join([
+            '-L', # transform symlink into referent file/dir
+            '--no-group', # use default group here for creating local files
+            '--no-perms --chmod=ugo=rwX', # obey local umask
+        ])
+
         jobinfo = self.get_job()
         simserverindex = slotno
         job_results_dir = self.get_job().parent_workload.job_results_dir
@@ -387,7 +395,7 @@ class FireSimServerNode(FireSimNode):
                     rsync_cap = rsync_project(remote_dir=mountpoint + outputfile,
                             local_dir=job_dir,
                             ssh_opts="-o StrictHostKeyChecking=no",
-                            extra_opts="-L",
+                            extra_opts=copy_back_extra_opts,
                             upload=False,
                             capture=True)
                     rootLogger.debug(rsync_cap)
@@ -409,7 +417,7 @@ class FireSimServerNode(FireSimNode):
                 rsync_cap = rsync_project(remote_dir=remote_sim_run_dir + simoutputfile,
                         local_dir=job_dir,
                         ssh_opts="-o StrictHostKeyChecking=no",
-                        extra_opts="-L",
+                        extra_opts=copy_back_extra_opts,
                         upload=False,
                         capture=True)
                 rootLogger.debug(rsync_cap)


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Currently, whatever permissions are in the rootfs are preserved when copying results back from the runner.  It makes more sense for the umask and default group settings of the user running the manager to be obeyed in the end-result files.  This makes it much more deterministic in a flow where other user-id's need to be given access to the FireSim results.

#### Related PRs / Issues

<!-- List any related issues here -->

fixes #1150 

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

This simplifies the potential permissions of files created in `results-workload` so that they obey the umask and default
group set by the user's environment that is running the firesim manager.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

No impact to Verilog or AGFI, only manager copy-back behavior.


### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [X] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [X] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [X] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
