### PR TITLE
Tag AGFI with sha of toplevel repo

### DIFF
--- a/deploy/awstools/afitools.py
+++ b/deploy/awstools/afitools.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import distutils.util
 import logging
 import boto3
 from awstools.awstools import depaginated_boto_query
+
+from pprint import pformat
+from schema import Schema, And, SchemaError, Or, Use # type: ignore
 
 rootLogger = logging.getLogger()
 
@@ -104,18 +108,65 @@ def share_agfi_in_all_regions(agfi_id, useridlist):
         afi_id = get_afi_for_agfi(agfi_id, region)
         share_afi_with_users(afi_id, region, useridlist)
 
-def firesim_tags_to_description(buildtriplet, deploytriplet, commit):
-    """ Serialize the tags we want to set for storage in the AGFI description """
-    return """firesim-buildtriplet:{},firesim-deploytriplet:{},firesim-commit:{}""".format(buildtriplet,deploytriplet,commit)
+# max length of tag values is taken from early in FireSim when AWS tags were used and
+# had a limit of 256.  The AWS API does not document a constraint on the length of
+# description on https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFpgaImage.html
+# retrieved on 03MAR2022
+ILLEGAL_KV_CHARS=':,'
+STR256 = And(str, lambda s: len(s) < 256, lambda s: all([c not in s for c in ILLEGAL_KV_CHARS]),
+	     error=f"Must be string shorter than 256, not containing {pformat(ILLEGAL_KV_CHARS)}"
+	    )
+STRBOOL = Or(And(str, Use(distutils.util.strtobool)),bool)
+TAG_DICT_SCHEMA = Schema({
+    'firesim-buildtriplet': STR256,
+    'firesim-deploytriplet': STR256,
+    'firesim-commit': STR256,
+    'firesim-origin': STR256,
+    'firesim-ispushed': STRBOOL,
+    'top-commit': STR256,
+    'top-origin': STR256,
+    'top-ispushed': STRBOOL,
+})
 
-def firesim_description_to_tags(description):
+# ensure that someone doesn't add a key that has illegal characters into schema
+for k in TAG_DICT_SCHEMA.schema.keys():
+    try:
+        STR256.validate(k)
+    except SchemaError as e:
+        raise SchemaError(f'TAG_DICT_SCHEMA key {k} failed to validate with STR256') from e
+
+def firesim_tags_to_description(tags: dict) -> str:
+    """ Serialize the tags we want to set for storage in the AGFI description
+    Args:
+        tags: dict of tags that conforms to tag_dict_schema.validate(tags)
+    Throws:
+        subclass of `schema.SchemaError` if `tags` fails to validate
+    Returns:
+        Serialized tags
+    """
+    validated = TAG_DICT_SCHEMA.validate(tags)
+    return ",".join([f"{k}:{v}" for k, v in validated.items()])
+
+
+def firesim_description_to_tags(description: str) -> dict:
     """ Deserialize the tags we want to read from the AGFI description string.
-    Return dictionary of keys/vals [buildtriplet, deploytriplet, commit]. """
+    Args:
+        AGFI description string
+    Returns:
+         dictionary of keys/vals [buildtriplet, deploytriplet, commit].
+         that should validate to `TAG_DICT_SCHEMA`.  However, it will
+         only log any exception during validation as a warning.
+    """
     returndict = dict()
     desc_split = description.split(",")
     for keypair in desc_split:
         splitpair = keypair.split(":")
         returndict[splitpair[0]] = splitpair[1]
+    try:
+        TAG_DICT_SCHEMA.validate(returndict)
+    except SchemaError as ex:
+        rootLogger.warning(f"Encountered schema validation error when deserializing {description}",
+                           exc_info=ex)
     return returndict
 
 def get_firesim_tagval_for_afi(afi_id, tagkey):

--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -14,9 +14,10 @@ from fabric.contrib.project import rsync_project # type: ignore
 
 from awstools.afitools import firesim_tags_to_description, copy_afi_to_all_regions
 from awstools.awstools import send_firesim_notification, get_aws_userid, get_aws_region, auto_create_bucket, valid_aws_configure_creds, aws_resource_names, get_snsname_arn
+from util.git import git_origin_sha_is_pushed
 
 # imports needed for python type checking
-from typing import Optional, Dict, Any, TYPE_CHECKING
+from typing import Hashable, Optional, Dict, Any, TYPE_CHECKING, Union
 if TYPE_CHECKING:
     from buildtools.buildconfig import BuildConfig
 
@@ -255,33 +256,36 @@ class F1BitBuilder(BitBuilder):
         s3bucket = self.s3_bucketname
         afiname = self.build_config.name
 
+        # tags will be expected to awstools.afitools.TAG_DICT_SCHEMA.validate(tags)
+        tags: Dict[Hashable, Union[str, bool]] = {}
+
         # construct the "tags" we store in the AGFI description
-        tag_buildtriplet = self.build_config.get_chisel_triplet()
-        tag_deploytriplet = tag_buildtriplet
+        tags['firesim-buildtriplet'] = self.build_config.get_chisel_triplet()
+        tags['firesim-deploytriplet'] = tags['firesim-buildtriplet']
         if self.build_config.deploytriplet:
-            tag_deploytriplet = self.build_config.deploytriplet
+            tags['firesim-deploytriplet'] = self.build_config.deploytriplet
 
-        # the asserts are left over from when we tried to do this with tags
-        # - technically I don't know how long these descriptions are allowed to be,
-        # but it's at least 256*3, so I'll leave these here for now as sanity
-        # checks.
-        assert len(tag_buildtriplet) <= 255, "ERR: aws does not support tags longer than 256 chars for buildtriplet"
-        assert len(tag_deploytriplet) <= 255, "ERR: aws does not support tags longer than 256 chars for deploytriplet"
+        toplevel_superproject_path = "."
+        while True:
+            next_higher_superproject = local(
+                f"git -C {toplevel_superproject_path} rev-parse --show-superproject-working-tree",
+                capture=True
+            )
+            if next_higher_superproject == "":
+                break
+            toplevel_superproject_path = next_higher_superproject
 
-        is_dirty_str = local("if [[ $(git status --porcelain) ]]; then echo '-dirty'; fi", capture=True)
-        hash = local("git rev-parse HEAD", capture=True)
-        tag_fsimcommit = hash + is_dirty_str
-
-        assert len(tag_fsimcommit) <= 255, "ERR: aws does not support tags longer than 256 chars for fsimcommit"
+        tags['firesim-origin'], tags['firesim-commit'], tags['firesim-ispushed'] = git_origin_sha_is_pushed(".")
+        tags['top-origin'], tags['top-commit'], tags['top-ispushed'] = git_origin_sha_is_pushed(toplevel_superproject_path)
 
         # construct the serialized description from these tags.
-        description = firesim_tags_to_description(tag_buildtriplet, tag_deploytriplet, tag_fsimcommit)
+        description = firesim_tags_to_description(tags)
 
         # if we're unlucky, multiple vivado builds may launch at the same time. so we
         # append the build node IP + a random string to diff them in s3
         global_append = "-" + str(env.host_string) + "-" + ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(10)) + ".tar"
 
-        with lcd(f"{local_results_dir}/cl_{tag_buildtriplet}/build/checkpoints/to_aws/"):
+        with lcd(f"{local_results_dir}/cl_{tags['firesim-buildtriplet']}/build/checkpoints/to_aws/"):
             files = local('ls *.tar', capture=True)
             rootLogger.debug(files)
             rootLogger.debug(files.stderr)

--- a/deploy/tests/afitools/test_afi_tools.py
+++ b/deploy/tests/afitools/test_afi_tools.py
@@ -1,0 +1,64 @@
+import logging
+import random
+import string
+
+import pytest
+import sure
+
+rootLogger = logging.getLogger()
+
+# In case you put any package-level tests, make sure they use the test credentials too
+pytestmark = pytest.mark.usefixtures("aws_test_credentials")
+
+@pytest.mark.usefixtures("aws_test_credentials")
+class TestFireSimTags:
+    "Test serialization and deserialization of AGFI descriptions"
+
+    def test_str256(self):
+        from awstools.afitools import STR256, ILLEGAL_KV_CHARS
+
+        rl = rootLogger
+
+        rl.info('STR256 allows empty string')
+        STR256.validate('').should.be.equal('')
+
+        # make a grab-bag of legal string characters
+        legal = ''.join(set(c for c in string.ascii_letters + string.digits).difference(ILLEGAL_KV_CHARS))
+
+        rl.info('STR256 limits string length to 255')
+        s = ''.join(random.SystemRandom().choice(legal) for _ in range(56))
+        STR256.validate(s).should.equal(s)
+
+        s = ''.join(random.SystemRandom().choice(legal) for _ in range(256))
+        STR256.validate.when.called_with(s).should.throw(Exception)
+
+        rl.info('STR256 does not allow ILLEGAL_KV_CHARS')
+        s = ''.join(random.SystemRandom().choice(legal) for _ in range(56)) + ILLEGAL_KV_CHARS
+        STR256.validate.when.called_with(s).should.throw(Exception)
+
+        rl.info('STR256 does not allow integer type')
+        with pytest.raises(Exception):
+            STR256().validate(123)
+        # maybe this should be changed to just coerce things into str, in which case we would
+        #STR256().validate(123).should.equal(str(123))
+
+
+    def test_strbool(self):
+        from awstools.afitools import STRBOOL
+
+        rl = rootLogger
+
+        rl.info('STRBOOL takes bools')
+        STRBOOL.validate(True).should.equal(True)
+        STRBOOL.validate(False).should.equal(False)
+
+        rl.info('STRBOOL coerces known strings to bool')
+        for s in ('yes', 'YES', 'TRUE', '1'):
+            STRBOOL.validate(s).should.equal(True)
+
+        for s in ('no', 'NO', 'False', '0'):
+            STRBOOL.validate(s).should.equal(False)
+
+        rl.info('STRBOOL throws for unknown strings')
+        for s in ('bogus', 'not_coerceable'):
+            STRBOOL.validate.when.called_with(s).should.throw(Exception)

--- a/deploy/tests/util/conftest.py
+++ b/deploy/tests/util/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+from subprocess import run, CompletedProcess
+import sure
+
+
+def shell(cmd:str) -> CompletedProcess:
+    return run(cmd, check=True, shell=True, capture_output=True, text=True)
+
+@pytest.fixture()
+def temp_cloned_repo(tmp_path):
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    shell(f"git -C {origin} init ")
+    oa = origin / "a.txt"
+    oa.write_text("This is a file")
+    ob = origin / "b.txt"
+    ob.write_text("This is file b")
+    shell(f"git -C {origin} add .")
+    shell(f"git -C {origin} commit -m initial")
+
+    clone = tmp_path / "clone"
+    shell(f"git -C {tmp_path} clone origin clone")
+    clone.exists().should.equal(True)
+
+    oc = origin / "c.txt"
+    oc.write_text("This file won't be in the clone.")
+    shell(f"git -C {origin} add c.txt")
+    shell(f"git -C {origin} commit -m 'adding c.txt'")
+    yield clone
+

--- a/deploy/tests/util/test_git.py
+++ b/deploy/tests/util/test_git.py
@@ -1,0 +1,165 @@
+import logging
+from os import fspath
+import pytest
+import re
+from subprocess import run, PIPE
+import sure
+
+from util.streamlogger import InfoStreamLogger
+
+
+rootLogger=logging.getLogger()
+
+class TestGitAssumptions:
+    """Test git features that we depend on"""
+
+    def test_git_fetch_pack_for_unadvertised_sha(self):
+        """in buildafi.git_origin_sha_is_pushed() we use git fetch-pack
+           to query the origin remote for the existence of a 40-digit sha
+           Unless the git remote server is configured to accept shas as arguments
+           (see the end of `git fetch-pack --help` for details) the code we use
+           could falsely indicate that a commit is not pushed in the AGFI metadata
+        """
+
+        """If this test starts failing, then we could fall back to a much slower
+           implementation for is_pushed:
+               # make sure all of the tracking branches are up to date locally
+               # this could be really expensive if we intentionally do a shallow clone
+               # of a really big repo for CI or builds
+               git fetch --unshallow --prune origin
+               upstream=$(git branch --contains {sha} --remote --list 'origin/*')
+               is_pushed=$(test -n "$upstream") # it is pushed if the git-branch command prints branches
+               # this also assumes that the upstream doesn't have tags that are unreachable
+               # from branches. If you do, then finding things that are only reachable from tags
+               # on the remote is a pain because tags get flattened into a single namespace
+               # when they are fetched to local.  You would need to use git-ls-remote
+               # to grab all refs that the remote knows about and then ask your local clone
+               # whether the sha in question has anything not reachable from any of those
+               # refs
+               git ls-remote origin | awk '{print ^$1}' | xargs -x git rev-list {sha}
+               # and if that outputs any revisions, they are not pushed and only reachable
+               # from {sha}.  However, the -x is really important to notice because this
+               # cmdline could get very long and has to be given as one cmd to git CLI
+        """
+
+        rootLogger.info("Ensure origin remote is defined and resolve it's fetch URL")
+        url = run("git remote get-url origin", check=True, shell=True, stdout=PIPE, text=True).stdout.rstrip("\n")
+        rootLogger.info(f"url:'{url}'")
+
+        rootLogger.info("Ask origin for all 'advertised' objects")
+        remote_refs = run("git ls-remote origin | awk '{print $1}'", shell=True, check=True, stdout=PIPE, text=True).stdout.rstrip("\n")
+        remote_refs = set(remote_refs.split("\n"))
+        remote_refs.should_not.be.empty
+        rootLogger.info(f"found {len(remote_refs)} remote references")
+
+        rootLogger.info("start from the default branch of the origin (as of whenever we fetched last)")
+        sha = run(f"git rev-parse origin/HEAD", text=True,
+                     check=True, shell=True, stdout=PIPE).stdout.rstrip("\n")
+        rootLogger.info(f"starting sha:'{sha}'")
+
+        while sha in remote_refs:
+            # walk first parents backward in history
+            # will exit non-zero if we get to the end
+            sha = run(f"git rev-parse {sha}~", text=True,
+                      check=True, shell=True, stdout=PIPE).stdout.rstrip("\n")
+
+        # now sha isn't in remote_refs
+        rootLogger.info("Ask origin to send unadvertised commit that you know is reachable from there")
+        with InfoStreamLogger('stdout'), InfoStreamLogger('stderr'):
+            # if the server doesn't think 'sha' exists, then this will exit non-zero
+            # that can only happen if the server is configured to disallow requesting
+            # specific shas
+            run(f"git fetch-pack --depth=1 {url} {sha}", check=True, shell=True)
+
+
+class TestGitHelpers:
+    """Test util/git.py functionality """
+
+    def test_git_origin(self, temp_cloned_repo):
+        from util.git import git_origin
+        origin = git_origin(fspath(temp_cloned_repo))
+        # this assertion is tightly coupled to how temp_cloned_repo fixture is setup in conftest.py
+        origin.should.equal(fspath(temp_cloned_repo.parent / "origin"))
+
+
+    def test_git_origin_undefined_returns_empty_string(self, temp_cloned_repo):
+        from util.git import git_origin
+        run(f"git -C {temp_cloned_repo} remote remove origin", shell=True, check=True)
+        origin = git_origin(fspath(temp_cloned_repo))
+        origin.should.equal("")
+
+
+    def test_sha_dirty(self, temp_cloned_repo):
+        from util.git import git_sha_dirty
+
+        sha = []
+        is_dirty = []
+        rootLogger.info("temp_cloned_repo should initially be clean")
+        s, d = git_sha_dirty(fspath(temp_cloned_repo))
+        sha.append(s)
+        is_dirty.append(d)
+        sha[0].should.match(r'[0-9a-f]{40}', re.I)
+        is_dirty[0].should.equal("")
+
+        rootLogger.info("Modifying a file in temp_cloned_repo should make it dirty")
+        fileb = temp_cloned_repo / "b.txt"
+        fileb.write_text("I am modifying b.txt")
+        s, d = git_sha_dirty(fspath(temp_cloned_repo))
+        sha.append(s)
+        is_dirty.append(d)
+        sha[1].should.equal(sha[0])
+        is_dirty[1].should.equal("-dirty")
+
+        rootLogger.info("Committing my modifications should make it a new sha and clean again")
+        run(f"git -C {temp_cloned_repo} commit -m 'a message' b.txt", shell=True, check=True)
+        s, d = git_sha_dirty(fspath(temp_cloned_repo))
+        sha.append(s)
+        is_dirty.append(d)
+        sha[2].should.match(r'[0-9a-f]{40}', re.I)
+        sha[2].should_not.equal(sha[0])
+        is_dirty[2].should.equal("")
+
+
+    def test_git_is_pushed(self, temp_cloned_repo):
+        from util.git import git_origin, git_server_do_you_have_this, git_sha_dirty, GitServerSHA1Denial
+        from fabric.api import env
+
+        # prevent fabric from raising SystemExit because error message is less useful
+        env.abort_exception = Exception
+
+        origin = git_origin(fspath(temp_cloned_repo))
+        sha, dirty = git_sha_dirty(fspath(temp_cloned_repo))
+
+        rootLogger.info("Initial request should be denied due to server config")
+        with pytest.raises(GitServerSHA1Denial):
+            git_server_do_you_have_this(origin, sha, fspath(temp_cloned_repo))
+
+        rootLogger.info("Change origin config to allow request for unadvertized shas (matching Github)")
+        run(f"git -C {origin} config --local uploadpack.allowReachableSHA1InWant true", shell=True, check=True)
+
+        is_pushed = git_server_do_you_have_this(origin, sha, fspath(temp_cloned_repo))
+        rootLogger.info("Initially cloned commit should exist on origin")
+        is_pushed.should.equal(True)
+
+        rootLogger.info("Making a new commit, it should not exist on origin")
+        fileb = temp_cloned_repo / "b.txt"
+        fileb.write_text("I am modifying b.txt")
+        run(f"git -C {temp_cloned_repo} commit -m 'a message' b.txt", shell=True, check=True)
+        sha, dirty = git_sha_dirty(fspath(temp_cloned_repo))
+        is_pushed = git_server_do_you_have_this(origin, sha, fspath(temp_cloned_repo))
+        is_pushed.should.equal(False)
+
+
+    def test_git_is_pushed_throws_on_unexpected_error(self, temp_cloned_repo):
+        from util.git import git_origin, git_server_do_you_have_this, git_sha_dirty
+        from fabric.api import env
+
+        origin = git_origin(fspath(temp_cloned_repo))
+        sha, dirty = git_sha_dirty(fspath(temp_cloned_repo))
+
+        expected_exception = env.abort_exception if env.abort_exception else SystemExit
+        with pytest.raises(expected_exception) as exc:
+            rootLogger.info("Calling get_server_do_you_have_this with invalid remote_url should raise")
+            git_server_do_you_have_this(fspath(temp_cloned_repo.parent / "not_a_directory"),
+                                        sha,
+                                        fspath(temp_cloned_repo))

--- a/deploy/util/git.py
+++ b/deploy/util/git.py
@@ -1,0 +1,83 @@
+from typing import Tuple
+from fabric.api import local, lcd, warn_only, hide # type: ignore
+from fabric.utils import error, abort # type: ignore
+import re
+
+class GitServerSHA1Denial(Exception):
+    """Used to indicate Git Server config doesn't allow efficient query in git_server_do_you_have_this"""
+
+def git_sha_dirty(workdir:str = ".") -> Tuple[str, str]:
+    with lcd(workdir):
+        is_dirty_str = local("if [[ $(git status --porcelain) ]]; then echo '-dirty'; fi", capture=True)
+        hash = local("git rev-parse HEAD", capture=True)
+        return hash, is_dirty_str
+
+
+def git_origin(workdir:str = ".") -> str:
+    """
+    Args:
+        workdir: path to git repository working tree
+    Returns:
+        first fetch url of 'origin' remote in `workdir` or emptystring if it is not defined
+    """
+    with lcd(workdir), warn_only():
+        origin = local("git remote get-url origin", capture=True)
+        if origin.return_code != 0:
+            origin = ""
+        return origin
+
+
+def git_server_do_you_have_this(remote_url:str, sha:str, workdir:str = ".") -> bool:
+    """Query git at `remote_url` for existence of `sha`
+    Notes:
+        requires that your git server is configured with `uploadpack.allowReachableSHA1InWant` or
+        (more likely due to the computational complexity of reachability) `uploadpack.allowAnySHA1InWant`
+        If your server does not support requesting unadvertized shas, you will receive a `GitServerSHA1Denial`
+        exception
+    Args:
+        remote_url: url of a git 'remote'
+        sha: 40-hex sha string of a commit object
+        workdir. Default is ".": path to git working tree
+    Raises:
+        `GitServerDenial` when server does not allow unadvertised objects to be requested
+        `fabric.env.abort_exception` or `SystemExit` on unrecognized non-zero
+        exit from `git fetch-pack`
+    Returns:
+        True if `sha` is found by `remote_url`, False if `sha` is `not our ref`
+    """
+    with lcd(workdir), warn_only():
+        # NOTE: if the remote git server doesn't have at least uploadpack.allowReachableSHA1InWant, then
+        #       this will turn into a false-negative.  It currently works for GitHub and there is
+        #       test_git.py::TestGitAssumptions::test_git_fetch_pack_for_sha to ensure it continues to work
+        fp_res = local(f"git fetch-pack --depth=1 {remote_url} {sha}", capture=True)
+        if fp_res.return_code == 0:
+            return True
+        elif re.search(r'not our ref', fp_res.stderr):
+            return False
+        elif re.search(r'Server does not allow request for unadvertised object', fp_res.stderr):
+            raise GitServerSHA1Denial(fp_res.stderr)
+        else:
+            # some other unexpected kind of error happened, throw like fabric
+            # would if warn_only wasn't in place
+            msg = f"local() encountered an error (return code {fp_res.return_code}) while executing '{fp_res.command}'"
+            # force fabric to print stdout and stderr because we captured them and they weren't printed yet
+            with hide('stdout', 'stderr'):
+                error(message=msg, func=abort, stdout=fp_res, stderr=fp_res.stderr)
+
+    return False # only to make mypy pass, this can never be reached.
+
+def git_origin_sha_is_pushed(workdir:str = ".") -> Tuple[str, str, bool]:
+    """Query git server regarding current commit checked out in `workdir`
+    Args:
+        workdir: run git at this path
+    Returns:
+        3-tuple of:
+        * origin URL - empty string if origin remote does not exist
+        * sha - 40 character git sho with -dirty suffix if status isn't clean
+        * is_pushed - indication of whether sha exists on origin
+    """
+    hash, is_dirty_str = git_sha_dirty(workdir)
+    origin = git_origin(workdir)
+    is_pushed = git_server_do_you_have_this(origin, hash, workdir)
+
+    return origin, hash + is_dirty_str, is_pushed

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -347,6 +347,7 @@ set -o pipefail
         mypy-boto3-ec2==1.21.9 \
         sure==2.0.0 \
         pylddwrap==1.2.1 \
+        schema==0.7.5 \
     )
     if [[ -n "$PIP_PKGS[*]" ]]; then
         "${DRY_RUN_ECHO[@]}" $SUDO "${CONDA_PIP_EXE}" install "${PIP_PKGS[@]}"

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -217,7 +217,7 @@ repo_state     := $(fpga_work_dir)/design/repo_state
 fpga_driver_dir:= $(fpga_work_dir)/driver
 
 # Enumerates the subset of generated files that must be copied over for FPGA compilation
-fpga_delivery_files = $(addprefix $(fpga_work_dir)/design/$(BASE_FILE_NAME), \
+fpga_delivery_files = $(repo_state) $(addprefix $(fpga_work_dir)/design/$(BASE_FILE_NAME), \
 	.sv .defines.vh .env.tcl \
 	.synthesis.xdc .implementation.xdc)
 


### PR DESCRIPTION
Similar to how we changed repo_state_summary.sh to create repo_state file from
the toplevel git superproject, generate the commit tag for the AGFI from the toplevel
repo.

Add firesim_origin and top_origin tags to contain URL for those repos.

Add ispushed tags to indicate whether the commit existed on respective origin at the
time the AGFI was created.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->
Rewrite of #936.  h/t @filipstamenkovic-sifive for doing the rewrite!

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

Adds tags to AGFIs to aid in reproducing builds where Firesim is not the toplevel repo (Chipyard-as-top, etc).

Also adds tags to indicate whether the hash was pushed to a remote named `origin` or not at the time of build.

Adds `util.git` module to the firesim python for doing some of the tag introspection.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

Doesn't 

### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [X] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [X] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [X] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [X] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
