### PR TITLE
Fix switch build under clang-format header order

### DIFF
--- a/target-design/switch/baseport.h
+++ b/target-design/switch/baseport.h
@@ -1,3 +1,8 @@
+#ifndef __BASEPORT_H
+#define __BASEPORT_H
+
+#include "flit.h"
+
 #define FLIT_BITS 64
 #define BITTIME_PER_QUANTA 512
 #define CYCLES_PER_QUANTA (BITTIME_PER_QUANTA / FLIT_BITS)
@@ -181,3 +186,4 @@ void BasePort::setup_send_buf() {
     *((uint64_t *)(current_output_buf) + bigtokenno * 8) = 0L;
   }
 }
+#endif // __BASEPORT_H

--- a/target-design/switch/flit.h
+++ b/target-design/switch/flit.h
@@ -1,3 +1,6 @@
+#ifndef __FLIT_H
+#define __FLIT_H
+
 #include <stdlib.h>
 
 #define BROADCAST_ADJUSTED (0xffff)
@@ -84,3 +87,4 @@ uint16_t get_port_from_flit(uint64_t flit, int current_port) {
   // printf("port: %04x\n", sendport);
   return sendport;
 }
+#endif // __FLIT_H

--- a/target-design/switch/shmemport.h
+++ b/target-design/switch/shmemport.h
@@ -1,3 +1,6 @@
+#ifndef __SHMEMPORT_H
+#define __SHMEMPORT_H
+
 #include <errno.h>
 
 class ShmemPort : public BasePort {
@@ -186,3 +189,4 @@ void ShmemPort::tick() {
   // swap buf pointers
   current_input_buf = recvbufs[currentround];
 }
+#endif // __SSHMEMPORT_H

--- a/target-design/switch/socketport.h
+++ b/target-design/switch/socketport.h
@@ -1,3 +1,6 @@
+#ifndef __SOCKETPORT_H
+#define __SOCKETPORT_H
+
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -210,3 +213,4 @@ void SocketServerPort::tick() {
 void SocketServerPort::tick_pre() {
   // does nothing in this port
 }
+#endif // __SOCKETPORT_H

--- a/target-design/switch/sshport.h
+++ b/target-design/switch/sshport.h
@@ -1,3 +1,5 @@
+#ifndef __SSHPORT_H
+#define __SSHPORT_H
 
 #include <queue>
 
@@ -172,3 +174,4 @@ void SSHPort::tick() {
 void SSHPort::tick_pre() {
   // don't need to do anything for SSHPorts
 }
+#endif // __SSHPORT_H


### PR DESCRIPTION

`baseport.h` was referring to things in `flit.h`, and clang-format reordered the imports alphabetically such that `flit.h` no longer preceeded `baseport.h`. I explicitly called out this header dependency, and added header guards on all files for good measure. 

Omitting from the changelog since it didn't make it into a release. 
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->


#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
