### PR TITLE
test updating AMI to 1.12.1

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -39,7 +39,7 @@ rootLogger = logging.getLogger()
 # https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Images:visibility=public-images;search=FPGA%20Developer;sort=name
 # And whenever this changes, you also need to update deploy/tests/test_amis.json
 # by running scripts/update_test_amis.py
-f1_ami_name = "FPGA Developer AMI - 1.11.1-40257ab5-6688-4c95-97d1-e251a40fd1fc"
+f1_ami_name = "FPGA Developer AMI - 1.12.1-40257ab5-6688-4c95-97d1-e251a40fd1fc"
 
 class MockBoto3Instance:
     """ This is used for testing without actually launching instances. """

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -10,29 +10,29 @@
 # own images.
 
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0b969bdcc09663973
+    agfi: agfi-0eaeaaec5bd306fae
     deploy_triplet_override: null
     custom_runtime_config: null
 
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0d9d8e9255c80dac5
+    agfi: agfi-08e8e3b9298cb9472
     deploy_triplet_override: null
     custom_runtime_config: null
 
 # DOCREF START: Example HWDB Entry
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0c45d995a46cce5dc
+    agfi: agfi-0594aacc0c8228264
     deploy_triplet_override: null
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-08719c613c2f314cc
+    agfi: agfi-0073db2b54ab0a502
     deploy_triplet_override: null
     custom_runtime_config: null
 
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-0b747b88806aeed5c
+    agfi: agfi-019ccbf133bad277d
     deploy_triplet_override: null
     custom_runtime_config: null
 

--- a/deploy/tests/test_amis.json
+++ b/deploy/tests/test_amis.json
@@ -1,8 +1,8 @@
 [
   {
-    "ami_id": "ami-02d069917d7c319a3",
-    "name": "FPGA Developer AMI - 1.11.1-40257ab5-6688-4c95-97d1-e251a40fd1fc",
-    "description": "FPGA Developer AMI with Xilinx 2021.1 toolset and XRT with log4j updated to 2.17",
+    "ami_id": "ami-0ef416754763a5ab7",
+    "name": "FPGA Developer AMI - 1.12.1-40257ab5-6688-4c95-97d1-e251a40fd1fc",
+    "description": "Xilinx 2021.2 release with latest AMI updates",
     "owner_id": "679593333241",
     "public": true,
     "virtualization_type": "hvm",

--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -32,7 +32,7 @@ To launch a manager instance, follow these steps:
    not lost when pricing spikes on the spot market.
 #. In the *Name* field, give the instance a recognizable name, for example ``firesim-manager-1``. This is purely for your own convenience and can also be left blank.
 #. In the *Application and OS Images* search box, search for
-   ``FPGA Developer AMI - 1.11.1-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and
+   ``FPGA Developer AMI - 1.12.1-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and
    select the AMI that appears under the ***Community AMIs*** tab (there
    should be only one). **DO NOT USE ANY OTHER VERSION.** For example, **do not** use `FPGA Developer AMI` from the *AWS Marketplace AMIs* tab, as you will likely get an incorrect version of the AMI.
 #. In the *Instance Type* drop-down, select the instance type of


### PR DESCRIPTION
1.11.1 is delisted in search now, so we need to bump. This PR is for testing to see how far things get.

#### Related PRs / Issues

#1172 

#### UI / API Impact

Fix setup docs. Maybe break lots of other stuff.

#### Verilog / AGFI Compatibility

This bumps vivado version 2021.1 -> 2021.2, so we'll see.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you regenerate and publicly share default AGFIs?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
