### PR TITLE
test updating AMI to 1.13.0

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -39,7 +39,7 @@ rootLogger = logging.getLogger()
 # https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Images:visibility=public-images;search=FPGA%20Developer;sort=name
 # And whenever this changes, you also need to update deploy/tests/test_amis.json
 # by running scripts/update_test_amis.py
-f1_ami_name = "FPGA Developer AMI - 1.11.1-40257ab5-6688-4c95-97d1-e251a40fd1fc"
+f1_ami_name = "FPGA Developer AMI 1.13.0-40257ab5-6688-4c95-97d1-e251a40fd1fc"
 
 class MockBoto3Instance:
     """ This is used for testing without actually launching instances. """

--- a/deploy/tests/test_amis.json
+++ b/deploy/tests/test_amis.json
@@ -1,8 +1,8 @@
 [
   {
-    "ami_id": "ami-02d069917d7c319a3",
-    "name": "FPGA Developer AMI - 1.11.1-40257ab5-6688-4c95-97d1-e251a40fd1fc",
-    "description": "FPGA Developer AMI with Xilinx 2021.1 toolset and XRT with log4j updated to 2.17",
+    "ami_id": "ami-028791b62b23efdd9",
+    "name": "FPGA Developer AMI 1.13.0-40257ab5-6688-4c95-97d1-e251a40fd1fc",
+    "description": "Xilinx tools 2022.1 with XRT",
     "owner_id": "679593333241",
     "public": true,
     "virtualization_type": "hvm",

--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -32,7 +32,7 @@ To launch a manager instance, follow these steps:
    not lost when pricing spikes on the spot market.
 #. In the *Name* field, give the instance a recognizable name, for example ``firesim-manager-1``. This is purely for your own convenience and can also be left blank.
 #. In the *Application and OS Images* search box, search for
-   ``FPGA Developer AMI - 1.11.1-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and
+   ``FPGA Developer AMI 1.13.0-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and
    select the AMI that appears under the ***Community AMIs*** tab (there
    should be only one). **DO NOT USE ANY OTHER VERSION.** For example, **do not** use `FPGA Developer AMI` from the *AWS Marketplace AMIs* tab, as you will likely get an incorrect version of the AMI.
 #. In the *Instance Type* drop-down, select the instance type of


### PR DESCRIPTION
1.11.1 is delisted in search now, so we need to bump. This PR is for testing to see how far things get.

#### Related PRs / Issues

#1172 

#### UI / API Impact

Fix setup docs. Maybe break lots of other stuff.

#### Verilog / AGFI Compatibility

This bumps vivado version 2021.1 -> 2022.1, so we'll see.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
