### PR TITLE
Backports go to stable branch, which should generally point to the la…

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,4 @@
 pull_request_rules:
-  # For FireSim version 1.x.y, here let x = minor, y = patch
-  # Only support backporting to the last minor release branch.
-  # This rule will need to be updated on minor releases.
   - name: backport to latest minor release
     conditions:
       - merged
@@ -10,7 +7,7 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - 1.13.x
+          - stable
         ignore_conflicts: True
         label_conflicts: "bp-conflict"
       label:


### PR DESCRIPTION
Backports go to stable branch, which should generally point to the last released version.

#### Related PRs / Issues

N/A

#### UI / API Impact

Only for devs.

#### Verilog / AGFI Compatibility

No changes.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
