### PR TITLE
Fix various VCS metasimulation breakages

### DIFF
--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -61,7 +61,7 @@ $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(design_h) $(lib) $(DRIVER) $(driver_h) 
 $(PLATFORM): $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
 
 # Sources for building MIDAS-level simulators. Must be defined before sources VCS/Verilator Makefrags
-override CXXFLAGS += -include $(design_h)
+override CXXFLAGS += -std=c++17 -include $(design_h)
 
 # Models of FPGA primitives that are used in host-level sim, but not in FPGATop
 sim_fpga_resource_models := $(v_dir)/BUFGCE.v

--- a/sim/midas/src/main/cc/emul/mmio.cc
+++ b/sim/midas/src/main/cc/emul/mmio.cc
@@ -1,10 +1,6 @@
 #include "mmio.h"
-#include "mm.h"
-#include "mm_dramsim2.h"
 #include <cassert>
-#include <cmath>
-#include <iostream>
-#include <memory>
+#include <cstdlib>
 
 void mmio_t::read_req(uint64_t addr, size_t size, size_t len) {
   mmio_req_addr_t ar(0, addr, size, len);
@@ -85,26 +81,4 @@ bool mmio_t::write_resp() {
     write_inflight = false;
     return true;
   }
-}
-
-extern uint64_t main_time;
-extern std::unique_ptr<mmio_t> master;
-extern std::unique_ptr<mmio_t> dma;
-std::unique_ptr<mm_t> slave[MEM_NUM_CHANNELS];
-
-void init(uint64_t memsize, bool dramsim) {
-  master.reset(new mmio_t(CTRL_BEAT_BYTES));
-  dma.reset(new mmio_t(DMA_BEAT_BYTES));
-  for (int mem_channel_index = 0; mem_channel_index < MEM_NUM_CHANNELS;
-       mem_channel_index++) {
-    slave[mem_channel_index].reset(
-        dramsim ? (mm_t *)new mm_dramsim2_t(1 << MEM_ID_BITS)
-                : (mm_t *)new mm_magic_t);
-    slave[mem_channel_index]->init(memsize, MEM_BEAT_BYTES, 64);
-  }
-}
-
-void load_mems(const char *fname) {
-  slave[0]->load_mem(0, fname);
-  // TODO: allow file to be split across slaves
 }

--- a/sim/midas/src/main/cc/emul/mmio.h
+++ b/sim/midas/src/main/cc/emul/mmio.h
@@ -38,6 +38,15 @@ struct mmio_resp_data_t {
       : id(id_), data(data_), last(last_) {}
 };
 
+/**
+ * @brief  staging container for driver-mastered AXI4 transactions
+ *
+ *  AXI4 transactions bound for the RTL-simulator context are queued up in this
+ *  data structure as they wait to be driven into the verilated / or VCS design.
+ *
+ *  Used for CPU-mastered AXI4 (aka, DMA), and MMIO requests (see simif_t::read,
+ *  simif_t::write).
+ */
 class mmio_t {
 public:
   mmio_t(size_t size) : read_inflight(false), write_inflight(false) {

--- a/sim/midas/src/main/cc/emul/vcs-harness.cc
+++ b/sim/midas/src/main/cc/emul/vcs-harness.cc
@@ -1,21 +1,15 @@
-#include "mm.h"
-#include "mm_dramsim2.h"
-#include "mmio.h"
+#include "simif_emul.h"
 #include <DirectC.h>
 #include <cassert>
 #include <cmath>
 #include <exception>
 #include <fesvr/context.h>
-#include <memory>
 #include <stdio.h>
 
 extern context_t *host;
 extern bool vcs_fin;
 extern bool vcs_rst;
 extern uint64_t main_time;
-extern std::unique_ptr<mmio_t> master;
-extern std::unique_ptr<mmio_t> dma;
-extern std::unique_ptr<mm_t> slave[MEM_NUM_CHANNELS];
 
 static const size_t CTRL_DATA_SIZE = CTRL_BEAT_BYTES / sizeof(uint32_t);
 static const size_t DMA_DATA_SIZE = DMA_BEAT_BYTES / sizeof(uint32_t);
@@ -218,40 +212,44 @@ void tick(vc_handle reset,
           vc_handle mem_3_b_bits_resp,
           vc_handle mem_3_b_bits_id) {
   try {
-    mmio_t *m, *d;
-    assert(m = dynamic_cast<mmio_t *>(master.get()));
-    assert(d = dynamic_cast<mmio_t *>(dma.get()));
+    // The driver ucontext is initialized before spawning the VCS
+    // context, so these pointers should be initialized.
+    assert(simif_emul_t::dma != nullptr);
+    assert(simif_emul_t::master != nullptr);
+
     assert(DMA_STRB_SIZE <= 2);
 
     uint32_t ctrl_r_data[CTRL_DATA_SIZE];
     for (size_t i = 0; i < CTRL_DATA_SIZE; i++) {
       ctrl_r_data[i] = vc_4stVectorRef(ctrl_r_bits_data)[i].d;
     }
+
     uint32_t dma_r_data[DMA_DATA_SIZE];
     for (size_t i = 0; i < DMA_DATA_SIZE; i++) {
       dma_r_data[i] = vc_4stVectorRef(dma_r_bits_data)[i].d;
     }
-    m->tick(vcs_rst,
-            vc_getScalar(ctrl_ar_ready),
-            vc_getScalar(ctrl_aw_ready),
-            vc_getScalar(ctrl_w_ready),
-            vc_4stVectorRef(ctrl_r_bits_id)->d,
-            ctrl_r_data,
-            vc_getScalar(ctrl_r_bits_last),
-            vc_getScalar(ctrl_r_valid),
-            vc_4stVectorRef(ctrl_b_bits_id)->d,
-            vc_getScalar(ctrl_b_valid));
 
-    d->tick(vcs_rst,
-            vc_getScalar(dma_ar_ready),
-            vc_getScalar(dma_aw_ready),
-            vc_getScalar(dma_w_ready),
-            vc_4stVectorRef(dma_r_bits_id)->d,
-            dma_r_data,
-            vc_getScalar(dma_r_bits_last),
-            vc_getScalar(dma_r_valid),
-            vc_4stVectorRef(dma_b_bits_id)->d,
-            vc_getScalar(dma_b_valid));
+    simif_emul_t::master->tick(vcs_rst,
+                               vc_getScalar(ctrl_ar_ready),
+                               vc_getScalar(ctrl_aw_ready),
+                               vc_getScalar(ctrl_w_ready),
+                               vc_4stVectorRef(ctrl_r_bits_id)->d,
+                               ctrl_r_data,
+                               vc_getScalar(ctrl_r_bits_last),
+                               vc_getScalar(ctrl_r_valid),
+                               vc_4stVectorRef(ctrl_b_bits_id)->d,
+                               vc_getScalar(ctrl_b_valid));
+
+    simif_emul_t::dma->tick(vcs_rst,
+                            vc_getScalar(dma_ar_ready),
+                            vc_getScalar(dma_aw_ready),
+                            vc_getScalar(dma_w_ready),
+                            vc_4stVectorRef(dma_r_bits_id)->d,
+                            dma_r_data,
+                            vc_getScalar(dma_r_bits_last),
+                            vc_getScalar(dma_r_valid),
+                            vc_4stVectorRef(dma_b_bits_id)->d,
+                            vc_getScalar(dma_b_valid));
 
 #define MEMORY_CHANNEL_TICK(IDX)                                               \
   uint32_t mem_##IDX##_w_data[MEM_DATA_SIZE];                                  \
@@ -259,26 +257,26 @@ void tick(vc_handle reset,
     mem_##IDX##_w_data[i] = vc_4stVectorRef(mem_##IDX##_w_bits_data)[i].d;     \
   }                                                                            \
                                                                                \
-  slave[IDX]->tick(vcs_rst,                                                    \
-                   vc_getScalar(mem_##IDX##_ar_valid),                         \
-                   vc_4stVectorRef(mem_##IDX##_ar_bits_addr)->d,               \
-                   vc_4stVectorRef(mem_##IDX##_ar_bits_id)->d,                 \
-                   vc_4stVectorRef(mem_##IDX##_ar_bits_size)->d,               \
-                   vc_4stVectorRef(mem_##IDX##_ar_bits_len)->d,                \
+  simif_emul_t::slave[IDX]->tick(vcs_rst,                                      \
+                                 vc_getScalar(mem_##IDX##_ar_valid),           \
+                                 vc_4stVectorRef(mem_##IDX##_ar_bits_addr)->d, \
+                                 vc_4stVectorRef(mem_##IDX##_ar_bits_id)->d,   \
+                                 vc_4stVectorRef(mem_##IDX##_ar_bits_size)->d, \
+                                 vc_4stVectorRef(mem_##IDX##_ar_bits_len)->d,  \
                                                                                \
-                   vc_getScalar(mem_##IDX##_aw_valid),                         \
-                   vc_4stVectorRef(mem_##IDX##_aw_bits_addr)->d,               \
-                   vc_4stVectorRef(mem_##IDX##_aw_bits_id)->d,                 \
-                   vc_4stVectorRef(mem_##IDX##_aw_bits_size)->d,               \
-                   vc_4stVectorRef(mem_##IDX##_aw_bits_len)->d,                \
+                                 vc_getScalar(mem_##IDX##_aw_valid),           \
+                                 vc_4stVectorRef(mem_##IDX##_aw_bits_addr)->d, \
+                                 vc_4stVectorRef(mem_##IDX##_aw_bits_id)->d,   \
+                                 vc_4stVectorRef(mem_##IDX##_aw_bits_size)->d, \
+                                 vc_4stVectorRef(mem_##IDX##_aw_bits_len)->d,  \
                                                                                \
-                   vc_getScalar(mem_##IDX##_w_valid),                          \
-                   vc_4stVectorRef(mem_##IDX##_w_bits_strb)->d,                \
-                   mem_##IDX##_w_data,                                         \
-                   vc_getScalar(mem_##IDX##_w_bits_last),                      \
+                                 vc_getScalar(mem_##IDX##_w_valid),            \
+                                 vc_4stVectorRef(mem_##IDX##_w_bits_strb)->d,  \
+                                 mem_##IDX##_w_data,                           \
+                                 vc_getScalar(mem_##IDX##_w_bits_last),        \
                                                                                \
-                   vc_getScalar(mem_##IDX##_r_ready),                          \
-                   vc_getScalar(mem_##IDX##_b_ready));
+                                 vc_getScalar(mem_##IDX##_r_ready),            \
+                                 vc_getScalar(mem_##IDX##_b_ready));
 
     MEMORY_CHANNEL_TICK(0)
 #ifdef MEM_HAS_CHANNEL1
@@ -296,86 +294,86 @@ void tick(vc_handle reset,
     else
       vcs_fin = false;
 
-    vc_putScalar(ctrl_aw_valid, m->aw_valid());
-    vc_putScalar(ctrl_ar_valid, m->ar_valid());
-    vc_putScalar(ctrl_w_valid, m->w_valid());
-    vc_putScalar(ctrl_w_bits_last, m->w_last());
-    vc_putScalar(ctrl_r_ready, m->r_ready());
-    vc_putScalar(ctrl_b_ready, m->b_ready());
+    vc_putScalar(ctrl_aw_valid, simif_emul_t::master->aw_valid());
+    vc_putScalar(ctrl_ar_valid, simif_emul_t::master->ar_valid());
+    vc_putScalar(ctrl_w_valid, simif_emul_t::master->w_valid());
+    vc_putScalar(ctrl_w_bits_last, simif_emul_t::master->w_last());
+    vc_putScalar(ctrl_r_ready, simif_emul_t::master->r_ready());
+    vc_putScalar(ctrl_b_ready, simif_emul_t::master->b_ready());
 
     vec32 md[CTRL_DATA_SIZE];
     md[0].c = 0;
-    md[0].d = m->aw_id();
+    md[0].d = simif_emul_t::master->aw_id();
     vc_put4stVector(ctrl_aw_bits_id, md);
     md[0].c = 0;
-    md[0].d = m->aw_addr();
+    md[0].d = simif_emul_t::master->aw_addr();
     vc_put4stVector(ctrl_aw_bits_addr, md);
     md[0].c = 0;
-    md[0].d = m->aw_size();
+    md[0].d = simif_emul_t::master->aw_size();
     vc_put4stVector(ctrl_aw_bits_size, md);
     md[0].c = 0;
-    md[0].d = m->aw_len();
+    md[0].d = simif_emul_t::master->aw_len();
     vc_put4stVector(ctrl_aw_bits_len, md);
     md[0].c = 0;
-    md[0].d = m->ar_id();
+    md[0].d = simif_emul_t::master->ar_id();
     vc_put4stVector(ctrl_ar_bits_id, md);
     md[0].c = 0;
-    md[0].d = m->ar_addr();
+    md[0].d = simif_emul_t::master->ar_addr();
     vc_put4stVector(ctrl_ar_bits_addr, md);
     md[0].c = 0;
-    md[0].d = m->ar_size();
+    md[0].d = simif_emul_t::master->ar_size();
     vc_put4stVector(ctrl_ar_bits_size, md);
     md[0].c = 0;
-    md[0].d = m->ar_len();
+    md[0].d = simif_emul_t::master->ar_len();
     vc_put4stVector(ctrl_ar_bits_len, md);
     md[0].c = 0;
-    md[0].d = m->w_strb();
+    md[0].d = simif_emul_t::master->w_strb();
     vc_put4stVector(ctrl_w_bits_strb, md);
 
     for (size_t i = 0; i < CTRL_DATA_SIZE; i++) {
       md[i].c = 0;
-      md[i].d = ((uint32_t *)m->w_data())[i];
+      md[i].d = ((uint32_t *)simif_emul_t::master->w_data())[i];
     }
     vc_put4stVector(ctrl_w_bits_data, md);
 
-    vc_putScalar(dma_aw_valid, d->aw_valid());
-    vc_putScalar(dma_ar_valid, d->ar_valid());
-    vc_putScalar(dma_w_valid, d->w_valid());
-    vc_putScalar(dma_w_bits_last, d->w_last());
-    vc_putScalar(dma_r_ready, d->r_ready());
-    vc_putScalar(dma_b_ready, d->b_ready());
+    vc_putScalar(dma_aw_valid, simif_emul_t::dma->aw_valid());
+    vc_putScalar(dma_ar_valid, simif_emul_t::dma->ar_valid());
+    vc_putScalar(dma_w_valid, simif_emul_t::dma->w_valid());
+    vc_putScalar(dma_w_bits_last, simif_emul_t::dma->w_last());
+    vc_putScalar(dma_r_ready, simif_emul_t::dma->r_ready());
+    vc_putScalar(dma_b_ready, simif_emul_t::dma->b_ready());
 
     vec32 dd[DMA_DATA_SIZE];
     dd[0].c = 0;
-    dd[0].d = d->aw_id();
+    dd[0].d = simif_emul_t::dma->aw_id();
     vc_put4stVector(dma_aw_bits_id, dd);
     dd[0].c = 0;
-    dd[0].d = d->aw_addr();
+    dd[0].d = simif_emul_t::dma->aw_addr();
     dd[1].c = 0;
-    dd[1].d = d->aw_addr() >> 32;
+    dd[1].d = simif_emul_t::dma->aw_addr() >> 32;
     vc_put4stVector(dma_aw_bits_addr, dd);
     dd[0].c = 0;
-    dd[0].d = d->aw_size();
+    dd[0].d = simif_emul_t::dma->aw_size();
     vc_put4stVector(dma_aw_bits_size, dd);
     dd[0].c = 0;
-    dd[0].d = d->aw_len();
+    dd[0].d = simif_emul_t::dma->aw_len();
     vc_put4stVector(dma_aw_bits_len, dd);
     dd[0].c = 0;
-    dd[0].d = d->ar_id();
+    dd[0].d = simif_emul_t::dma->ar_id();
     vc_put4stVector(dma_ar_bits_id, dd);
     dd[0].c = 0;
-    dd[0].d = d->ar_addr();
+    dd[0].d = simif_emul_t::dma->ar_addr();
     dd[1].c = 0;
-    dd[1].d = d->ar_addr() >> 32;
+    dd[1].d = simif_emul_t::dma->ar_addr() >> 32;
     vc_put4stVector(dma_ar_bits_addr, dd);
     dd[0].c = 0;
-    dd[0].d = d->ar_size();
+    dd[0].d = simif_emul_t::dma->ar_size();
     vc_put4stVector(dma_ar_bits_size, dd);
     dd[0].c = 0;
-    dd[0].d = d->ar_len();
+    dd[0].d = simif_emul_t::dma->ar_len();
     vc_put4stVector(dma_ar_bits_len, dd);
 
-    auto strb = d->w_strb();
+    auto strb = simif_emul_t::dma->w_strb();
     for (size_t i = 0; i < DMA_STRB_SIZE; i++) {
       dd[i].c = 0;
       dd[i].d = ((uint32_t *)(&strb))[i];
@@ -384,35 +382,35 @@ void tick(vc_handle reset,
 
     for (size_t i = 0; i < DMA_DATA_SIZE; i++) {
       dd[i].c = 0;
-      dd[i].d = ((uint32_t *)d->w_data())[i];
+      dd[i].d = ((uint32_t *)simif_emul_t::dma->w_data())[i];
     }
     vc_put4stVector(dma_w_bits_data, dd);
 
 #define MEMORY_CHANNEL_PROP(IDX)                                               \
-  vc_putScalar(mem_##IDX##_aw_ready, slave[IDX]->aw_ready());                  \
-  vc_putScalar(mem_##IDX##_ar_ready, slave[IDX]->ar_ready());                  \
-  vc_putScalar(mem_##IDX##_w_ready, slave[IDX]->w_ready());                    \
-  vc_putScalar(mem_##IDX##_b_valid, slave[IDX]->b_valid());                    \
-  vc_putScalar(mem_##IDX##_r_valid, slave[IDX]->r_valid());                    \
-  vc_putScalar(mem_##IDX##_r_bits_last, slave[IDX]->r_last());                 \
+  vc_putScalar(mem_##IDX##_aw_ready, simif_emul_t::slave[IDX]->aw_ready());    \
+  vc_putScalar(mem_##IDX##_ar_ready, simif_emul_t::slave[IDX]->ar_ready());    \
+  vc_putScalar(mem_##IDX##_w_ready, simif_emul_t::slave[IDX]->w_ready());      \
+  vc_putScalar(mem_##IDX##_b_valid, simif_emul_t::slave[IDX]->b_valid());      \
+  vc_putScalar(mem_##IDX##_r_valid, simif_emul_t::slave[IDX]->r_valid());      \
+  vc_putScalar(mem_##IDX##_r_bits_last, simif_emul_t::slave[IDX]->r_last());   \
                                                                                \
   vec32 sd_##IDX[MEM_DATA_SIZE];                                               \
   sd_##IDX[0].c = 0;                                                           \
-  sd_##IDX[0].d = slave[IDX]->b_id();                                          \
+  sd_##IDX[0].d = simif_emul_t::slave[IDX]->b_id();                            \
   vc_put4stVector(mem_##IDX##_b_bits_id, sd_##IDX);                            \
   sd_##IDX[0].c = 0;                                                           \
-  sd_##IDX[0].d = slave[IDX]->b_resp();                                        \
+  sd_##IDX[0].d = simif_emul_t::slave[IDX]->b_resp();                          \
   vc_put4stVector(mem_##IDX##_b_bits_resp, sd_##IDX);                          \
   sd_##IDX[0].c = 0;                                                           \
-  sd_##IDX[0].d = slave[IDX]->r_id();                                          \
+  sd_##IDX[0].d = simif_emul_t::slave[IDX]->r_id();                            \
   vc_put4stVector(mem_##IDX##_r_bits_id, sd_##IDX);                            \
   sd_##IDX[0].c = 0;                                                           \
-  sd_##IDX[0].d = slave[IDX]->r_resp();                                        \
+  sd_##IDX[0].d = simif_emul_t::slave[IDX]->r_resp();                          \
   vc_put4stVector(mem_##IDX##_r_bits_resp, sd_##IDX);                          \
                                                                                \
   for (size_t i = 0; i < MEM_DATA_SIZE; i++) {                                 \
     sd_##IDX[i].c = 0;                                                         \
-    sd_##IDX[i].d = ((uint32_t *)slave[IDX]->r_data())[i];                     \
+    sd_##IDX[i].d = ((uint32_t *)simif_emul_t::slave[IDX]->r_data())[i];       \
   }                                                                            \
   vc_put4stVector(mem_##IDX##_r_bits_data, sd_##IDX);
 

--- a/sim/midas/src/main/cc/emul/verilator-harness.cc
+++ b/sim/midas/src/main/cc/emul/verilator-harness.cc
@@ -1,141 +1,148 @@
-#include "mm.h"
-#include "mm_dramsim2.h"
-#include "mmio.h"
+#include "simif_emul.h"
 #include <cassert>
 #include <cmath>
-#include <memory>
 #include <verilated.h>
 #if VM_TRACE
 #include <verilated_vcd_c.h>
 #endif // VM_TRACE
 
 extern uint64_t main_time;
-extern std::unique_ptr<mmio_t> master;
-extern std::unique_ptr<mmio_t> dma;
-extern std::unique_ptr<mm_t> slave[MEM_NUM_CHANNELS];
-
 extern Vverilator_top *top;
 #if VM_TRACE
 extern VerilatedVcdC *tfp;
 #endif // VM_TRACE
 
 void tick() {
-  mmio_t *m, *d;
-  assert(m = dynamic_cast<mmio_t *>(master.get()));
-  assert(d = dynamic_cast<mmio_t *>(dma.get()));
+  // The driver ucontext is initialized before spawning the verilator
+  // context, so these pointers should be initialized.
+  assert(simif_emul_t::dma != nullptr);
+  assert(simif_emul_t::master != nullptr);
 
   // ASSUMPTION: All models have *no* combinational paths through I/O
   // Step 1: Clock lo -> propagate signals between DUT and software models
-  top->ctrl_aw_valid = m->aw_valid();
-  top->ctrl_aw_bits_id = m->aw_id();
-  top->ctrl_aw_bits_addr = m->aw_addr();
-  top->ctrl_aw_bits_size = m->aw_size();
-  top->ctrl_aw_bits_len = m->aw_len();
+  top->ctrl_aw_valid = simif_emul_t::simif_emul_t::master->aw_valid();
+  top->ctrl_aw_bits_id = simif_emul_t::master->aw_id();
+  top->ctrl_aw_bits_addr = simif_emul_t::master->aw_addr();
+  top->ctrl_aw_bits_size = simif_emul_t::master->aw_size();
+  top->ctrl_aw_bits_len = simif_emul_t::master->aw_len();
 
-  top->ctrl_ar_valid = m->ar_valid();
-  top->ctrl_ar_bits_id = m->ar_id();
-  top->ctrl_ar_bits_addr = m->ar_addr();
-  top->ctrl_ar_bits_size = m->ar_size();
-  top->ctrl_ar_bits_len = m->ar_len();
+  top->ctrl_ar_valid = simif_emul_t::master->ar_valid();
+  top->ctrl_ar_bits_id = simif_emul_t::master->ar_id();
+  top->ctrl_ar_bits_addr = simif_emul_t::master->ar_addr();
+  top->ctrl_ar_bits_size = simif_emul_t::master->ar_size();
+  top->ctrl_ar_bits_len = simif_emul_t::master->ar_len();
 
-  top->ctrl_w_valid = m->w_valid();
-  top->ctrl_w_bits_strb = m->w_strb();
-  top->ctrl_w_bits_last = m->w_last();
+  top->ctrl_w_valid = simif_emul_t::master->w_valid();
+  top->ctrl_w_bits_strb = simif_emul_t::master->w_strb();
+  top->ctrl_w_bits_last = simif_emul_t::master->w_last();
 
-  top->ctrl_r_ready = m->r_ready();
-  top->ctrl_b_ready = m->b_ready();
-  memcpy(&top->ctrl_w_bits_data, m->w_data(), CTRL_BEAT_BYTES);
+  top->ctrl_r_ready = simif_emul_t::master->r_ready();
+  top->ctrl_b_ready = simif_emul_t::master->b_ready();
+  memcpy(
+      &top->ctrl_w_bits_data, simif_emul_t::master->w_data(), CTRL_BEAT_BYTES);
 
-  top->dma_aw_valid = d->aw_valid();
-  top->dma_aw_bits_id = d->aw_id();
-  top->dma_aw_bits_addr = d->aw_addr();
-  top->dma_aw_bits_size = d->aw_size();
-  top->dma_aw_bits_len = d->aw_len();
+  top->dma_aw_valid = simif_emul_t::dma->aw_valid();
+  top->dma_aw_bits_id = simif_emul_t::dma->aw_id();
+  top->dma_aw_bits_addr = simif_emul_t::dma->aw_addr();
+  top->dma_aw_bits_size = simif_emul_t::dma->aw_size();
+  top->dma_aw_bits_len = simif_emul_t::dma->aw_len();
 
-  top->dma_ar_valid = d->ar_valid();
-  top->dma_ar_bits_id = d->ar_id();
-  top->dma_ar_bits_addr = d->ar_addr();
-  top->dma_ar_bits_size = d->ar_size();
-  top->dma_ar_bits_len = d->ar_len();
+  top->dma_ar_valid = simif_emul_t::dma->ar_valid();
+  top->dma_ar_bits_id = simif_emul_t::dma->ar_id();
+  top->dma_ar_bits_addr = simif_emul_t::dma->ar_addr();
+  top->dma_ar_bits_size = simif_emul_t::dma->ar_size();
+  top->dma_ar_bits_len = simif_emul_t::dma->ar_len();
 
-  top->dma_w_valid = d->w_valid();
-  top->dma_w_bits_strb = d->w_strb();
-  top->dma_w_bits_last = d->w_last();
+  top->dma_w_valid = simif_emul_t::dma->w_valid();
+  top->dma_w_bits_strb = simif_emul_t::dma->w_strb();
+  top->dma_w_bits_last = simif_emul_t::dma->w_last();
 
-  top->dma_r_ready = d->r_ready();
-  top->dma_b_ready = d->b_ready();
+  top->dma_r_ready = simif_emul_t::dma->r_ready();
+  top->dma_b_ready = simif_emul_t::dma->b_ready();
 #if DMA_DATA_BITS > 64
-  memcpy(top->dma_w_bits_data, d->w_data(), DMA_BEAT_BYTES);
+  memcpy(top->dma_w_bits_data, simif_emul_t::dma->w_data(), DMA_BEAT_BYTES);
 #else
-  memcpy(&top->dma_w_bits_data, d->w_data(), DMA_BEAT_BYTES);
+  memcpy(&top->dma_w_bits_data, simif_emul_t::dma->w_data(), DMA_BEAT_BYTES);
 #endif
 
-  top->mem_0_aw_ready = slave[0]->aw_ready();
-  top->mem_0_ar_ready = slave[0]->ar_ready();
-  top->mem_0_w_ready = slave[0]->w_ready();
-  top->mem_0_b_valid = slave[0]->b_valid();
-  top->mem_0_b_bits_id = slave[0]->b_id();
-  top->mem_0_b_bits_resp = slave[0]->b_resp();
-  top->mem_0_r_valid = slave[0]->r_valid();
-  top->mem_0_r_bits_id = slave[0]->r_id();
-  top->mem_0_r_bits_resp = slave[0]->r_resp();
-  top->mem_0_r_bits_last = slave[0]->r_last();
+  top->mem_0_aw_ready = simif_emul_t::slave[0]->aw_ready();
+  top->mem_0_ar_ready = simif_emul_t::slave[0]->ar_ready();
+  top->mem_0_w_ready = simif_emul_t::slave[0]->w_ready();
+  top->mem_0_b_valid = simif_emul_t::slave[0]->b_valid();
+  top->mem_0_b_bits_id = simif_emul_t::slave[0]->b_id();
+  top->mem_0_b_bits_resp = simif_emul_t::slave[0]->b_resp();
+  top->mem_0_r_valid = simif_emul_t::slave[0]->r_valid();
+  top->mem_0_r_bits_id = simif_emul_t::slave[0]->r_id();
+  top->mem_0_r_bits_resp = simif_emul_t::slave[0]->r_resp();
+  top->mem_0_r_bits_last = simif_emul_t::slave[0]->r_last();
 #if MEM_DATA_BITS > 64
-  memcpy(top->mem_0_r_bits_data, slave[0]->r_data(), MEM_BEAT_BYTES);
+  memcpy(
+      top->mem_0_r_bits_data, simif_emul_t::slave[0]->r_data(), MEM_BEAT_BYTES);
 #else
-  memcpy(&top->mem_0_r_bits_data, slave[0]->r_data(), MEM_BEAT_BYTES);
+  memcpy(&top->mem_0_r_bits_data,
+         simif_emul_t::slave[0]->r_data(),
+         MEM_BEAT_BYTES);
 #endif
 #ifdef MEM_HAS_CHANNEL1
-  top->mem_1_aw_ready = slave[1]->aw_ready();
-  top->mem_1_ar_ready = slave[1]->ar_ready();
-  top->mem_1_w_ready = slave[1]->w_ready();
-  top->mem_1_b_valid = slave[1]->b_valid();
-  top->mem_1_b_bits_id = slave[1]->b_id();
-  top->mem_1_b_bits_resp = slave[1]->b_resp();
-  top->mem_1_r_valid = slave[1]->r_valid();
-  top->mem_1_r_bits_id = slave[1]->r_id();
-  top->mem_1_r_bits_resp = slave[1]->r_resp();
-  top->mem_1_r_bits_last = slave[1]->r_last();
+  top->mem_1_aw_ready = simif_emul_t::slave[1]->aw_ready();
+  top->mem_1_ar_ready = simif_emul_t::slave[1]->ar_ready();
+  top->mem_1_w_ready = simif_emul_t::slave[1]->w_ready();
+  top->mem_1_b_valid = simif_emul_t::slave[1]->b_valid();
+  top->mem_1_b_bits_id = simif_emul_t::slave[1]->b_id();
+  top->mem_1_b_bits_resp = simif_emul_t::slave[1]->b_resp();
+  top->mem_1_r_valid = simif_emul_t::slave[1]->r_valid();
+  top->mem_1_r_bits_id = simif_emul_t::slave[1]->r_id();
+  top->mem_1_r_bits_resp = simif_emul_t::slave[1]->r_resp();
+  top->mem_1_r_bits_last = simif_emul_t::slave[1]->r_last();
 #if MEM_DATA_BITS > 64
-  memcpy(top->mem_1_r_bits_data, slave[1]->r_data(), MEM_BEAT_BYTES);
+  memcpy(
+      top->mem_1_r_bits_data, simif_emul_t::slave[1]->r_data(), MEM_BEAT_BYTES);
 #else
-  memcpy(&top->mem_1_r_bits_data, slave[1]->r_data(), MEM_BEAT_BYTES);
+  memcpy(&top->mem_1_r_bits_data,
+         simif_emul_t::slave[1]->r_data(),
+         MEM_BEAT_BYTES);
 #endif
 #endif // MEM_HAS_CHANNEL1
 
 #ifdef MEM_HAS_CHANNEL2
-  top->mem_2_aw_ready = slave[2]->aw_ready();
-  top->mem_2_ar_ready = slave[2]->ar_ready();
-  top->mem_2_w_ready = slave[2]->w_ready();
-  top->mem_2_b_valid = slave[2]->b_valid();
-  top->mem_2_b_bits_id = slave[2]->b_id();
-  top->mem_2_b_bits_resp = slave[2]->b_resp();
-  top->mem_2_r_valid = slave[2]->r_valid();
-  top->mem_2_r_bits_id = slave[2]->r_id();
-  top->mem_2_r_bits_resp = slave[2]->r_resp();
-  top->mem_2_r_bits_last = slave[2]->r_last();
+  top->mem_2_aw_ready = simif_emul_t::slave[2]->aw_ready();
+  top->mem_2_ar_ready = simif_emul_t::slave[2]->ar_ready();
+  top->mem_2_w_ready = simif_emul_t::slave[2]->w_ready();
+  top->mem_2_b_valid = simif_emul_t::slave[2]->b_valid();
+  top->mem_2_b_bits_id = simif_emul_t::slave[2]->b_id();
+  top->mem_2_b_bits_resp = simif_emul_t::slave[2]->b_resp();
+  top->mem_2_r_valid = simif_emul_t::slave[2]->r_valid();
+  top->mem_2_r_bits_id = simif_emul_t::slave[2]->r_id();
+  top->mem_2_r_bits_resp = simif_emul_t::slave[2]->r_resp();
+  top->mem_2_r_bits_last = simif_emul_t::slave[2]->r_last();
 #if MEM_DATA_BITS > 64
-  memcpy(top->mem_2_r_bits_data, slave[2]->r_data(), MEM_BEAT_BYTES);
+  memcpy(
+      top->mem_2_r_bits_data, simif_emul_t::slave[2]->r_data(), MEM_BEAT_BYTES);
 #else
-  memcpy(&top->mem_2_r_bits_data, slave[2]->r_data(), MEM_BEAT_BYTES);
+  memcpy(&top->mem_2_r_bits_data,
+         simif_emul_t::slave[2]->r_data(),
+         MEM_BEAT_BYTES);
 #endif
 #endif // MEM_HAS_CHANNEL2
 
 #ifdef MEM_HAS_CHANNEL3
-  top->mem_3_aw_ready = slave[3]->aw_ready();
-  top->mem_3_ar_ready = slave[3]->ar_ready();
-  top->mem_3_w_ready = slave[3]->w_ready();
-  top->mem_3_b_valid = slave[3]->b_valid();
-  top->mem_3_b_bits_id = slave[3]->b_id();
-  top->mem_3_b_bits_resp = slave[3]->b_resp();
-  top->mem_3_r_valid = slave[3]->r_valid();
-  top->mem_3_r_bits_id = slave[3]->r_id();
-  top->mem_3_r_bits_resp = slave[3]->r_resp();
-  top->mem_3_r_bits_last = slave[3]->r_last();
+  top->mem_3_aw_ready = simif_emul_t::slave[3]->aw_ready();
+  top->mem_3_ar_ready = simif_emul_t::slave[3]->ar_ready();
+  top->mem_3_w_ready = simif_emul_t::slave[3]->w_ready();
+  top->mem_3_b_valid = simif_emul_t::slave[3]->b_valid();
+  top->mem_3_b_bits_id = simif_emul_t::slave[3]->b_id();
+  top->mem_3_b_bits_resp = simif_emul_t::slave[3]->b_resp();
+  top->mem_3_r_valid = simif_emul_t::slave[3]->r_valid();
+  top->mem_3_r_bits_id = simif_emul_t::slave[3]->r_id();
+  top->mem_3_r_bits_resp = simif_emul_t::slave[3]->r_resp();
+  top->mem_3_r_bits_last = simif_emul_t::slave[3]->r_last();
 #if MEM_DATA_BITS > 64
-  memcpy(top->mem_3_r_bits_data, slave[3]->r_data(), MEM_BEAT_BYTES);
+  memcpy(
+      top->mem_3_r_bits_data, simif_emul_t::slave[3]->r_data(), MEM_BEAT_BYTES);
 #else
-  memcpy(&top->mem_3_r_bits_data, slave[3]->r_data(), MEM_BEAT_BYTES);
+  memcpy(&top->mem_3_r_bits_data,
+         simif_emul_t::slave[3]->r_data(),
+         MEM_BEAT_BYTES);
 #endif
 #endif // MEM_HAS_CHANNEL3
 
@@ -155,130 +162,130 @@ void tick() {
   main_time++;
 
   // Step 2: Clock high, tick all software models and evaluate DUT with posedge
-  m->tick(top->reset,
-          top->ctrl_ar_ready,
-          top->ctrl_aw_ready,
-          top->ctrl_w_ready,
-          top->ctrl_r_bits_id,
-          &top->ctrl_r_bits_data,
-          top->ctrl_r_bits_last,
-          top->ctrl_r_valid,
-          top->ctrl_b_bits_id,
-          top->ctrl_b_valid);
+  simif_emul_t::master->tick(top->reset,
+                             top->ctrl_ar_ready,
+                             top->ctrl_aw_ready,
+                             top->ctrl_w_ready,
+                             top->ctrl_r_bits_id,
+                             &top->ctrl_r_bits_data,
+                             top->ctrl_r_bits_last,
+                             top->ctrl_r_valid,
+                             top->ctrl_b_bits_id,
+                             top->ctrl_b_valid);
 
-  d->tick(top->reset,
-          top->dma_ar_ready,
-          top->dma_aw_ready,
-          top->dma_w_ready,
-          top->dma_r_bits_id,
-          &top->dma_r_bits_data,
-          top->dma_r_bits_last,
-          top->dma_r_valid,
-          top->dma_b_bits_id,
-          top->dma_b_valid);
+  simif_emul_t::dma->tick(top->reset,
+                          top->dma_ar_ready,
+                          top->dma_aw_ready,
+                          top->dma_w_ready,
+                          top->dma_r_bits_id,
+                          &top->dma_r_bits_data,
+                          top->dma_r_bits_last,
+                          top->dma_r_valid,
+                          top->dma_b_bits_id,
+                          top->dma_b_valid);
 
-  slave[0]->tick(top->reset,
-                 top->mem_0_ar_valid,
-                 top->mem_0_ar_bits_addr,
-                 top->mem_0_ar_bits_id,
-                 top->mem_0_ar_bits_size,
-                 top->mem_0_ar_bits_len,
+  simif_emul_t::slave[0]->tick(top->reset,
+                               top->mem_0_ar_valid,
+                               top->mem_0_ar_bits_addr,
+                               top->mem_0_ar_bits_id,
+                               top->mem_0_ar_bits_size,
+                               top->mem_0_ar_bits_len,
 
-                 top->mem_0_aw_valid,
-                 top->mem_0_aw_bits_addr,
-                 top->mem_0_aw_bits_id,
-                 top->mem_0_aw_bits_size,
-                 top->mem_0_aw_bits_len,
+                               top->mem_0_aw_valid,
+                               top->mem_0_aw_bits_addr,
+                               top->mem_0_aw_bits_id,
+                               top->mem_0_aw_bits_size,
+                               top->mem_0_aw_bits_len,
 
-                 top->mem_0_w_valid,
-                 top->mem_0_w_bits_strb,
+                               top->mem_0_w_valid,
+                               top->mem_0_w_bits_strb,
 #if MEM_DATA_BITS > 64
-                 top->mem_0_w_bits_data,
+                               top->mem_0_w_bits_data,
 #else
-                 &top->mem_0_w_bits_data,
+                               &top->mem_0_w_bits_data,
 #endif
-                 top->mem_0_w_bits_last,
+                               top->mem_0_w_bits_last,
 
-                 top->mem_0_r_ready,
-                 top->mem_0_b_ready);
+                               top->mem_0_r_ready,
+                               top->mem_0_b_ready);
 
 #ifdef MEM_HAS_CHANNEL1
-  slave[1]->tick(top->reset,
-                 top->mem_1_ar_valid,
-                 top->mem_1_ar_bits_addr,
-                 top->mem_1_ar_bits_id,
-                 top->mem_1_ar_bits_size,
-                 top->mem_1_ar_bits_len,
+  simif_emul_t::slave[1]->tick(top->reset,
+                               top->mem_1_ar_valid,
+                               top->mem_1_ar_bits_addr,
+                               top->mem_1_ar_bits_id,
+                               top->mem_1_ar_bits_size,
+                               top->mem_1_ar_bits_len,
 
-                 top->mem_1_aw_valid,
-                 top->mem_1_aw_bits_addr,
-                 top->mem_1_aw_bits_id,
-                 top->mem_1_aw_bits_size,
-                 top->mem_1_aw_bits_len,
+                               top->mem_1_aw_valid,
+                               top->mem_1_aw_bits_addr,
+                               top->mem_1_aw_bits_id,
+                               top->mem_1_aw_bits_size,
+                               top->mem_1_aw_bits_len,
 
-                 top->mem_1_w_valid,
-                 top->mem_1_w_bits_strb,
+                               top->mem_1_w_valid,
+                               top->mem_1_w_bits_strb,
 #if MEM_DATA_BITS > 64
-                 top->mem_1_w_bits_data,
+                               top->mem_1_w_bits_data,
 #else
-                 &top->mem_1_w_bits_data,
+                               &top->mem_1_w_bits_data,
 #endif
-                 top->mem_1_w_bits_last,
+                               top->mem_1_w_bits_last,
 
-                 top->mem_1_r_ready,
-                 top->mem_1_b_ready);
+                               top->mem_1_r_ready,
+                               top->mem_1_b_ready);
 #endif // MEM_HAS_CHANNEL1
 #ifdef MEM_HAS_CHANNEL2
-  slave[2]->tick(top->reset,
-                 top->mem_2_ar_valid,
-                 top->mem_2_ar_bits_addr,
-                 top->mem_2_ar_bits_id,
-                 top->mem_2_ar_bits_size,
-                 top->mem_2_ar_bits_len,
+  simif_emul_t::slave[2]->tick(top->reset,
+                               top->mem_2_ar_valid,
+                               top->mem_2_ar_bits_addr,
+                               top->mem_2_ar_bits_id,
+                               top->mem_2_ar_bits_size,
+                               top->mem_2_ar_bits_len,
 
-                 top->mem_2_aw_valid,
-                 top->mem_2_aw_bits_addr,
-                 top->mem_2_aw_bits_id,
-                 top->mem_2_aw_bits_size,
-                 top->mem_2_aw_bits_len,
+                               top->mem_2_aw_valid,
+                               top->mem_2_aw_bits_addr,
+                               top->mem_2_aw_bits_id,
+                               top->mem_2_aw_bits_size,
+                               top->mem_2_aw_bits_len,
 
-                 top->mem_2_w_valid,
-                 top->mem_2_w_bits_strb,
+                               top->mem_2_w_valid,
+                               top->mem_2_w_bits_strb,
 #if MEM_DATA_BITS > 64
-                 top->mem_2_w_bits_data,
+                               top->mem_2_w_bits_data,
 #else
-                 &top->mem_2_w_bits_data,
+                               &top->mem_2_w_bits_data,
 #endif
-                 top->mem_2_w_bits_last,
+                               top->mem_2_w_bits_last,
 
-                 top->mem_2_r_ready,
-                 top->mem_2_b_ready);
+                               top->mem_2_r_ready,
+                               top->mem_2_b_ready);
 #endif // MEM_HAS_CHANNEL2
 #ifdef MEM_HAS_CHANNEL3
-  slave[3]->tick(top->reset,
-                 top->mem_3_ar_valid,
-                 top->mem_3_ar_bits_addr,
-                 top->mem_3_ar_bits_id,
-                 top->mem_3_ar_bits_size,
-                 top->mem_3_ar_bits_len,
+  simif_emul_t::slave[3]->tick(top->reset,
+                               top->mem_3_ar_valid,
+                               top->mem_3_ar_bits_addr,
+                               top->mem_3_ar_bits_id,
+                               top->mem_3_ar_bits_size,
+                               top->mem_3_ar_bits_len,
 
-                 top->mem_3_aw_valid,
-                 top->mem_3_aw_bits_addr,
-                 top->mem_3_aw_bits_id,
-                 top->mem_3_aw_bits_size,
-                 top->mem_3_aw_bits_len,
+                               top->mem_3_aw_valid,
+                               top->mem_3_aw_bits_addr,
+                               top->mem_3_aw_bits_id,
+                               top->mem_3_aw_bits_size,
+                               top->mem_3_aw_bits_len,
 
-                 top->mem_3_w_valid,
-                 top->mem_3_w_bits_strb,
+                               top->mem_3_w_valid,
+                               top->mem_3_w_bits_strb,
 #if MEM_DATA_BITS > 64
-                 top->mem_3_w_bits_data,
+                               top->mem_3_w_bits_data,
 #else
-                 &top->mem_3_w_bits_data,
+                               &top->mem_3_w_bits_data,
 #endif
-                 top->mem_3_w_bits_last,
+                               top->mem_3_w_bits_last,
 
-                 top->mem_3_r_ready,
-                 top->mem_3_b_ready);
+                               top->mem_3_r_ready,
+                               top->mem_3_b_ready);
 #endif // MEM_HAS_CHANNEL3
 
   top->clock = 1;

--- a/sim/midas/src/main/cc/emul/verilator-harness.cc
+++ b/sim/midas/src/main/cc/emul/verilator-harness.cc
@@ -20,7 +20,7 @@ void tick() {
 
   // ASSUMPTION: All models have *no* combinational paths through I/O
   // Step 1: Clock lo -> propagate signals between DUT and software models
-  top->ctrl_aw_valid = simif_emul_t::simif_emul_t::master->aw_valid();
+  top->ctrl_aw_valid = simif_emul_t::master->aw_valid();
   top->ctrl_aw_bits_id = simif_emul_t::master->aw_id();
   top->ctrl_aw_bits_addr = simif_emul_t::master->aw_addr();
   top->ctrl_aw_bits_size = simif_emul_t::master->aw_size();

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -75,7 +75,7 @@ simif_emul_t::simif_emul_t() {
   }
 }
 
-simif_emul_t::~simif_emul_t() { };
+simif_emul_t::~simif_emul_t(){};
 
 void simif_emul_t::host_init(int argc, char **argv) {
   // Parse args

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -16,10 +16,6 @@
 
 uint64_t main_time = 0;
 
-mmio_t *simif_emul_t::master = nullptr;
-mmio_t *simif_emul_t::dma = nullptr;
-mm_t *simif_emul_t::slave[MEM_NUM_CHANNELS] = {nullptr};
-
 #ifdef VCS
 context_t *host;
 context_t target;
@@ -77,20 +73,9 @@ simif_emul_t::simif_emul_t() {
     to_host_streams.push_back(
         StreamToCPU(params, mmio_read_func, pcis_read_func));
   }
-
-  assert(master == nullptr);
-  assert(dma == nullptr);
-  master = new mmio_t(CTRL_BEAT_BYTES);
-  dma = new mmio_t(DMA_BEAT_BYTES);
 }
 
-simif_emul_t::~simif_emul_t() {
-  delete master;
-  delete dma;
-  for (int i = 0; i < MEM_NUM_CHANNELS; i++) {
-    delete slave[i];
-  }
-}
+simif_emul_t::~simif_emul_t() { };
 
 void simif_emul_t::host_init(int argc, char **argv) {
   // Parse args

--- a/sim/midas/src/main/cc/simif_emul.h
+++ b/sim/midas/src/main/cc/simif_emul.h
@@ -34,17 +34,20 @@ public:
   /**
    * @brief Pointers to inter-context (i.e., between VCS/verilator and driver)
    * AXI4 transaction channels
+   *
+   * These have external linkage to enable VCS to easily access them.
    */
-  static mmio_t *master;
-  static mmio_t *dma;
+  inline static mmio_t *master = new mmio_t(CTRL_BEAT_BYTES);
+  inline static mmio_t *dma = new mmio_t(DMA_BEAT_BYTES);
   /**
    * @brief Host DRAM models shared across the RTL simulator and driver
    * contexts.
    *
    * The driver only needs access to these to implement a faster form of
-   * loadmem.
+   * loadmem, which instead of using mmio (~10 cycles per MMIO transaction),
+   * writes directly into the backing memory (0 cycles). See simif_emul_t::load_mems.
    */
-  static mm_t *slave[MEM_NUM_CHANNELS];
+  inline static mm_t* slave[MEM_NUM_CHANNELS] = {nullptr};
 
 private:
   // The maximum number of cycles the RTL simulator can advance before

--- a/sim/midas/src/main/cc/simif_emul.h
+++ b/sim/midas/src/main/cc/simif_emul.h
@@ -45,9 +45,10 @@ public:
    *
    * The driver only needs access to these to implement a faster form of
    * loadmem, which instead of using mmio (~10 cycles per MMIO transaction),
-   * writes directly into the backing memory (0 cycles). See simif_emul_t::load_mems.
+   * writes directly into the backing memory (0 cycles). See
+   * simif_emul_t::load_mems.
    */
-  inline static mm_t* slave[MEM_NUM_CHANNELS] = {nullptr};
+  inline static mm_t *slave[MEM_NUM_CHANNELS] = {nullptr};
 
 private:
   // The maximum number of cycles the RTL simulator can advance before

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -176,7 +176,7 @@ $(PLATFORM): $($(PLATFORM))
 driver: $(PLATFORM)
 
 $(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
-	-std=c++11 -I$(platforms_dir)/f1/aws-fpga/sdk/userspace/include
+	-I$(platforms_dir)/f1/aws-fpga/sdk/userspace/include
 # We will copy shared libs into same directory as driver on runhost, so add $ORIGIN to rpath
 $(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' -L /usr/local/lib64 -lfpga_mgmt
 
@@ -189,7 +189,7 @@ $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	TOP_DIR=$(chipyard_dir)
 
 $(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
-	-std=c++14 -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
+	-idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
 $(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
 	-L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil
 

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -150,7 +150,10 @@ vcs = $(GENERATED_DIR)/$(DESIGN)
 vcs_debug = $(GENERATED_DIR)/$(DESIGN)-debug
 
 $(vcs) $(vcs_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VCS_CXXOPTS) -I$(VCS_HOME)/include -D RTLSIM
-$(vcs) $(vcs_debug): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
+# VCS can mangle the ordering of libraries and object files at link time such
+# that some valid dependencies are pruned when --as-needed is set.
+# Conservatively set --no-as-needed in case --as-needed is defined in LDFLAGS.
+$(vcs) $(vcs_debug): export LDFLAGS := $(LDFLAGS) -Wl,--no-as-needed $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
 
 $(vcs): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
 	$(MAKE) -C $(simif_dir) vcs PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -177,7 +177,6 @@ driver: $(PLATFORM)
 
 $(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
 	-std=c++11 -I$(platforms_dir)/f1/aws-fpga/sdk/userspace/include
-# Statically link libfesvr to make it easier to distribute drivers to f1 instances
 # We will copy shared libs into same directory as driver on runhost, so add $ORIGIN to rpath
 $(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' -L /usr/local/lib64 -lfpga_mgmt
 
@@ -191,7 +190,6 @@ $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 
 $(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
 	-std=c++14 -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
-# Statically link libfesvr to make it easier to distribute drivers to f1 instances
 $(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
 	-L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil
 

--- a/sim/target-agnostic.mk
+++ b/sim/target-agnostic.mk
@@ -39,18 +39,15 @@ PLATFORM ?=
 DRIVER_CC ?=
 DRIVER_H ?=
 
+# Target-specific CXX and LD flags for compiling the driver and meta-simulators
+# These should be platform independent should be governed by the target-specific makefrag
+TARGET_CXX_FLAGS ?=
+TARGET_LD_FLAGS ?=
+
+# END MAKEFRAG INTERFACE
+
 # Defined for each platform
 platforms_dir := $(abspath $(firesim_base_dir)/../platforms)
-vitis_CXX_FLAGS ?= -std=c++14 -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
-vitis_LD_FLAGS ?= -L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil
-f1_CXX_FLAGS ?= -std=c++11 -I$(platforms_dir)/f1/aws-fpga/sdk/userspace/include
-f1_LD_FLAGS ?=
-
-# Target-specific CXX and LD flags for compiling the driver and meta-simulators
-TARGET_CXX_FLAGS ?=
-override TARGET_CXX_FLAGS += $($(PLATFORM)_CXX_FLAGS)
-TARGET_LD_FLAGS ?=
-override TARGET_LD_FLAGS += $($(PLATFORM)_LD_FLAGS)
 
 simif_dir = $(firesim_base_dir)/midas/src/main/cc
 midas_h  = $(shell find $(simif_dir) -name "*.h")
@@ -178,7 +175,8 @@ $(PLATFORM): $($(PLATFORM))
 .PHONY: driver
 driver: $(PLATFORM)
 
-$(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS)
+$(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
+	-std=c++11 -I$(platforms_dir)/f1/aws-fpga/sdk/userspace/include
 # Statically link libfesvr to make it easier to distribute drivers to f1 instances
 # We will copy shared libs into same directory as driver on runhost, so add $ORIGIN to rpath
 $(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' -L /usr/local/lib64 -lfpga_mgmt
@@ -191,9 +189,11 @@ $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	GEN_DIR=$(OUTPUT_DIR)/build OUT_DIR=$(OUTPUT_DIR) DRIVER="$(DRIVER_CC)" \
 	TOP_DIR=$(chipyard_dir)
 
-$(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS)
+$(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
+	-std=c++14 -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
 # Statically link libfesvr to make it easier to distribute drivers to f1 instances
-$(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
+$(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
+	-L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil
 
 
 # Compile Driver


### PR DESCRIPTION
This resolves three separate issues make VCS metasimulators unusable. We really need CI for this... 

1) 5e445b6: prevents driver-specific LD/CXX args from leaking into the metasimulator builds, and don't play nice with VCS in general

2) a8226d9: for some reason under VCS calling get on this pointer and dynamically casting it to mmio_t produces a pointer that no longer points the originating raw pointer. This doesn't seem like "right" fix i just put it here to start a conversation. 

3) 6679cdd: LDFLAGS brought it by conda, set `--as-needed` by default. The main issue is that VCS mangles the the order of objects and libraries such that libraries that are needed end up preceeding the objects that refer to them. I'm not sure how to fix the VCS invocation so i instead set `--no-as-needed`. 

The linkage of `mmio_t` `mm_t` instances between the driver context and the vcs/verilator context is a recurring problem. These are both global and `unique_ptr`s -- which seems like a gross misuse of `unique_ptr`. In SiFive's fork, i've switched these to be raw pointers because i was seeing instances of the runtime double-freeing the underlying data structure. 

I don't really see an easy way, short of re-engineeering how metasimulation is implemented (which is on the long list of things to do), to avoid using globals to share references to `mmio_t` and `mm_t`s. So it seems to me that either switching them to being `shared_ptr`s or raw pointers freed when the driver is torn down are the two best options. I'm open to alternatives. 

#### Related PRs / Issues

None

<!-- List any related issues here -->

#### UI / API Impact

None

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

N/C

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
