### PR TITLE
Resolve some common spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ FIRRTL deduplication interaction.
 * Fix VCS-related breakages in MIDASExamples, SynthUnittests #725
 * Fix breakages related to new FIRRTL 1.4 DedupModules by limiting how many times it runs (#738, see #766)
 * Replace DualQueue in the DRAM memory model scheduler with RRArbiter+Queue to prevent write starvation (#753)
-* A bug that broke tracerV when using heterogenous mixes of tiles #776 
+* A bug that broke tracerV when using heterogeneous mixes of tiles #776
 
 ### Removed
 * Coremark and SPEC workloads moved to Chipyard
@@ -492,7 +492,7 @@ A more detailed account of everything included is included in the dev->master PR
     * Resolves #56 
 * PR #193. Fedora networking now works in FireSim 
     * Address assignment fixed (gets assigned IP addresses in slot-order on firesim)
-* PR #204. Fix support for heterogenous rootfs's - each job can have its own rootfs, or no rootfs at all
+* PR #204. Fix support for heterogeneous rootfs's - each job can have its own rootfs, or no rootfs at all
 
 ### Deprecated
 

--- a/deploy/runtools/utils.py
+++ b/deploy/runtools/utils.py
@@ -28,7 +28,7 @@ def get_local_shared_libraries(elf: str) -> List[Tuple[str, str]]:
          * known members of glibc.  These could be copyable but
            glibc is very coupled to the kernel version and following the pattern
            of the conda packages we build from, we will not copy glibc around.
-           We compile against centos7 glibc and given the backwards compatability of glibc
+           We compile against centos7 glibc and given the backwards compatibility of glibc
            should be able to copy everything else to most other hosts
            and they will work from a DSO linker/loader perspective (i.e.
            if you're building a driver for AWS, it doesn't magically work

--- a/platforms/vitis/cl_firesim/Makefile
+++ b/platforms/vitis/cl_firesim/Makefile
@@ -142,7 +142,7 @@ $(SIM_RUN_DIR)/emconfig.json:
 	emconfigutil --platform $(DEVICE) --od $(SIM_RUN_DIR)
 
 # Populate the run directory. Vitis wants certain files to reside in the same
-# directory as the application binary, keep things seperated by building up a
+# directory as the application binary, keep things separated by building up a
 # fresh location that can be cleanly removed.
 delivered_sim_inputs = $(addprefix $(SIM_RUN_DIR)/, $(driver_bin) $(runtime_conf))
 $(SIM_RUN_DIR)/%: $(DRIVER_DIR)/%

--- a/sim/midas/README.md
+++ b/sim/midas/README.md
@@ -30,7 +30,7 @@ but other resource-reducing optimizations are under development.
 ### 2. Different Inputs and Invocation Model (FIRRTL Stage).
 
 Golden Gate is not invoked in the same process as the target generator.
-instead it's invoked as a seperate process and provided with three inputs:
+instead it's invoked as a separate process and provided with three inputs:
 1) FIRRTL for the target-design
 2) Associated FIRRTL annotations for that design
 3) A compiler parameterization (derived from Rocket Chip's Config system).

--- a/sim/midas/src/main/cc/rtlsim/ml-verilator-conf.vlt
+++ b/sim/midas/src/main/cc/rtlsim/ml-verilator-conf.vlt
@@ -1,5 +1,5 @@
 // HACK: Disable MULTIDRIVEN linting, since verilator cannot determine if two
 // syntactically different clocks are aliases of one another if they are
-// driven by seperate ports.
+// driven by separate ports.
 `verilator_config
 lint_off -rule MULTIDRIVEN

--- a/sim/midas/src/main/scala/midas/passes/HoistStopAndPrintfEnables.scala
+++ b/sim/midas/src/main/scala/midas/passes/HoistStopAndPrintfEnables.scala
@@ -10,7 +10,7 @@ import firrtl.ir._
 import firrtl.options.Dependency
 
 /**
-  * Pushes enable expressions into seperate nodes that can be consistently
+  * Pushes enable expressions into separate nodes that can be consistently
   * optimized across by CSE. This ensures that associated pairs of stops and
   * printfs will have references to a common enable node, which allows
   * AssertionSynthesis to correctly group and synthesize them.

--- a/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
+++ b/sim/midas/src/main/scala/midas/stage/GoldenGateCompilerPhase.scala
@@ -69,7 +69,7 @@ class GoldenGateCompilerPhase extends Phase {
     val loweredSimulator = hostLoweringCompiler.execute(simulator)
 
     // Workaround under-constrained transform dependencies by forcing the
-    // emitter to run last in a seperate compiler.
+    // emitter to run last in a separate compiler.
     val emitter = new Compiler(
         Seq(Dependency(midas.passes.WriteXDCFile), Dependency[firrtl.SystemVerilogEmitter]),
         Forms.LowForm)

--- a/sim/midas/src/main/scala/midas/widgets/HostPort.scala
+++ b/sim/midas/src/main/scala/midas/widgets/HostPort.scala
@@ -84,7 +84,7 @@ class HostPortIO[+T <: Data](private val targetPortProto: T) extends Record with
             leafTargets
           )
         } else {
-        // Bridge is the source; it asserts target-valid and recieves target-backpressure
+        // Bridge is the source; it asserts target-valid and receives target-backpressure
           FAMEChannelConnectionAnnotation.sink(
             fwdChName,
             DecoupledForwardChannel.sink(validTarget, readyTarget),


### PR DESCRIPTION
SiFive's code linting has started telling us how to English. Seemed easy enough to backport the fixes. Good thing it can't grammar (see: me). 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues
None
<!-- List any related issues here -->

#### UI / API Impact
None
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
 N/A
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
