### PR TITLE
Metasimulation: remove dependency on fesvr for ucontext

### DIFF
--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -66,8 +66,8 @@ override CXXFLAGS += -std=c++17 -include $(design_h)
 # Models of FPGA primitives that are used in host-level sim, but not in FPGATop
 sim_fpga_resource_models := $(v_dir)/BUFGCE.v
 
-emul_files := simif simif_emul emul/mmio
-emul_h     := $(driver_h) $(bridge_h)  $( $(addprefix $(midas_dir)/, $(addsuffix .h, $(emul_files) emul/mmio)))
+emul_files := simif simif_emul emul/mmio emul/context
+emul_h     := $(driver_h) $(bridge_h) $(addprefix $(midas_dir)/, $(addsuffix .h, $(emul_files)))
 # This includes c sources and static libraries
 emul_cc    := $(DRIVER) $(bridge_cc) $(addprefix $(midas_dir)/, $(addsuffix .cc, $(emul_files))) $(lib)
 emul_v     := $(design_vh) $(design_v) $(sim_fpga_resource_models)

--- a/sim/midas/src/main/cc/emul/context.cc
+++ b/sim/midas/src/main/cc/emul/context.cc
@@ -50,8 +50,8 @@ void context_t::init(void (*f)(void*), void* a)
 #ifdef USE_UCONTEXT
   getcontext(context.get());
   context->uc_link = creator->context.get();
-  // Note this is 1024x larger than what is found upstream in spike
-  context->uc_stack.ss_size = 64* 1024 * 1024;
+  // Note this is larger than what is upstream in spike to support using VCS as a child context
+  context->uc_stack.ss_size = 64 * 1024 * 1024;
   context->uc_stack.ss_sp = new void*[context->uc_stack.ss_size/sizeof(void*)];
 #ifndef GLIBC_64BIT_PTR_BUG
   makecontext(context.get(), (void(*)(void))&context_t::wrapper, 1, this);

--- a/sim/midas/src/main/cc/emul/context.cc
+++ b/sim/midas/src/main/cc/emul/context.cc
@@ -1,0 +1,118 @@
+// clang-format off
+#include "context.h"
+#include <assert.h>
+#include <sched.h>
+#include <stdlib.h>
+
+static __thread context_t* cur;
+
+context_t::context_t()
+  : creator(NULL), func(NULL), arg(NULL),
+#ifndef USE_UCONTEXT
+    mutex(PTHREAD_MUTEX_INITIALIZER),
+    cond(PTHREAD_COND_INITIALIZER), flag(0)
+#else
+    context(new ucontext_t)
+#endif
+{
+}
+
+#ifdef USE_UCONTEXT
+#ifndef GLIBC_64BIT_PTR_BUG
+void context_t::wrapper(context_t* ctx)
+{
+#else
+void context_t::wrapper(unsigned int hi, unsigned int lo)
+{
+  context_t* ctx = reinterpret_cast<context_t*>(static_cast<unsigned long>(lo) | (static_cast<unsigned long>(hi) << 32));
+#endif
+  ctx->creator->switch_to();
+  ctx->func(ctx->arg);
+}
+#else
+void* context_t::wrapper(void* a)
+{
+  context_t* ctx = static_cast<context_t*>(a);
+  cur = ctx;
+  ctx->creator->switch_to();
+
+  ctx->func(ctx->arg);
+  return NULL;
+}
+#endif
+
+void context_t::init(void (*f)(void*), void* a)
+{
+  func = f;
+  arg = a;
+  creator = current();
+
+#ifdef USE_UCONTEXT
+  getcontext(context.get());
+  context->uc_link = creator->context.get();
+  // Note this is 1024x larger than what is found upstream in spike
+  context->uc_stack.ss_size = 64* 1024 * 1024;
+  context->uc_stack.ss_sp = new void*[context->uc_stack.ss_size/sizeof(void*)];
+#ifndef GLIBC_64BIT_PTR_BUG
+  makecontext(context.get(), (void(*)(void))&context_t::wrapper, 1, this);
+#else
+  unsigned int hi(reinterpret_cast<unsigned long>(this) >> 32);
+  unsigned int lo(reinterpret_cast<unsigned long>(this));
+  makecontext(context.get(), (void(*)(void))&context_t::wrapper, 2, hi, lo);
+#endif
+  switch_to();
+#else
+  assert(flag == 0);
+
+  pthread_mutex_lock(&creator->mutex);
+  creator->flag = 0;
+  if (pthread_create(&thread, NULL, &context_t::wrapper, this) != 0)
+    abort();
+  pthread_detach(thread);
+  while (!creator->flag)
+    pthread_cond_wait(&creator->cond, &creator->mutex);
+  pthread_mutex_unlock(&creator->mutex);
+#endif
+}
+
+context_t::~context_t()
+{
+  assert(this != cur);
+}
+
+void context_t::switch_to()
+{
+  assert(this != cur);
+#ifdef USE_UCONTEXT
+  context_t* prev = cur;
+  cur = this;
+  if (swapcontext(prev->context.get(), context.get()) != 0)
+    abort();
+#else
+  cur->flag = 0;
+  this->flag = 1;
+  pthread_mutex_lock(&this->mutex);
+  pthread_cond_signal(&this->cond);
+  pthread_mutex_unlock(&this->mutex);
+  pthread_mutex_lock(&cur->mutex);
+  while (!cur->flag)
+    pthread_cond_wait(&cur->cond, &cur->mutex);
+  pthread_mutex_unlock(&cur->mutex);
+#endif
+}
+
+context_t* context_t::current()
+{
+  if (cur == NULL)
+  {
+    cur = new context_t;
+#ifdef USE_UCONTEXT
+    getcontext(cur->context.get());
+#else
+    cur->thread = pthread_self();
+    cur->flag = 1;
+#endif
+  }
+  return cur;
+}
+// clang-format on

--- a/sim/midas/src/main/cc/emul/context.cc
+++ b/sim/midas/src/main/cc/emul/context.cc
@@ -50,8 +50,9 @@ void context_t::init(void (*f)(void*), void* a)
 #ifdef USE_UCONTEXT
   getcontext(context.get());
   context->uc_link = creator->context.get();
-  // Note this is larger than what is upstream in spike to support using VCS as a child context
-  context->uc_stack.ss_size = 64 * 1024 * 1024;
+  // Note this is larger than what was historically upstream in spike to support using
+  // VCS as a child context. 8 MiB was chosen as it is a typical linux max stack size. 
+  context->uc_stack.ss_size = 8 * 1024 * 1024;
   context->uc_stack.ss_sp = new void*[context->uc_stack.ss_size/sizeof(void*)];
 #ifndef GLIBC_64BIT_PTR_BUG
   makecontext(context.get(), (void(*)(void))&context_t::wrapper, 1, this);

--- a/sim/midas/src/main/cc/emul/context.h
+++ b/sim/midas/src/main/cc/emul/context.h
@@ -27,7 +27,7 @@ static_assert (sizeof(void*)         == 8, "ptr size doesn't match expected 64bi
 
 #endif
 
-class context_t
+class context_t final
 {
  public:
   context_t();

--- a/sim/midas/src/main/cc/emul/context.h
+++ b/sim/midas/src/main/cc/emul/context.h
@@ -1,48 +1,48 @@
 #ifndef _EMUL_CONTEXT_H
 #define _EMUL_CONTEXT_H
-// clang-format off
 
 // This was copied from riscv-fesvr, which is now hosted in spike.
-// Disable formatting to minimize the diff
 
 // A replacement for ucontext.h, which is sadly deprecated.
 
 #include <pthread.h>
 
 #if defined(__GLIBC__)
-# undef USE_UCONTEXT
-# define USE_UCONTEXT
-# include <ucontext.h>
-# include <memory>
+#undef USE_UCONTEXT
+#define USE_UCONTEXT
 #include <limits.h>
+#include <memory>
+#include <ucontext.h>
 
 #if (ULONG_MAX > UINT_MAX) // 64-bit systems only
-#if (100*GLIB_MAJOR_VERSION+GLIB_MINOR_VERSION < 208)
+#if (100 * GLIB_MAJOR_VERSION + GLIB_MINOR_VERSION < 208)
 #define GLIBC_64BIT_PTR_BUG
-static_assert (sizeof(unsigned int)  == 4, "uint size doesn't match expected 32bit");
-static_assert (sizeof(unsigned long) == 8, "ulong size doesn't match expected 64bit");
-static_assert (sizeof(void*)         == 8, "ptr size doesn't match expected 64bit");
+static_assert(sizeof(unsigned int) == 4,
+              "uint size doesn't match expected 32bit");
+static_assert(sizeof(unsigned long) == 8,
+              "ulong size doesn't match expected 64bit");
+static_assert(sizeof(void *) == 8, "ptr size doesn't match expected 64bit");
 #endif
 #endif /* ULONG_MAX > UINT_MAX */
 
 #endif
 
-class context_t final
-{
- public:
+class context_t final {
+public:
   context_t();
   ~context_t();
-  void init(void (*func)(void*), void* arg);
+  void init(void (*func)(void *), void *arg);
   void switch_to();
-  static context_t* current();
- private:
-  context_t* creator;
-  void (*func)(void*);
-  void* arg;
+  static context_t *current();
+
+private:
+  context_t *creator;
+  void (*func)(void *);
+  void *arg;
 #ifdef USE_UCONTEXT
   std::unique_ptr<ucontext_t> context;
 #ifndef GLIBC_64BIT_PTR_BUG
-  static void wrapper(context_t*);
+  static void wrapper(context_t *);
 #else
   static void wrapper(unsigned int, unsigned int);
 #endif
@@ -51,9 +51,8 @@ class context_t final
   pthread_mutex_t mutex;
   pthread_cond_t cond;
   volatile int flag;
-  static void* wrapper(void*);
+  static void *wrapper(void *);
 #endif
 };
 
-// clang-format on
 #endif

--- a/sim/midas/src/main/cc/emul/context.h
+++ b/sim/midas/src/main/cc/emul/context.h
@@ -1,0 +1,59 @@
+#ifndef _EMUL_CONTEXT_H
+#define _EMUL_CONTEXT_H
+// clang-format off
+
+// This was copied from riscv-fesvr, which is now hosted in spike.
+// Disable formatting to minimize the diff
+
+// A replacement for ucontext.h, which is sadly deprecated.
+
+#include <pthread.h>
+
+#if defined(__GLIBC__)
+# undef USE_UCONTEXT
+# define USE_UCONTEXT
+# include <ucontext.h>
+# include <memory>
+#include <limits.h>
+
+#if (ULONG_MAX > UINT_MAX) // 64-bit systems only
+#if (100*GLIB_MAJOR_VERSION+GLIB_MINOR_VERSION < 208)
+#define GLIBC_64BIT_PTR_BUG
+static_assert (sizeof(unsigned int)  == 4, "uint size doesn't match expected 32bit");
+static_assert (sizeof(unsigned long) == 8, "ulong size doesn't match expected 64bit");
+static_assert (sizeof(void*)         == 8, "ptr size doesn't match expected 64bit");
+#endif
+#endif /* ULONG_MAX > UINT_MAX */
+
+#endif
+
+class context_t
+{
+ public:
+  context_t();
+  ~context_t();
+  void init(void (*func)(void*), void* arg);
+  void switch_to();
+  static context_t* current();
+ private:
+  context_t* creator;
+  void (*func)(void*);
+  void* arg;
+#ifdef USE_UCONTEXT
+  std::unique_ptr<ucontext_t> context;
+#ifndef GLIBC_64BIT_PTR_BUG
+  static void wrapper(context_t*);
+#else
+  static void wrapper(unsigned int, unsigned int);
+#endif
+#else
+  pthread_t thread;
+  pthread_mutex_t mutex;
+  pthread_cond_t cond;
+  volatile int flag;
+  static void* wrapper(void*);
+#endif
+};
+
+// clang-format on
+#endif

--- a/sim/midas/src/main/cc/emul/verilator-harness.cc
+++ b/sim/midas/src/main/cc/emul/verilator-harness.cc
@@ -13,8 +13,6 @@ extern VerilatedVcdC *tfp;
 #endif // VM_TRACE
 
 void tick() {
-  // The driver ucontext is initialized before spawning the verilator
-  // context, so these pointers should be initialized.
   assert(simif_emul_t::dma != nullptr);
   assert(simif_emul_t::master != nullptr);
 

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -3,7 +3,7 @@
 #include "simif_emul.h"
 #ifdef VCS
 #include "emul/vcs_main.h"
-#include <fesvr/context.h>
+#include <emul/context.h>
 #else
 #include <verilated.h>
 #if VM_TRACE

--- a/sim/src/main/makefrag/fasedtests/Makefrag
+++ b/sim/src/main/makefrag/fasedtests/Makefrag
@@ -52,8 +52,7 @@ $(FIRRTL_FILE) $(ANNO_FILE): $(chisel_srcs) $(FIRRTL_JAR) $(SCALA_BUILDTOOL_DEPS
 driver_dir = $(firesim_base_dir)/src/main/cc
 DRIVER_H = $(shell find $(driver_dir) -name "*.h")
 DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, fasedtests/* firesim/systematic_scheduler))) \
-		$(driver_dir)/midasexamples/simif_peek_poke.cc \
-		$(RISCV)/lib/libfesvr.a
+		$(driver_dir)/midasexamples/simif_peek_poke.cc
 
 TARGET_CXX_FLAGS := -g -O2 -I$(driver_dir) -I$(driver_dir)/fasedtests -I$(RISCV)/include
 TARGET_LD_FLAGS :=

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -60,8 +60,7 @@ DRIVER_H = $(shell find $(driver_dir) -name "*.h")
 DRIVER_CC := \
 		$(driver_dir)/midasexamples/simif_peek_poke.cc \
 		$(driver_dir)/midasexamples/Driver.cc \
-		$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))  \
-		$(RISCV)/lib/libfesvr.a
+		$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))
 
 TARGET_CXX_FLAGS := -DDESIGNDRIVERCLASS=$(DESIGN)_t -DDESIGNNAME_$(DESIGN) -I$(driver_dir) -I$(RISCV)/include -I$(driver_dir)/midasexamples -g
 TARGET_LD_FLAGS :=


### PR DESCRIPTION
This is part 1 of simplifying FireSim's dependencies on external libraries for metasimulation. Metasimulation support for VCS has a dependence on FESVR for setting up a coroutine for VCS execution. We lazily brought that in with the RISC-V toolchain. 

Instead of trying to make this dependency on spike/fesvr more explicit, here i copy the two source files we care about in tree as we have previously discussed. 

----

As part of removing dramsim2, i discovered that the stack that was being allocated (in the heap) for the VCS context was only 64K. I suspect modern versions of VCS need a larger stack: the segfaults i was seeing previously were due to VCS's stack overflowing into previously allocated structures on the heap.

In the long run, we're going to switch to DPI and remove the threading here. For now we need to make this less dangerous:
1) Just allocate much larger stack dynamically (as i have done initially)
2) Allocate a larger stack statically; somewhere else with less risk of overflow / or more obvious error. 
3) Just use the pthreads implementation of fesvr/context. I'm not sure we really need the light weight context switching ucontext gives us. 

The main issue is i don't know how much stack VCS needs. Suggestions? 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

#1177 
<!-- List any related issues here -->

#### UI / API Impact

None
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

N/C
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
