### PR TITLE
Added debug flags to CI

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -34,9 +34,10 @@ Debugging Failures
 When a failure occurs on the manager instance the CI will stop or terminate the instance (terminate if your instance is using the spot market).
 Currently, the only way to access any running instance that is created from the CI is to do the following:
 
-1. Request the CI PEM file needed to SSH into the CI instances (ask the FireSim developers)
-2. Obtain the public IP address from the "Launch AWS instance used for the FireSim manager (instance info found here)" (which runs the `launch-manager-instance.py` script) step in the `setup-self-hosted-manager` job in the CI.
-3. SSH into the instance and do any testing required.
+1. In the PR, apply the `ci:debug` flag to prevent the CI instance from being terminated
+2. Request the CI PEM file needed to SSH into the CI instances (ask the FireSim developers)
+3. Obtain the public IP address from the "Launch AWS instance used for the FireSim manager (instance info found here)" (which runs the `launch-manager-instance.py` script) step in the `setup-self-hosted-manager` job in the CI.
+4. SSH into the instance and do any testing required.
 
 If the instance is stopped, then you must request a AWS IAM user account from the FireSim developers to access the EC2 console and restart the instance.
 

--- a/.github/scripts/setup-manager-self-hosted.py
+++ b/.github/scripts/setup-manager-self-hosted.py
@@ -14,17 +14,11 @@ from ci_variables import *
 
 def wait_machine_launch_complete():
     # Catch any exception that occurs so that we can gracefully teardown
-    try:
-        # wait until machine launch is complete
-        with settings(warn_only=True):
-            rc = run("timeout 20m grep -q '.*machine launch script complete.*' <(tail -f /machine-launchstatus)").return_code
-            if rc != 0:
-                run("cat /machine-launchstatus.log")
-                raise Exception("machine-launch-script.sh failed to run")
-    except BaseException as e:
-        traceback.print_exc(file=sys.stdout)
-        terminate_workflow_instances(ci_personal_api_token, ci_workflow_run_id)
-        sys.exit(1)
+     with settings(warn_only=True):
+        rc = run("timeout 20m grep -q '.*machine launch script complete.*' <(tail -f /machine-launchstatus)").return_code
+        if rc != 0:
+            run("cat /machine-launchstatus.log")
+            raise Exception("machine-launch-script.sh failed to run")
 
 def setup_self_hosted_runners():
     """ Installs GHA self-hosted runner machinery on the manager.  """

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -18,7 +18,8 @@ env:
   LANG: "en_US.UTF-8" # required by SBT when it sees boost directories
   LANGUAGE: "en_US:en"
   LC_ALL: "en_US.UTF-8"
-
+  CI_LABEL_DEBUG: ${{ contains(github.event.pull_request.labels.*.name, 'ci:debug') }}
+  
 jobs:
   cancel-prior-workflows:
     name: cancel-prior-workflows
@@ -74,7 +75,7 @@ jobs:
       - name: Setup N Github Actions Runners on AWS instance
         run: ./.github/scripts/setup-manager-self-hosted.py
       - name: Catch potentially orphaned manager
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (env.CI_LABEL_DEBUG != 'true') && (failure() || cancelled()) }}
         uses: ./.github/actions/change-workflow-instance-states
         with:
           new-state: terminate
@@ -92,13 +93,14 @@ jobs:
       - name: Run AWS configure
         run: ./.github/scripts/run-aws-configure.py
       - name: Setup Workflow monitor
+        if: ${{ (env.CI_LABEL_DEBUG != 'true') }}
         uses: ./.github/actions/setup-workflow-monitor
         with:
           max-runtime-hours: 10
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
       - name: Catch potentially orphaned manager
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (env.CI_LABEL_DEBUG != 'true') && (failure() || cancelled()) }}
         uses: ./.github/actions/change-workflow-instance-states
         with:
           new-state: terminate


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

This is just a quick check that occurs in a couple of key portions of the workflow during which instance termination happens. Basically, if the workflow detects the `ci:debug` flag is in the PR body, then it will skip the actions that will terminate the AWS instance. Otherwise, what currently happens, is that CI will immediately terminate the manager instance on failure. If the problem is not recreatable locally, or you need to debug something running in the CI environment, this flag is a useful tool.

The second half of this change is making it so that whenever CI runs the machine launch script on a fresh instance, it isn't torn down within the python script and instead allows the enclosing workflow to decide how this is terminated.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
