### PR TITLE
Allocated memory using MAP_NORESERVE

### DIFF
--- a/sim/midas/src/main/cc/emul/mm.cc
+++ b/sim/midas/src/main/cc/emul/mm.cc
@@ -37,8 +37,12 @@ void mm_t::init(size_t sz, int wsz, int lsz) {
   assert(wsz > 0 && lsz > 0 && (lsz & (lsz - 1)) == 0 && lsz % wsz == 0);
   word_size = wsz;
   line_size = lsz;
-  data = (uint8_t *)mmap(
-      NULL, sz, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  data = (uint8_t *)mmap(NULL,
+                         sz,
+                         PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS | MAP_NORESERVE,
+                         -1,
+                         0);
   if (data == MAP_FAILED) {
     std::perror("[mm_t] mmap for backing storage failed");
     exit(-1);


### PR DESCRIPTION
In `mm.c`, memory mappings are now created using `MAP_NORESERVE`. By default, the call attempts to allocate petabytes, failing eagerly on some systems. With `MAP_NORESERVE`, the oversized allocation succeeds, but a segfault occurs if there is not enough backing physical memory as execution progresses.

#### Related PRs / Issues

N/A

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
