### PR TITLE
Fix FireSim library setup

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -175,23 +175,24 @@ if [ "$IS_LIBRARY" = false ]; then
       echo "firesim-dir: '../../../../'" > $marshal_cfg
     fi
     env_append "export FIRESIM_STANDALONE=1"
-else
-    env_append "source $target_chipyard_dir/env.sh"
-fi
 
-# FireMarshal Setup
-if [ "$IS_LIBRARY" = true ]; then
-    target_chipyard_dir="$RDIR/../.."
-
-    # setup marshal symlink
-    ln -sf ../../../software/firemarshal $RDIR/sw/firesim-software
-else
+    # FireMarshal setup
     target_chipyard_dir="$RDIR/target-design/chipyard"
 
     # setup marshal symlink
     ln -sf ../target-design/chipyard/software/firemarshal $RDIR/sw/firesim-software
 
     env_append "export PATH=$RDIR/sw/firesim-software:\$PATH"
+
+else
+    # FireMarshal setup
+    target_chipyard_dir="$RDIR/../.."
+
+    # setup marshal symlink
+    ln -sf ../../../software/firemarshal $RDIR/sw/firesim-software
+
+    # Source CY env.sh in library-mode
+    env_append "source $target_chipyard_dir/env.sh"
 fi
 
 cd "$RDIR"


### PR DESCRIPTION
FireSim-as-a-library is broken because the `$target_chipyard_dir` in the `build-setup.sh` was not set before it was used (it is used to add `source $cy/env.sh` to the FireSim `env.sh`). This fixes this issue by setting the variable (and initializing the FireMarshal symlink) earlier in the file.

#### Related PRs / Issues

Broken by #1206 

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
