### PR TITLE
Introduced trait to represent the interface to channel ports

### DIFF
--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -73,12 +73,13 @@ case class HostMemChannelParams(
 
 
 // Platform agnostic wrapper of the simulation models for FPGA
-class FPGATop(implicit p: Parameters) extends LazyModule with UnpackedWrapperConfig with HasWidgets {
+class FPGATop(implicit p: Parameters) extends LazyModule with HasWidgets {
   require(p(HostMemNumChannels) <= 4, "Midas-level simulation harnesses support up to 4 channels")
   require(p(CtrlNastiKey).dataBits == 32,
     "Simulation control bus must be 32-bits wide per AXI4-lite specification")
-  lazy val config = p(SimWrapperKey)
   val master = addWidget(new SimulationMaster)
+
+  val bridgeAnnos = p(SimWrapperKey).annotations collect { case ba: BridgeIOAnnotation => ba }
   val bridgeModuleMap: ListMap[BridgeIOAnnotation, BridgeModule[_ <: Record with HasChannels]] = 
     ListMap((bridgeAnnos.map(anno => anno -> addWidget(anno.elaborateWidget))):_*)
 

--- a/sim/midas/src/main/scala/midas/core/SimWrapper.scala
+++ b/sim/midas/src/main/scala/midas/core/SimWrapper.scala
@@ -72,6 +72,23 @@ trait UnpackedWrapperConfig {
   }
 }
 
+
+/**
+ *  Represents the interface of the target to which bridges connect.
+ */
+trait TargetChannelIO {
+  /** Mapping of all output pipe channels. */
+  def wireOutputPortMap: Map[String, ReadyValidIO[Data]]
+  /** Mapping of all input pipe channels. */
+  def wireInputPortMap: Map[String, ReadyValidIO[Data]]
+  /** Mapping of output ready-valid channels. */
+  def rvOutputPortMap: Map[String, TargetRVPortType]
+  /** Mapping of input ready-valid channels. */
+  def rvInputPortMap: Map[String, TargetRVPortType]
+  /** Channel carrying clock tokens to the target. */
+  def clockElement: (String, DecoupledIO[Data])
+}
+
 /**
   * Builds a Record of tokenized interfaces based on a set of [[FAMEChannelConnectionAnnotations]].
   * Chisel-types are reconstructed by looking up a FIRRTL type in [[SimWrapperConfig].leafTypeMap
@@ -87,7 +104,8 @@ trait UnpackedWrapperConfig {
   * name.
   */
 
-abstract class ChannelizedWrapperIO(val config: SimWrapperConfig) extends Record with UnpackedWrapperConfig {
+abstract class ChannelizedWrapperIO(val config: SimWrapperConfig)
+    extends Record with UnpackedWrapperConfig with TargetChannelIO {
 
   def regenTypesFromField(name: String, tpe: firrtl.ir.Type): Seq[(String, ChLeafType)] = tpe match {
     case firrtl.ir.BundleType(fields) => fields.flatMap(f => regenTypesFromField(prefixWith(name, f.name), f.tpe))

--- a/sim/midas/src/main/scala/midas/widgets/Bridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Bridge.scala
@@ -3,7 +3,7 @@
 package midas
 package widgets
 
-import midas.core.{SimWrapperChannels}
+import midas.core.{TargetChannelIO}
 
 import freechips.rocketchip.config.{Parameters, Field}
 
@@ -86,5 +86,5 @@ trait HasChannels {
   def allChannelNames(): Seq[String]
 
   // Called in FPGATop to connect the instantiated bridge to channel ports on the wrapper
-  private[midas] def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, channels: SimWrapperChannels): Unit
+  private[midas] def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, channels: TargetChannelIO): Unit
 }

--- a/sim/midas/src/main/scala/midas/widgets/ChannelizedHostPort.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ChannelizedHostPort.scala
@@ -2,7 +2,7 @@
 
 package midas.widgets
 
-import midas.core.SimWrapperChannels
+import midas.core.{TargetChannelIO}
 
 import midas.passes.fame.{FAMEChannelInfo, FAMEChannelConnectionAnnotation}
 
@@ -131,14 +131,14 @@ trait ChannelizedHostPortIO extends HasChannels { this: Record =>
     }
   }
 
-  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, simWrapper: SimWrapperChannels): Unit = {
+  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, targetIO: TargetChannelIO): Unit = {
     val local2globalName = bridgeAnno.channelMapping.toMap
     for ((_, channel, metadata) <- channels) {
       val localName = reverseElementMap(channel)
       if (metadata.bridgeSunk) {
-        channel <> simWrapper.wireOutputPortMap(local2globalName(localName))
+        channel <> targetIO.wireOutputPortMap(local2globalName(localName))
       } else {
-        simWrapper.wireInputPortMap(local2globalName(localName)) <> channel
+        targetIO.wireInputPortMap(local2globalName(localName)) <> channel
       }
     }
   }

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -2,7 +2,7 @@
 
 package midas.widgets
 
-import midas.core.{SimWrapperChannels, SimUtils}
+import midas.core.{TargetChannelIO, SimUtils}
 import midas.core.SimUtils.{RVChTuple}
 import midas.passes.fame.{FAMEChannelConnectionAnnotation, TargetClockChannel}
 
@@ -145,8 +145,8 @@ class ClockTokenVector(numClocks: Int) extends Bundle with HasChannels with Cloc
   val clocks = new DecoupledIO(Vec(numClocks, Bool()))
 
   def allChannelNames = Seq(clockChannelName)
-  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, simIo: SimWrapperChannels): Unit =
-    simIo.clockElement._2 <> clocks
+  def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, targetIO: TargetChannelIO): Unit =
+    targetIO.clockElement._2 <> clocks
   def generateAnnotations(): Unit = {}
 }
 


### PR DESCRIPTION
`TargetChannelIO` now exposes the minimum required information bridges need to connect up to the `SimWrapper` and the target design.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

N/A

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

N/A

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
