### PR TITLE
Removed the in-memory bridge annotation

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/AssertionSynthesis.scala
+++ b/sim/midas/src/main/scala/midas/passes/AssertionSynthesis.scala
@@ -240,8 +240,9 @@ private[passes] class AssertionSynthesis extends firrtl.Transform {
         val assertMessages = asserts.map(formattedMessages(_))
         val bridgeAnno = BridgeIOAnnotation(
           target = portRT,
-          widget = (p: Parameters) => new AssertBridgeModule(AssertBridgeParameters(assertPortName, resetPortName, assertMessages))(p),
-          channelNames = Seq(resetPortName, assertPortName)
+          channelNames = Seq(resetPortName, assertPortName),
+          widgetClass = classOf[AssertBridgeModule].getName,
+          widgetConstructorKey = AssertBridgeParameters(assertPortName, resetPortName, assertMessages)
         )
         assertAnnos ++= Seq(resetConditionAnno, assertFCCA, resetFCCA, bridgeAnno)
       }

--- a/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
+++ b/sim/midas/src/main/scala/midas/passes/AutoCounterTransform.scala
@@ -218,7 +218,8 @@ class AutoCounterTransform extends Transform with AutoCounterConsts {
         target = topMT.ref(topWiringPrefix),
         // We need to pass the name of the trigger port so each bridge can
         // disambiguate between them and connect to the correct one in simulation mapping
-        widget = (p: Parameters) => new AutoCounterBridgeModule(AutoCounterParameters(eventMetadata, triggerPortName, globalResetName))(p),
+        widgetClass = classOf[AutoCounterBridgeModule].getName,
+        widgetConstructorKey = AutoCounterParameters(eventMetadata, triggerPortName, globalResetName),
         channelNames = (triggerFCCA +: globalResetFCCA +: fccas).map(_.globalName)
       )
       Seq(bridgeAnno, triggerSinkAnno, triggerFCCA, globalResetFCCA, globalResetSink) ++ fccas

--- a/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
+++ b/sim/midas/src/main/scala/midas/passes/PrintSynthesis.scala
@@ -143,7 +143,8 @@ private[passes] class PrintSynthesis extends firrtl.Transform {
       val fccaAnnos = resetFCCA +: printFCCAs
       val bridgeAnno = BridgeIOAnnotation(
         target = ModuleTarget(c.main, c.main).ref(topWiringPrefix.stripSuffix("_")),
-        widget = (p: Parameters) => new PrintBridgeModule(PrintBridgeParameters(resetPortName, portTuples))(p),
+        widgetClass = classOf[PrintBridgeModule].getName,
+        widgetConstructorKey = PrintBridgeParameters(resetPortName, portTuples),
         channelNames = fccaAnnos.map(_.globalName)
       )
       (resetConditionAnno +: bridgeAnno +: fccaAnnos, resetPort, resetPortConn)

--- a/sim/midas/src/main/scala/midas/passes/UpdateBridgeClockInfo.scala
+++ b/sim/midas/src/main/scala/midas/passes/UpdateBridgeClockInfo.scala
@@ -23,7 +23,7 @@ object UpdateBridgeClockInfo extends Transform {
       s"Expected exactly one ChannelClockInfoAnnotation. Got: ${infoMaps.size}")
     val infoMap = infoMaps.head
     val annosx =  state.annotations.map({
-      case a@BridgeIOAnnotation(_,_,None,_,_,_) =>
+      case a : BridgeIOAnnotation if a.clockInfo == None =>
         // There will be some cases where this is left unpopulated, i.e., for the clockBridge
         a.copy(clockInfo = infoMap.get(a.channelMapping.values.head))
       case o => o

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -74,8 +74,8 @@ case class ClockBridgeAnnotation(val target: ModuleTarget, clocks: Seq[RationalC
     BridgeIOAnnotation(
       target.copy(module = target.circuit).ref(port),
       channelMapping.toMap,
-      widget = Some((p: Parameters) => new ClockBridgeModule(ClockParameters(clocks))(p))
-    )
+      widgetClass = classOf[ClockBridgeModule].getName,
+      widgetConstructorKey = Some(ClockParameters(clocks)))
   }
 }
 


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

In-memory bridges were used to simplify the construction of bridges in 3 midas transforms. To simplify bridge annotation representation, this patch removes them and moves all uses over to the `widgetClass`/`widgetConstructorKey` interface. As an added benefit, this ensures that no user can construct bridge annotations that cannot be serialized. In intermediary `.fir` dumps, now bridge parameters show up correctly serialized.


#### Related PRs / Issues

N/A

#### UI / API Impact

User-facing API unchanged. In midas transforms, bridges can no longer be specified through lambdas.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
