### PR TITLE
Materialized bridge FCCAs in BridgeExtraction

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/fame/Annotations.scala
+++ b/sim/midas/src/main/scala/midas/passes/fame/Annotations.scala
@@ -65,19 +65,6 @@ case class FAMEChannelConnectionAnnotation(
 
   def getBridgeModule(): String = sources.getOrElse(sinks.get).head.module
 
-  def moveFromBridge(portName: String): FAMEChannelConnectionAnnotation = {
-    def updateRT(rT: ReferenceTarget): ReferenceTarget = ModuleTarget(rT.circuit, rT.circuit).ref(portName).field(rT.ref)
-
-    require(sources == None || sinks == None, "Bridge-connected channels cannot loopback")
-    val rTs = sources.getOrElse(sinks.get) ++ clock ++ (channelInfo match {
-      case i: DecoupledForwardChannel => Seq(i.readySink.getOrElse(i.readySource.get))
-      case other => Seq()
-    })
-
-    val localRenames = RenameMap(Map((rTs.map(rT => rT -> Seq(updateRT(rT)))):_*))
-    copy(globalName = s"${portName}_${globalName}").update(localRenames).head.asInstanceOf[this.type]
-  }
-
   override def getTargets: Seq[ReferenceTarget] = clock ++: (sources.toSeq.flatten ++ sinks.toSeq.flatten)
 }
 

--- a/sim/midas/src/main/scala/midas/widgets/Bridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Bridge.scala
@@ -63,27 +63,19 @@ trait Bridge[HPType <: Record with HasChannels, WidgetType <: BridgeModule[HPTyp
     annotate(new ChiselAnnotation { def toFirrtl = {
         BridgeAnnotation(
           self.toNamed.toTarget,
-          bridgeIO.allChannelNames,
+          bridgeIO.bridgeChannels,
           widgetClass = widgetClassSymbol.fullName,
           widgetConstructorKey = constructorArg)
       }
     })
-    // Emit annotations to capture channel information
-    bridgeIO.generateAnnotations()
   }
 }
 
 trait HasChannels {
   /**
-    *  Called to emit FCCAs in the target RTL in order to assign the target
-    *  port's fields to channels.
+    * Returns a list of channel descriptors.
     */
-  def generateAnnotations(): Unit
-
-  /**
-    * Returns a list of channel names for which FAMEChannelConnectionAnnotations have been generated
-    */
-  def allChannelNames(): Seq[String]
+  def bridgeChannels(): Seq[BridgeChannel]
 
   // Called in FPGATop to connect the instantiated bridge to channel ports on the wrapper
   private[midas] def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, channels: TargetChannelIO): Unit

--- a/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ClockBridge.scala
@@ -4,7 +4,7 @@ package midas.widgets
 
 import midas.core.{TargetChannelIO, SimUtils}
 import midas.core.SimUtils.{RVChTuple}
-import midas.passes.fame.{FAMEChannelConnectionAnnotation, TargetClockChannel}
+import midas.passes.fame.{FAMEChannelConnectionAnnotation, TargetClockChannel, RTRenamer}
 
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.DensePrefixSum
@@ -12,7 +12,9 @@ import freechips.rocketchip.util.DensePrefixSum
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.{BaseModule, Direction, ChiselAnnotation, annotate}
-import firrtl.annotations.{ModuleTarget, ReferenceTarget}
+
+import firrtl.{RenameMap}
+import firrtl.annotations.{Annotation, ModuleTarget, ReferenceTarget}
 
 /**
   * Defines a generated clock as a rational multiple of some reference clock. The generated
@@ -87,18 +89,14 @@ class RationalClockBridge(val allClocks: Seq[RationalClock]) extends BlackBox wi
   annotate(new ChiselAnnotation { def toFirrtl =
       BridgeAnnotation(
         target = outer.toTarget,
-        channelNames = Seq(clockChannelName),
+        bridgeChannels = Seq(
+          ClockBridgeChannel(
+            name = clockChannelName,
+            sinks = io.clocks.map(_.toTarget),
+            clocks = allClocks,
+            clockMFMRs)),
         widgetClass = classOf[ClockBridgeModule].getName,
         widgetConstructorKey = Some(ClockParameters(allClocks))
-      )
-  })
-  annotate(new ChiselAnnotation { def toFirrtl =
-      FAMEChannelConnectionAnnotation(
-        clockChannelName,
-        channelInfo = TargetClockChannel(allClocks, clockMFMRs),
-        clock = None, // Clock channels do not have a reference clock
-        sinks = Some(io.clocks.map(_.toTarget)),
-        sources = None
       )
   })
 }
@@ -127,9 +125,11 @@ object RationalClockBridge {
 class ClockTokenVector(numClocks: Int) extends Bundle with HasChannels with ClockBridgeConsts {
   val clocks = new DecoupledIO(Vec(numClocks, Bool()))
 
-  def allChannelNames = Seq(clockChannelName)
+  def bridgeChannels = Seq()
+
   def connectChannels2Port(bridgeAnno: BridgeIOAnnotation, targetIO: TargetChannelIO): Unit =
     targetIO.clockElement._2 <> clocks
+
   def generateAnnotations(): Unit = {}
 }
 


### PR DESCRIPTION
This patch moves the materialization of FCCAs connected to bridges to the `BridgeExtraction` stage.
Up to that point, information about channels connected to bridges is carried in the `bridgeChannels` field of the `SerializableBridgeAnnotation`. Bridges with IO towards the target must construct `BridgeChannel` decriptors
for the channels they want materialized instead of eagerly creating FCCAs.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

#1223 
#1224 

#### UI / API Impact

All changes are hidden behind publicly-visible APIs.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
