### PR TITLE
Add XDCAnnotation type hints, end-to-end test, empty arg list support

### DIFF
--- a/sim/midas/src/main/scala/midas/passes/WriteXDCFile.scala
+++ b/sim/midas/src/main/scala/midas/passes/WriteXDCFile.scala
@@ -27,6 +27,11 @@ private[midas] object WriteXDCFile extends Transform with DependencyAPIMigration
       argumentList: Iterable[ReferenceTarget],
       pathToCircuit: Option[String]): Iterable[Iterable[String]] = {
 
+    // Just skip empty argument lists.
+    if (argumentList.isEmpty) {
+      return Seq(Seq())
+    }
+
     // Avoid the complexity of managing duplication of targets that don't
     // explicitly agree on a root module.
     //

--- a/sim/midas/targetutils/src/main/scala/midas/xdc/XDCAnnotation.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/xdc/XDCAnnotation.scala
@@ -70,13 +70,14 @@ case class XDCAnnotation(
     destinationFile: XDCDestinationFile,
     formatString: String,
     argumentList: ReferenceTarget*)
-    extends Annotation with XDCAnnotationConstants
+    extends Annotation with XDCAnnotationConstants with HasSerializationHints
     // This is included until we figure out how to gracefully handle deletion.
     with DontTouchAllTargets {
   def update(renames: RenameMap): Seq[firrtl.annotations.Annotation] = {
     val renamer = new ReferenceTargetRenamer(renames)
     Seq(XDCAnnotation(destinationFile, formatString, argumentList.map(a => renamer.exactRename(a)):_*))
   }
+  def typeHints: Seq[Class[_]] = Seq(classOf[XDCDestinationFile])
 }
 
 /**

--- a/sim/src/main/cc/midasexamples/CustomConstraints.h
+++ b/sim/src/main/cc/midasexamples/CustomConstraints.h
@@ -1,0 +1,10 @@
+// See LICENSE for license details.
+
+#include "ShiftRegister.h"
+
+// This is basically just the shift register but with additional XDC
+// constraints added.
+class CustomConstraints_t : public ShiftRegister_t {
+public:
+  using ShiftRegister_t::ShiftRegister_t;
+};

--- a/sim/src/main/cc/midasexamples/Driver.cc
+++ b/sim/src/main/cc/midasexamples/Driver.cc
@@ -91,6 +91,8 @@
 #include "ResetPulseBridgeTest.h"
 #elif defined DESIGNNAME_TerminationModule
 #include "TerminationModule.h"
+#elif defined DESIGNNAME_CustomConstraints
+#include "CustomConstraints.h"
 #endif
 
 class dut_emul_t :

--- a/sim/src/main/scala/midasexamples/CustomConstraints.scala
+++ b/sim/src/main/scala/midasexamples/CustomConstraints.scala
@@ -1,0 +1,16 @@
+//See LICENSE for license details.
+
+package firesim.midasexamples
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import midas.targetutils.xdc._
+
+class CustomConstraintsDUT extends ShiftRegisterDUT {
+  XDC(XDCFiles.Synthesis, "constrain_synth1")
+  XDC(XDCFiles.Synthesis, "constrain_synth2 [reg {}]", r0)
+  XDC(XDCFiles.Implementation, "constrain_impl1")
+  XDC(XDCFiles.Implementation, "constrain_impl2 [reg {}]", r1)
+}
+
+class CustomConstraints(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new CustomConstraintsDUT)

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -377,6 +377,23 @@ class TerminationF1Test extends TutorialSuite("TerminationModule") {
   1 to 10 foreach {x => runTest(backendSimulator, args = Seq("+termination-bridge-tick-rate=10", s"+seed=${x}"), shouldPass = true)}
 }
 
+class CustomConstraintsF1Test extends TutorialSuite("CustomConstraints") {
+  def readLines(filename: String): List[String] = {
+    val file = new File(genDir, s"/${filename}")
+    Source.fromFile(file).getLines.toList
+  }
+  it should s"generate synthesis XDC file" in {
+    val xdc = readLines("FireSim-generated.synthesis.xdc")
+    xdc should contain("constrain_synth1")
+    atLeast (1, xdc) should fullyMatch regex "constrain_synth2 \\[reg firesim_top/.*/dut/r0\\]".r
+  }
+  it should s"generate implementation XDC file" in {
+    val xdc = readLines("FireSim-generated.implementation.xdc")
+    xdc should contain("constrain_impl1")
+    atLeast (1, xdc) should fullyMatch regex "constrain_impl2 \\[reg WRAPPER_INST/CL/firesim_top/.*/dut/r1]".r
+  }
+}
+
 // Suite Collections
 class ChiselExampleDesigns extends Suites(
   new GCDF1Test,
@@ -388,6 +405,7 @@ class ChiselExampleDesigns extends Suites(
   new RiscSRAMF1Test,
   new AccumulatorF1Test,
   new VerilogAccumulatorF1Test,
+  new CustomConstraintsF1Test,
   // This test is known to fail non-deterministically. See https://github.com/firesim/firesim/issues/1147
   // new TerminationF1Test
 )


### PR DESCRIPTION
This commit does three things:

- Add a `CustomAnnotations` test to the midasexamples test suite which is basically the shift register test with additional uses of the `XDC(...)` Chisel API. The test checks whether the expected files get generated and contain the expected lines.

- Add an early out to `WriteXDCFile.formatArguments` in case the format argument list is empty. This allows the user to specify an XDC constraint that contains no format arguments, which until now would cause an exception in `argumentList.head`. The end-to-end test checks for this.

- Add type hints to the `XDCAnnotation` such that the `XDCDestinationFile` case objects get serialized properly.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->
None

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->
No impact

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->
No impact

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
