### PR TITLE
Bump to a conda-forge verilator 4.226 build that defaults to C++17

### DIFF
--- a/conda-reqs.conda-lock.yml
+++ b/conda-reqs.conda-lock.yml
@@ -5,11 +5,11 @@
 # available, unless you explicitly update the lock file.
 #
 # Install this environment as "YOURENV" with:
-#     conda-lock install -n YOURENV --file conda-requirements-riscv-tools-linux-64.conda-lock.yml
+#     conda-lock install -n YOURENV --file conda-reqs.conda-lock.yml
 # To update a single package to the latest version compatible with the version constraints in the source:
-#     conda-lock lock --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml --update PACKAGE
+#     conda-lock lock --lockfile conda-reqs.conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
-#     conda-lock -f /scratch/buildbot/firesim/conda-requirements-riscv-tools.yaml --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml
+#     conda-lock -f /scratch/buildbot/firesim/conda-requirements-riscv-tools.yaml -f /scratch/biancolin/firesim-check-verilator/conda-reqs.yaml --lockfile conda-reqs.conda-lock.yml
 metadata:
   channels:
   - url: conda-forge
@@ -19,11 +19,12 @@ metadata:
   - url: nodefaults
     used_env_vars: []
   content_hash:
-    linux-64: c3a9fc60e8d92f2a6a9de1c9329425f2561dcb26e445f4148ec0a2cdb94dcf53
+    linux-64: 44ade9efeba533c2a3c1975d535d18a2901fd4ed72ef6daa045dff8ef4864d32
   platforms:
   - linux-64
   sources:
   - /scratch/buildbot/firesim/conda-requirements-riscv-tools.yaml
+  - /scratch/biancolin/firesim-check-verilator/conda-reqs.yaml
 package:
 - category: main
   dependencies: {}
@@ -61,14 +62,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 87c986dab320658abaf3e701406b665c
-    sha256: 26a1a2d9e63440ec3b2a59297d47f7d5b405a3caab61bf93648e1621a46bb05a
+    md5: 41e4e87062433e283696cf384f952ef6
+    sha256: 058355034667e77d15389700f6b2364cc74efce0af63a418eacc1ce252458942
   manager: conda
   name: ca-certificates
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.9.14-ha878542_0.tar.bz2
-  version: 2022.9.14
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.9.24-ha878542_0.tar.bz2
+  version: 2022.9.24
 - category: main
   dependencies: {}
   hash:
@@ -182,14 +183,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: a56386ad31a7322940dd7d03fb3a9979
-    sha256: 8a6a7c6217c79f1afaf0fea71463a5577e2a165a743a04afd45b200d344d6de9
+    md5: 456b5b1d99e7a9654b331bcd82e71042
+    sha256: 3d234013a4e2f70f40068f29b8790e959d5cc97cd4b1c6a0aa5446eec03819b9
   manager: conda
   name: tzdata
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2022c-h191b570_0.tar.bz2
-  version: 2022c
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2022d-h191b570_0.tar.bz2
+  version: 2022d
 - category: main
   dependencies:
     font-ttf-dejavu-sans-mono: ''
@@ -404,17 +405,17 @@ package:
   version: 1.46.2
 - category: main
   dependencies:
-    libgcc-ng: '>=10.3.0'
-    libstdcxx-ng: '>=10.3.0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
   hash:
-    md5: e1b07832504eeba765d648389cc387a9
-    sha256: 0db0e8690f8f7f4543d81e612947962b61518c61036bf7bdb53146f64dfca852
+    md5: 493ac8b2503a949aebe33d99ea0c284f
+    sha256: 2e2b3fadca2aa04244197d645947b91edb73fed1da17b8c5f8b8f1fdc6cd06ac
   manager: conda
   name: expat
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.4.8-h27087fc_0.tar.bz2
-  version: 2.4.8
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.4.9-h27087fc_0.tar.bz2
+  version: 2.4.9
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -440,6 +441,18 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/gengetopt-2.23-h9c3ff4c_0.tar.bz2
   version: '2.23'
+- category: main
+  dependencies:
+    libgcc-ng: '>=12'
+  hash:
+    md5: 17f91dc8bb7a259b02be5bfb2cd2395f
+    sha256: e33f9c58fe6d48e65f3c271fdd39999ad439b0ea03c683ca609e50b7aeda47ee
+  manager: conda
+  name: gettext
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.19.8.1-h27087fc_1009.tar.bz2
+  version: 0.19.8.1
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -590,16 +603,16 @@ package:
   version: 3.4.2
 - category: main
   dependencies:
-    libgcc-ng: '>=7.5.0'
+    libgcc-ng: '>=10.3.0'
   hash:
-    md5: 5c0f338a513a2943c659ae619fca9211
-    sha256: 1ba9d434e982536abbbcd63505276270cb3a62844a0f1b6e52962e70be078abe
+    md5: b62b52da46c39ee2bc3c162ac7f1804d
+    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
   manager: conda
   name: libiconv
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.16-h516909a_0.tar.bz2
-  version: '1.16'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  version: '1.17'
 - category: main
   dependencies:
     libgcc-ng: '>=9.4.0'
@@ -1051,16 +1064,16 @@ package:
   version: 0.2.5
 - category: main
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    libiconv: '>=1.16,<1.17.0a0'
+    libgcc-ng: '>=12'
+    libiconv: '>=1.17,<2.0.0a0'
   hash:
-    md5: af46eaa305af6768321779615ed88ac4
-    sha256: 016719d88e6f84af579606cfd5e8d52b9c31c9ad38c54b92fff5d49044ca5673
+    md5: 9b0ebfb39213d15e60d2c211c9c443b6
+    sha256: 2af344c4c970412bb4f949a2d353a989bdb980e42040263b66cdb0e341ce63e5
   manager: conda
   name: diffutils
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/diffutils-3.8-ha1f6473_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/diffutils-3.8-h1869db9_1.tar.bz2
   version: '3.8'
 - category: main
   dependencies:
@@ -1076,6 +1089,19 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/dtc-1.6.1-h166bdaf_1.tar.bz2
   version: 1.6.1
+- category: main
+  dependencies:
+    gettext: ''
+    libgcc-ng: '>=9.4.0'
+  hash:
+    md5: 8d0b19bcc4a822e154eaf924483c9edb
+    sha256: 377377897759dc0183ad2db9a3c4472d50d81a74b62ad974f32109900d891743
+  manager: conda
+  name: findutils
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/findutils-4.6.0-h7f98852_1001.tar.bz2
+  version: 4.6.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1110,19 +1136,6 @@ package:
   version: 12.1.0
 - category: main
   dependencies:
-    libffi: '>=3.4.2,<3.5.0a0'
-    libgcc-ng: '>=9.4.0'
-  hash:
-    md5: af49250eca8e139378f8ff0ae9e57251
-    sha256: 1bb53c99b4943d210c881aad9158fb0235b348498bad1a7076d1f2bef6671922
-  manager: conda
-  name: gettext
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.19.8.1-h73d1719_1008.tar.bz2
-  version: 0.19.8.1
-- category: main
-  dependencies:
     libopenblas: '>=0.3.21,<1.0a0'
   hash:
     md5: d9b7a8639171f6c6fa0a983edabcfe2b
@@ -1146,6 +1159,20 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   version: 3.1.20191231
+- category: main
+  dependencies:
+    gettext: '>=0.19.8.1,<1.0a0'
+    libgcc-ng: '>=12'
+    libunistring: '>=0,<1.0a0'
+  hash:
+    md5: 7726ff4317aaecba7a4e7c2a16d38b21
+    sha256: 6051ca2b05ff5d08fcc1b5b653d34454dc0a099eec374683fea7ada6033bac62
+  manager: conda
+  name: libidn2
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.3-h166bdaf_0.tar.bz2
+  version: 2.3.3
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1209,14 +1236,14 @@ package:
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.12,<1.3.0a0'
   hash:
-    md5: b085539ca2b54a188848bcfcb970005d
-    sha256: f8b72568b2a8685f465722a929dbaea8ad2e1812fe70a96d1ad71c1bf14f6497
+    md5: c84e9e99fdbaf4afdbf818c38ad5fcec
+    sha256: a9926b65e44c5ec8bebb35c56e3b7327f3e1fffbdaf96b3f603877dc0121da94
   manager: conda
   name: libprotobuf
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.20.1-h6239696_4.tar.bz2
-  version: 3.20.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.21.6-h6239696_1.tar.bz2
+  version: 3.21.6
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1263,7 +1290,7 @@ package:
   dependencies:
     icu: '>=70.1,<71.0a0'
     libgcc-ng: '>=12'
-    libiconv: '>=1.16,<1.17.0a0'
+    libiconv: '>=1.16,<2.0.0a0'
     libzlib: '>=1.2.12,<1.3.0a0'
     xz: '>=5.2.5,<5.3.0a0'
   hash:
@@ -1384,7 +1411,7 @@ package:
 - category: main
   dependencies:
     libgcc-ng: '>=9.3.0'
-    libiconv: '>=1.16,<1.17.0a0'
+    libiconv: '>=1.16,<2.0.0a0'
   hash:
     md5: 33614741eb453005e0c74e027c325508
     sha256: 967aa10d9197b2a9753f21cb9e7d729560d90df41eb2fa2a3e2ffcb66891d98b
@@ -1529,19 +1556,6 @@ package:
   version: '5.39'
 - category: main
   dependencies:
-    gettext: ''
-    libgcc-ng: '>=9.4.0'
-  hash:
-    md5: 8d0b19bcc4a822e154eaf924483c9edb
-    sha256: 377377897759dc0183ad2db9a3c4472d50d81a74b62ad974f32109900d891743
-  manager: conda
-  name: findutils
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/findutils-4.6.0-h7f98852_1001.tar.bz2
-  version: 4.6.0
-- category: main
-  dependencies:
     libgcc-ng: '>=12'
     libpng: '>=1.6.37,<1.7.0a0'
     libzlib: '>=1.2.12,<1.3.0a0'
@@ -1566,6 +1580,23 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.1.0-h9ea6d83_10.tar.bz2
   version: 12.1.0
+- category: main
+  dependencies:
+    libgcc-ng: '>=12'
+    libidn2: '>=2,<3.0a0'
+    libstdcxx-ng: '>=12'
+    libtasn1: '>=4.19.0,<5.0a0'
+    nettle: '>=3.8.1,<3.9.0a0'
+    p11-kit: '>=0.24.1,<0.25.0a0'
+  hash:
+    md5: cbe8e27140d67c3f30e01cfb642a6e7c
+    sha256: 4a47e4558395b98fff4c1c44ad358dade62b350a03b5a784d4bc589d6eb7ac9e
+  manager: conda
+  name: gnutls
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.8-hf3e180e_0.tar.bz2
+  version: 3.7.8
 - category: main
   dependencies:
     gcc_impl_linux-64: 12.1.0 hea43390_16
@@ -1600,7 +1631,7 @@ package:
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
-    libxml2: '>=2.9.14,<2.10.0a0'
+    libxml2: '>=2.9.14,<2.11.0a0'
     libzlib: '>=1.2.12,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     lzo: '>=2.10,<3.0a0'
@@ -1645,51 +1676,22 @@ package:
   version: 14.0.6
 - category: main
   dependencies:
-    libgcc-ng: '>=12'
-    libllvm14: '>=14.0.6,<14.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.12,<1.3.0a0'
-  hash:
-    md5: cdbd49e0ab5c5a6c522acb8271977d4c
-    sha256: 5a359982db6223f0330682b4ac7bd2b6f0206cf566a5e074e3f0609bc5a1f98f
-  manager: conda
-  name: libclang13
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-14.0.6-default_h3a83d3e_0.tar.bz2
-  version: 14.0.6
-- category: main
-  dependencies:
     gettext: '>=0.19.8.1,<1.0a0'
-    libffi: '>=3.4.2,<3.5.0a0'
+    libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
-    libiconv: '>=1.16,<1.17.0a0'
+    libiconv: '>=1.17,<2.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.12,<1.3.0a0'
-    pcre: '>=8.45,<9.0a0'
+    pcre2: '>=10.37,<10.38.0a0'
   hash:
-    md5: ebeadbb5fbc44052eeb6f96a2136e3c2
-    sha256: 2ec01b1fbd21f9ec4a0a723a7dbe0c43db2f7dde88eb95586d63ea7f4e40193f
+    md5: fe768553d0fe619bb9704e3c79c0ee2e
+    sha256: 6ef0ee03ca5b59e3c86992dc5744ab1b45c1d3d130a04d756ca27381e41c1b80
   manager: conda
   name: libglib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.72.1-h2d90d5f_0.tar.bz2
-  version: 2.72.1
-- category: main
-  dependencies:
-    gettext: '>=0.19.8.1,<1.0a0'
-    libgcc-ng: '>=12'
-    libunistring: '>=0,<1.0a0'
-  hash:
-    md5: 7726ff4317aaecba7a4e7c2a16d38b21
-    sha256: 6051ca2b05ff5d08fcc1b5b653d34454dc0a099eec374683fea7ada6033bac62
-  manager: conda
-  name: libidn2
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.3-h166bdaf_0.tar.bz2
-  version: 2.3.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.74.0-h7a41b64_0.tar.bz2
+  version: 2.74.0
 - category: main
   dependencies:
     libblas: 3.9.0 16_linux64_openblas
@@ -1702,6 +1704,22 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_openblas.tar.bz2
   version: 3.9.0
+- category: main
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxml2: '>=2.9.14,<2.10.0a0'
+    libzlib: '>=1.2.12,<1.3.0a0'
+    zstd: '>=1.5.2,<1.6.0a0'
+  hash:
+    md5: aeff58c93ee0420df02eda7d85b5baf8
+    sha256: 7277bb679f36569a428f9768370ea7b5d61561110f3b7d58255ebadc8776ba96
+  manager: conda
+  name: libllvm15
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.1-h503ea73_0.tar.bz2
+  version: 15.0.1
 - category: main
   dependencies:
     jpeg: '>=9e,<10a'
@@ -1724,21 +1742,21 @@ package:
   version: 4.4.0
 - category: main
   dependencies:
-    libgcc-ng: '>=10.3.0'
-    libprotobuf: '>=3.20.0,<3.21.0a0'
-    libstdcxx-ng: '>=10.3.0'
-    libzlib: '>=1.2.11,<1.3.0a0'
+    libgcc-ng: '>=12'
+    libprotobuf: '>=3.21.6,<3.22.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
     ncurses: '>=6.3,<7.0a0'
-    openssl: '>=1.1.1n,<1.1.2a'
+    openssl: '>=1.1.1q,<1.1.2a'
     perl: '>=5.32.1,<5.33.0a0 *_perl5'
   hash:
-    md5: b7d4b8236c1a2e1aa02dc5c887e70f19
-    sha256: ddbcf44eb9dcb8556c1a5f511e2e028dab8545e82ee441a03bb54e52152fdd2a
+    md5: 6214246121a9e89e3d40e2ef16f0ce2c
+    sha256: f40975a3c76067602514c620b5afaba065baaca4e320499f46a62023033fc818
   manager: conda
   name: mosh
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mosh-1.3.2-pl5321h4a694d4_1012.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/mosh-1.3.2-pl5321h4981305_1013.tar.bz2
   version: 1.3.2
 - category: main
   dependencies:
@@ -1756,23 +1774,23 @@ package:
   version: 1.2.1
 - category: main
   dependencies:
-    libgcc-ng: '>=10.3.0'
-    libiconv: '>=1.16,<1.17.0a0'
-    libzlib: '>=1.2.11,<1.3.0a0'
+    libgcc-ng: '>=12'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.12,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=1.1.1o,<1.1.2a'
+    openssl: '>=1.1.1q,<1.1.2a'
     popt: '>=1.16,<2.0a0'
     xxhash: '>=0.8.0,<0.8.1.0a0'
     zstd: '>=1.5.2,<1.6.0a0'
   hash:
-    md5: 35f8fdb194162a71401a44dda9daeeb9
-    sha256: 037b93fe813b2230c73ac3e0ebccc3e423e0afbc9c7c3e9790c6c4c025af5d39
+    md5: 8bb91b42e10a2449da2d7fbef94eba0c
+    sha256: 940ddd78d697f3aca18ebbac6ff2531dbb22308d556d4db196424f9d966b9ad4
   manager: conda
   name: rsync
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rsync-3.2.3-hfa40b15_4.tar.bz2
-  version: 3.2.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/rsync-3.2.6-h220164a_0.tar.bz2
+  version: 3.2.6
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1789,6 +1807,22 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.39.3-h4ff8645_0.tar.bz2
   version: 3.39.3
+- category: main
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+    libidn2: '>=2,<3.0a0'
+    libunistring: '>=0,<1.0a0'
+    openssl: '>=1.1.1l,<1.1.2a'
+    zlib: '>=1.2.11,<1.3.0a0'
+  hash:
+    md5: 674f6b42484dbfd11906c3b0a93585e9
+    sha256: d46fe5f94627cc2cdbed1f3cbadd9693a7ff9550fce2b892ed4d334de841b6ce
+  manager: conda
+  name: wget
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/wget-1.20.3-ha56f1ee_1.tar.bz2
+  version: 1.20.3
 - category: main
   dependencies:
     libgcc-ng: '>=9.3.0'
@@ -1884,23 +1918,6 @@ package:
   version: 2.42.8
 - category: main
   dependencies:
-    libgcc-ng: '>=12'
-    libidn2: '>=2,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libtasn1: '>=4.18.0,<5.0a0'
-    nettle: '>=3.8.1,<3.9.0a0'
-    p11-kit: '>=0.24.1,<0.25.0a0'
-  hash:
-    md5: 12df79786a310d140fa0a399654d129b
-    sha256: 89c2366a9128f0018ace0c78b65d615b50d3dbcab529c232788cb09f413d5ec4
-  manager: conda
-  name: gnutls
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.7-hf3e180e_0.tar.bz2
-  version: 3.7.7
-- category: main
-  dependencies:
     libgcc-ng: '>=9.3.0'
     libglib: '>=2.66.4,<3.0a0'
     libstdcxx-ng: '>=9.3.0'
@@ -1942,20 +1959,34 @@ package:
   version: '2.12'
 - category: main
   dependencies:
-    libclang13: 14.0.6 default_h3a83d3e_0
     libgcc-ng: '>=12'
-    libllvm14: '>=14.0.6,<14.1.0a0'
+    libllvm15: '>=15.0.1,<15.1.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.12,<1.3.0a0'
   hash:
-    md5: eb70548da697e50cefa7ba939d57d001
-    sha256: 2e42f6b4dcb8b75f1eb25d6144fa13084f24a0d2f558a92f1086753bc4e523d4
+    md5: 6e589829ed83703e00b048f8157f7f08
+    sha256: 05379f8f5cf40bb9302248b5b68f86e1f697701210d42a1b3a0ecbeff1b8dfe8
   manager: conda
-  name: libclang
+  name: libclang-cpp15
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-14.0.6-default_h2e3cab8_0.tar.bz2
-  version: 14.0.6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.1-default_h2e3cab8_0.tar.bz2
+  version: 15.0.1
+- category: main
+  dependencies:
+    libgcc-ng: '>=12'
+    libllvm15: '>=15.0.1,<15.1.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
+  hash:
+    md5: 294ce7498f7fafa0044da2417738442f
+    sha256: be800140be1496cc66c1acf289a80e5a96ba5c2787df0678b9480d5abae2a4a2
+  manager: conda
+  name: libclang13
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.1-default_h3a83d3e_0.tar.bz2
+  version: 15.0.1
 - category: main
   dependencies:
     krb5: '>=1.19.3,<1.20.0a0'
@@ -1988,6 +2019,19 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.83.1-h7bff187_0.tar.bz2
   version: 7.83.1
+- category: main
+  dependencies:
+    gnutls: '>=3.7.6,<3.8.0a0'
+    libgcc-ng: '>=12'
+  hash:
+    md5: 78ff89df42ec0d4fe4355490d7843d9b
+    sha256: 780c82366caab4a741f2a4baa901a9b71fad6c2b8f1f64c168f10f61a939e9d4
+  manager: conda
+  name: libmicrohttpd
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.75-h2603550_1.tar.bz2
+  version: 0.9.75
 - category: main
   dependencies:
     giflib: '>=5.2.1,<5.3.0a0'
@@ -2056,30 +2100,14 @@ package:
     make: ''
     perl: ''
   hash:
-    md5: ca32c97ae3c69172f87f23d99806343f
-    sha256: 9fb8023a95d6609925585f8ea17880d05b141b8c36374d079df2e21c2c04a3ae
+    md5: 41af6df1758bae89161daf268566384e
+    sha256: e2f2302d69c0d6928d95a1c699b5ef0b14e0243e78495734962c78136d2e6b9f
   manager: conda
   name: verilator
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/verilator-4.226-he0ac6c6_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/verilator-4.226-he0ac6c6_1.tar.bz2
   version: '4.226'
-- category: main
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-    libidn2: '>=2,<3.0a0'
-    libunistring: '>=0,<1.0a0'
-    openssl: '>=1.1.1l,<1.1.2a'
-    zlib: '>=1.2.11,<1.3.0a0'
-  hash:
-    md5: 674f6b42484dbfd11906c3b0a93585e9
-    sha256: d46fe5f94627cc2cdbed1f3cbadd9693a7ff9550fce2b892ed4d334de841b6ce
-  manager: conda
-  name: wget
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wget-1.20.3-ha56f1ee_1.tar.bz2
-  version: 1.20.3
 - category: main
   dependencies:
     libgcc-ng: '>=9.3.0'
@@ -2213,14 +2241,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 963e8ceccba45b5cf15f33906d5a20a1
-    sha256: 9da8b43e2bcd47bc43015e85af96dd44394fbd51eb9b4fae61ec6e082c404231
+    md5: f66309b099374af91369e67e84af397d
+    sha256: 52e7459b3c457e888e2b6a4e6d13ab7f8675999bc12d20a83e34f12591a8771a
   manager: conda
   name: certifi
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2022.9.14-pyhd8ed1ab_0.tar.bz2
-  version: 2022.9.14
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2022.9.24-pyhd8ed1ab_0.tar.bz2
+  version: 2022.9.24
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2235,21 +2263,20 @@ package:
   version: 2.1.1
 - category: main
   dependencies:
-    clang-format-14: 14.0.6 default_h2e3cab8_0
-    libclang-cpp14: '>=14.0.6,<14.1.0a0'
+    libclang-cpp15: '>=15.0.1,<15.1.0a0'
     libgcc-ng: '>=12'
-    libllvm14: '>=14.0.6,<14.1.0a0'
+    libllvm15: '>=15.0.1,<15.1.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.12,<1.3.0a0'
   hash:
-    md5: 46f166532c575e94f97a42d8b4952006
-    sha256: a8dd07f8f99f2bb22add994bbbdf9a3f61c635285709e8700781da1c83809e54
+    md5: 7a362fdef3d72b52c5ce25ec03db84d2
+    sha256: 9d5e0eda13deaae0d5e0b92df2d5a7334f785b01d89266c650bedf0140744d7c
   manager: conda
-  name: clang-format
+  name: clang-format-15
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-14.0.6-default_h2e3cab8_0.tar.bz2
-  version: 14.0.6
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15-15.0.1-default_h2e3cab8_0.tar.bz2
+  version: 15.0.1
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2350,6 +2377,27 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.5-pyhd8ed1ab_0.tar.bz2
   version: 0.3.5
+- category: main
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libarchive: '>=3.5.2,<3.6.0a0'
+    libcurl: '>=7.82.0,<8.0a0'
+    libgcc-ng: '>=10.3.0'
+    libmicrohttpd: '>=0.9.75,<0.10.0a0'
+    libstdcxx-ng: '>=10.3.0'
+    libzlib: '>=1.2.11,<1.3.0a0'
+    sqlite: '>=3.38.2,<4.0a0'
+    xz: '>=5.2.5,<5.3.0a0'
+    zstd: '>=1.5.2,<1.6.0a0'
+  hash:
+    md5: 2e9ec0e21d51118b004f1f98e4fbf598
+    sha256: bee5b4a723472cc844775a36dbdca35ecb24f40fbb162924bd8536b05930c3dc
+  manager: conda
+  name: elfutils
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.187-h989201e_0.tar.bz2
+  version: '0.187'
 - category: main
   dependencies:
     python: '>=3.7'
@@ -2460,6 +2508,22 @@ package:
   version: '2.0'
 - category: main
   dependencies:
+    libclang13: 15.0.1 default_h3a83d3e_0
+    libgcc-ng: '>=12'
+    libllvm15: '>=15.0.1,<15.1.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
+  hash:
+    md5: 12b3d5cfa7a87103fcc906111aad80c1
+    sha256: a207724037b161dad53f24064e2d839ea35a82c1ff176e8bbd6bf3649323dbd4
+  manager: conda
+  name: libclang
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.1-default_h2e3cab8_0.tar.bz2
+  version: 15.0.1
+- category: main
+  dependencies:
     expat: '>=2.4.8,<3.0a0'
     fontconfig: '>=2.13.96,<3.0a0'
     fonts-conda-ecosystem: ''
@@ -2482,19 +2546,6 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h18fbbfe_3.tar.bz2
   version: 2.3.3
-- category: main
-  dependencies:
-    gnutls: '>=3.7.6,<3.8.0a0'
-    libgcc-ng: '>=12'
-  hash:
-    md5: 78ff89df42ec0d4fe4355490d7843d9b
-    sha256: 780c82366caab4a741f2a4baa901a9b71fad6c2b8f1f64c168f10f61a939e9d4
-  manager: conda
-  name: libmicrohttpd
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.75-h2603550_1.tar.bz2
-  version: 0.9.75
 - category: main
   dependencies:
     python: '>=3.4'
@@ -3019,22 +3070,21 @@ package:
   version: 1.15.1
 - category: main
   dependencies:
-    clang-format: 14.0.6 default_h2e3cab8_0
-    libclang: '>=14.0.6,<14.1.0a0'
-    libclang-cpp14: '>=14.0.6,<14.1.0a0'
+    clang-format-15: 15.0.1 default_h2e3cab8_0
+    libclang-cpp15: '>=15.0.1,<15.1.0a0'
     libgcc-ng: '>=12'
-    libllvm14: '>=14.0.6,<14.1.0a0'
+    libllvm15: '>=15.0.1,<15.1.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.12,<1.3.0a0'
   hash:
-    md5: 8ab329e2e110199b9adcf872c523df1a
-    sha256: ee142d5db1a2e1cde2fb678cd12b67db28da5b98e15b699988051ff65c6f1af4
+    md5: b27e221ef3f74976d431e55d946fac84
+    sha256: b137bc37dacf190159099bcac1cd4647adb23cb926461c8260202c95736312ef
   manager: conda
-  name: clang-tools
+  name: clang-format
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-14.0.6-default_h2e3cab8_0.tar.bz2
-  version: 14.0.6
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15.0.1-default_h2e3cab8_0.tar.bz2
+  version: 15.0.1
 - category: main
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -3091,32 +3141,11 @@ package:
   version: 0.15.2
 - category: main
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libarchive: '>=3.5.2,<3.6.0a0'
-    libcurl: '>=7.82.0,<8.0a0'
-    libgcc-ng: '>=10.3.0'
-    libmicrohttpd: '>=0.9.75,<0.10.0a0'
-    libstdcxx-ng: '>=10.3.0'
-    libzlib: '>=1.2.11,<1.3.0a0'
-    sqlite: '>=3.38.2,<4.0a0'
-    xz: '>=5.2.5,<5.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  hash:
-    md5: 2e9ec0e21d51118b004f1f98e4fbf598
-    sha256: bee5b4a723472cc844775a36dbdca35ecb24f40fbb162924bd8536b05930c3dc
-  manager: conda
-  name: elfutils
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.187-h989201e_0.tar.bz2
-  version: '0.187'
-- category: main
-  dependencies:
     curl: '>=7.83.1,<8.0a0'
     expat: '>=2.4.8,<3.0a0'
     gettext: ''
     libgcc-ng: '>=12'
-    libiconv: '>=1.16,<1.17.0a0'
+    libiconv: '>=1.16,<2.0.0a0'
     libzlib: '>=1.2.12,<1.3.0a0'
     openssl: '>=1.1.1q,<1.1.2a'
     pcre2: '>=10.37,<10.38.0a0'
@@ -3163,19 +3192,19 @@ package:
 - category: main
   dependencies:
     python: '>=3.6'
-    typing_extensions: '>=4'
+    typing_extensions: '>=4,<5'
   hash:
-    md5: d3641a0cd477a56cf13b7f7a5bb9e933
-    sha256: 697a9d1be6e3add3e3fbf1e737e87fdc223ab423f382c455372f1bfcc8766bce
+    md5: 87cafe8c7638a5ac6fd8ec8fb01f1508
+    sha256: 6f7da913ecad98951cadfe512af2c3979fbff752bf714da66760701e5463dd29
   manager: conda
   name: graphql-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.1-pyhd8ed1ab_0.tar.bz2
-  version: 3.2.1
+  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.3-pyhd8ed1ab_0.tar.bz2
+  version: 3.2.3
 - category: main
   dependencies:
-    cairo: '>=1.16.0,<1.17.0a0'
+    cairo: '>=1.16.0,<2.0.0a0'
     freetype: '>=2.12.1,<3.0a0'
     graphite2: ''
     icu: '>=70.1,<71.0a0'
@@ -3299,6 +3328,20 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.3.1-py39h1a9c180_1.tar.bz2
   version: 1.3.1
+- category: main
+  dependencies:
+    elfutils: '>=0.187,<0.188.0a0'
+    libgcc-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
+  hash:
+    md5: 5b3ed39ee3809d63d347b649de0a45f8
+    sha256: null
+  manager: conda
+  name: libdwarf
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/ucb-bar/linux-64/libdwarf-0.0.0.20190110_28_ga81397fc4-h753d276_0.tar.bz2
+  version: 0.0.0.20190110_28_ga81397fc4
 - category: main
   dependencies:
     libgcc-ng: '>=10.3.0'
@@ -3594,14 +3637,14 @@ package:
     python: '>=3.6'
     typing: '>=3.6,<4.0'
   hash:
-    md5: c57d6a6abb22c3796add680597ee0096
-    sha256: 824543c373d6318c335f7c304ef38dec40fe8e0f88ad7c7db92e181e3c5b1170
+    md5: f82cf1ff4aa8228ec71041b8adef19d6
+    sha256: d25441deeb45f575a85977e4444f15d26db2491f5471469f0e5e4fa2e8888a4b
   manager: conda
   name: tomlkit
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.11.4-pyha770c72_0.tar.bz2
-  version: 0.11.4
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.11.5-pyha770c72_0.tar.bz2
+  version: 0.11.5
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3738,6 +3781,24 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/brotlipy-0.7.0-py39hb9d737c_1004.tar.bz2
   version: 0.7.0
+- category: main
+  dependencies:
+    clang-format: 15.0.1 default_h2e3cab8_0
+    libclang: '>=15.0.1,<15.1.0a0'
+    libclang-cpp15: '>=15.0.1,<15.1.0a0'
+    libgcc-ng: '>=12'
+    libllvm15: '>=15.0.1,<15.1.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
+  hash:
+    md5: ef163795e59e62da40e622ee88b7f468
+    sha256: 8fcbebb32ca12bbe1413bada6ab559b280f10256e1d07f522d64cef0292b2f71
+  manager: conda
+  name: clang-tools
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-15.0.1-default_h2e3cab8_0.tar.bz2
+  version: 15.0.1
 - category: main
   dependencies:
     clikit: '>=0.6.0,<0.7.0'
@@ -3897,16 +3958,17 @@ package:
 - category: main
   dependencies:
     elfutils: '>=0.187,<0.188.0a0'
+    libdwarf: 0.0.0.20190110_28_ga81397fc4 h753d276_0
     libgcc-ng: '>=12'
     libzlib: '>=1.2.12,<1.3.0a0'
   hash:
-    md5: 5b3ed39ee3809d63d347b649de0a45f8
+    md5: 899c511688e6c41cb51c2921a8d25e63
     sha256: null
   manager: conda
-  name: libdwarf
+  name: libdwarf-dev
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/ucb-bar/linux-64/libdwarf-0.0.0.20190110_28_ga81397fc4-h753d276_0.tar.bz2
+  url: https://conda.anaconda.org/ucb-bar/linux-64/libdwarf-dev-0.0.0.20190110_28_ga81397fc4-h753d276_0.tar.bz2
   version: 0.0.0.20190110_28_ga81397fc4
 - category: main
   dependencies:
@@ -4002,7 +4064,7 @@ package:
   version: 1.1.5
 - category: main
   dependencies:
-    cairo: '>=1.16.0,<1.17.0a0'
+    cairo: '>=1.16.0,<2.0.0a0'
     fontconfig: '>=2.13.96,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
@@ -4143,7 +4205,7 @@ package:
 - category: main
   dependencies:
     atk-1.0: '>=2.36.0'
-    cairo: '>=1.16.0,<1.17.0a0'
+    cairo: '>=1.16.0,<2.0.0a0'
     gdk-pixbuf: '>=2.42.6,<3.0a0'
     gettext: '>=0.19.8.1,<1.0a0'
     libgcc-ng: '>=9.4.0'
@@ -4173,27 +4235,12 @@ package:
   version: 2.2.0
 - category: main
   dependencies:
-    elfutils: '>=0.187,<0.188.0a0'
-    libdwarf: 0.0.0.20190110_28_ga81397fc4 h753d276_0
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.12,<1.3.0a0'
-  hash:
-    md5: 899c511688e6c41cb51c2921a8d25e63
-    sha256: null
-  manager: conda
-  name: libdwarf-dev
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/ucb-bar/linux-64/libdwarf-dev-0.0.0.20190110_28_ga81397fc4-h753d276_0.tar.bz2
-  version: 0.0.0.20190110_28_ga81397fc4
-- category: main
-  dependencies:
-    cairo: '>=1.16.0,<1.17.0a0'
+    cairo: '>=1.16.0,<2.0.0a0'
     gdk-pixbuf: '>=2.42.8,<3.0a0'
     gettext: '>=0.19.8.1,<1.0a0'
     libgcc-ng: '>=12'
     libglib: '>=2.70.2,<3.0a0'
-    libxml2: '>=2.9.14,<2.10.0a0'
+    libxml2: '>=2.9.14,<2.11.0a0'
     pango: '>=1.50.7,<1.51.0a0'
   hash:
     md5: 921e53675ed5ea352f022b79abab076a
@@ -4222,13 +4269,13 @@ package:
     cryptography: '>=35.0'
     python: '>=3.6'
   hash:
-    md5: 1d7e241dfaf5475e893d4b824bb71b44
-    sha256: 02ee40855abbce429022d2653b9e1649f23398b2ebab53247de69bd35bc05ba5
+    md5: 2e7e3630919d29c8216bfa2cd643d79e
+    sha256: 72af60a6164a380730c00ee996bda265267b53a99662d7ceb2ec6ed47dd74a0b
   manager: conda
   name: pyopenssl
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-22.0.0-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-22.0.0-pyhd8ed1ab_1.tar.bz2
   version: 22.0.0
 - category: main
   dependencies:
@@ -4331,7 +4378,7 @@ package:
   version: 3.0.10
 - category: main
   dependencies:
-    cairo: '>=1.16.0,<1.17.0a0'
+    cairo: '>=1.16.0,<2.0.0a0'
     expat: '>=2.4.8,<3.0a0'
     fontconfig: '>=2.13.96,<3.0a0'
     fonts-conda-ecosystem: ''
@@ -4502,18 +4549,18 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.* *_cp39
     requests: '>=2.20.1,<3'
-    ruamel_yaml: '>=0.11.14,<0.16'
+    ruamel_yaml: '>=0.11.14,<0.17'
     setuptools: '>=31.0.1'
     toolz: '>=0.8.1'
   hash:
-    md5: b037107136fc0afe811f6e06380a3de6
-    sha256: be820e87023b67f458c3043d202554f9f367e5106bd68792388fe7ef682f1ba5
+    md5: 7b5613a2a677f1e2d1dad5a98fa43192
+    sha256: 61b904fe1a666885ef02c2f069c9fd12d88f9dc989b625e0a2f20a35430bd1f5
   manager: conda
   name: conda
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-4.14.0-py39hf3d152e_0.tar.bz2
-  version: 4.14.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-22.9.0-py39hf3d152e_1.tar.bz2
+  version: 22.9.0
 - category: main
   dependencies:
     appdirs: '>=1.4.3'

--- a/conda-reqs.yaml
+++ b/conda-reqs.yaml
@@ -80,7 +80,9 @@ dependencies:
     - graphviz
     - expect
     - dtc
-    - verilator==4.226
+      # Pull in a newer build of verilator 4.226 that defaults to C++17 for verilation
+      # See https://github.com/verilator/verilator/issues/3588
+    - verilator==4.226=he0ac6c6_1
     - screen
     - elfutils
     - libdwarf-dev==0.0.0.20190110_28_ga81397fc4 # from ucb-bar channel - using mainline libdwarf-feedstock


### PR DESCRIPTION
The old build provided gnu++14, which clashes with what we'd like to use to build most of the driver. Until the driver is built and packaged more independently, this pulls verilator-based metasimulator compile in line with the other platforms (VCS/F1/Vitis). 

There is some discussion here: https://github.com/verilator/verilator/issues/3588)

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

None.  Fewer warnings during verilator compile. Prevents future breakages. 
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

None

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
