### PR TITLE
TracerV: fix loop bounds in token processing

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
@@ -233,7 +233,7 @@ size_t tracerv_t::process_tokens(int num_beats, int minimum_batch_beats) {
   // TracerV bridge still exists, and no tracefile is created by default.
   if (this->tracefile) {
     if (this->human_readable || this->test_output) {
-      for (int i = 0; i < bytes_received; i += 8) {
+      for (int i = 0; i < (bytes_received / sizeof(uint64_t)); i += 8) {
         if (this->test_output) {
           fprintf(this->tracefile, "%016lx", OUTBUF[i + 7]);
           fprintf(this->tracefile, "%016lx", OUTBUF[i + 6]);
@@ -260,7 +260,7 @@ size_t tracerv_t::process_tokens(int num_beats, int minimum_batch_beats) {
       }
     } else if (this->fireperf) {
 
-      for (int i = 0; i < bytes_received; i += 8) {
+      for (int i = 0; i < (bytes_received / sizeof(uint64_t)); i += 8) {
         uint64_t cycle_internal = OUTBUF[i + 0];
 
         for (int q = 0; q < max_core_ipc; q++) {
@@ -276,7 +276,7 @@ size_t tracerv_t::process_tokens(int num_beats, int minimum_batch_beats) {
         }
       }
     } else {
-      for (int i = 0; i < bytes_received; i += 8) {
+      for (int i = 0; i < (bytes_received / sizeof(uint64_t)); i += 8) {
         // this stores as raw binary. stored as little endian.
         // e.g. to get the same thing as the human readable above,
         // flip all the bytes in each 512-bit line.


### PR DESCRIPTION
I introduced a bug in the token processing for TracerV when i made some of my Bridge Stream related changes, which caused TracerV's driver to access memory out-of-bounds of the token buffer it allocated. This UB can produce simulators that work correctly or produce erroneous instruction traces or segfault. 

There is a test for TracerV in Chipyard, but i believe it was disabled in haste during an RC bump and never reenabled. :( I have a fix for that I will PR to chipyard separately. 

It might be worth while to add TracerV to the linux poweroff test. We could use as a smoke test for simulator non-determinism and for TracerV health. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

(Likely) resolves https://github.com/firesim/firesim/issues/1231. 

<!-- List any related issues here -->

#### UI / API Impact

None

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

N/C

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
