### PR TITLE
Make AutoCounterCoverModule target modules

### DIFF
--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/AutoCounter.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/AutoCounter.rst
@@ -72,20 +72,17 @@ selected modules will generate counters.
 
 The filtered modules can be indicated using one of two methods:
 
-1. A module selection annotation within the top-level configuration
-   implementation (when using Chipyard, this would usually be ``DigitalTop``, but can also be any other module).  To use this method, add the
-   ``AutoCounterCoverModuleAnnotation`` annotation with the name of the module
-   for which you want the cover functions to be turned into AutoCounters.  The
-   following example will generate counters from cover functions within the
-   ``StreamWriter`` module:
+1. An annotation attached to the module for which cover functions should be
+   turned into AutoCounters.  The annotation requires a ``ModuleTarget`` which
+   can be pointed to any module in the design.  Alternatively, the current
+   module can be annotated as follows:
 
 .. code-block:: scala
 
-  class DigitalTop(implicit p: Parameters) extends ChipyardSystem
+  class SomeModule(implicit p: Parameters) extends Module
   {
-    override lazy val module = new DigitalTopModule(this)
-
-    chisel3.experimental.annotate(AutoCounterCoverModuleAnnotation("StreamWriter"))
+    chisel3.experimental.annotate(AutoCounterCoverModuleAnnotation(
+        Module.currentModule.get.toTarget))
   }
 
 2. An input file with a list of module names. This input file is named

--- a/sim/midas/targetutils/src/main/scala/midas/annotations.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/annotations.scala
@@ -225,10 +225,8 @@ case class AutoCounterCoverModuleFirrtlAnnotation(target: ModuleTarget) extends
   def duplicate(n: ModuleTarget) = this.copy(target = n)
 }
 
-case class AutoCounterCoverModuleAnnotation(target: String) extends ChiselAnnotation {
-  //TODO: fix the CircuitName arguemnt of ModuleTarget after chisel implements Target
-  //It currently doesn't matter since the transform throws away the circuit name
-  def toFirrtl =  AutoCounterCoverModuleFirrtlAnnotation(ModuleTarget("",target))
+case class AutoCounterCoverModuleAnnotation(target: ModuleTarget) extends ChiselAnnotation {
+  def toFirrtl =  AutoCounterCoverModuleFirrtlAnnotation(target)
 }
 
 

--- a/sim/src/main/scala/midasexamples/AutoCounterModule.scala
+++ b/sim/src/main/scala/midasexamples/AutoCounterModule.scala
@@ -87,7 +87,7 @@ class AutoCounterCoverModuleDUT(val instName: String = "dut")(implicit val v: Au
 
   cover(cycle8 , "CYCLES_DIV_8", "Count the number of times the cycle count is divisible by 8. Should be equal to number of cycles divided by 8")
 
-  chisel3.experimental.annotate(AutoCounterCoverModuleAnnotation("AutoCounterCoverModuleDUT"))
+  chisel3.experimental.annotate(AutoCounterCoverModuleAnnotation(Module.currentModule.get.toTarget))
 
   //--------VALIDATION---------------
 


### PR DESCRIPTION
Instead of hard-wiring a module name, now the annotation is placed on a proper module target.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->
N/A

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

N/A

#### Verilog / AGFI Compatibility

N/A

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
