### PR TITLE
Localize Java temp directory + Revert to using `sbt-launch.jar`

### DIFF
--- a/sim/.java_tmp/.gitignore
+++ b/sim/.java_tmp/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -40,7 +40,7 @@ JVM_MEMORY ?= 16G
 SCALA_VERSION ?= 2.12.10
 # Disable the SBT supershell as interacts poorly with scalatest output and breaks
 # the runtime config generator.
-export JAVA_TOOL_OPTIONS ?= -Xmx$(JVM_MEMORY) -Dsbt.supershell=false
+export JAVA_TOOL_OPTIONS ?= -Xmx$(JVM_MEMORY) -Xss8M -Dsbt.supershell=false -Djava.io.tmpdir=$(base_dir)/.java_tmp
 
 sbt_sources = $(shell find -L $(base_dir) -name target -prune -o -iname "*.sbt" -print 2> /dev/null)
 SCALA_BUILDTOOL_DEPS ?= $(sbt_sources)

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -53,7 +53,9 @@ override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 SBT_CLIENT_FLAG = --client
 endif
 
-SBT_BIN ?= sbt
+# Use java -jar approach by default so that SBT thin-client sees the JAVA flags
+# Workaround for behavior reported here: https://github.com/sbt/sbt/issues/6468
+SBT_BIN ?= java -jar $(rocketchip_dir)/sbt-launch.jar
 SBT = $(SBT_BIN) $(SBT_CLIENT_FLAG)
 
 define run_scala_main


### PR DESCRIPTION
Adds the following flags to Java invocation:
- `-Xss8M` - set stack size to 8M (matches what CY does for its large designs)
- `-Djava.io.tmpdir=$(base_dir)/.java_tmp` - set `tmpdir` variable that is used in FIRRTL compilation. this fixes a problem where on shared machines, without this variable FIRRTL compilation creates a `/tmp/.sbt` directory that others would try to create causing a failure.

This PR also reverts to using the `sbt-launch.jar` to invoke SBT instead of the SBT script. This works around - https://github.com/sbt/sbt/issues/6468

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
