### PR TITLE
Setup defaults to be single-node

### DIFF
--- a/deploy/run-farm-recipes/aws_ec2.yaml
+++ b/deploy/run-farm-recipes/aws_ec2.yaml
@@ -25,7 +25,7 @@ args:
     run_farm_hosts_to_use:
       - f1.16xlarge: 0
       - f1.4xlarge: 0
-      - f1.2xlarge: 0
+      - f1.2xlarge: 1
       - m4.16xlarge: 0
       - z1d.3xlarge: 0
       - z1d.6xlarge: 0

--- a/deploy/sample-backup-configs/sample_config_runtime.yaml
+++ b/deploy/sample-backup-configs/sample_config_runtime.yaml
@@ -21,9 +21,8 @@ metasimulation:
   metasimulation_only_vcs_plusargs: "+vcs+initreg+0 +vcs+initmem+0"
 
 target_config:
-    # Set topology: no_net_config to run without a network simulation
-    topology: example_8config
-    no_net_num_nodes: 2
+    topology: no_net_config
+    no_net_num_nodes: 1
     link_latency: 6405
     switching_latency: 10
     net_bandwidth: 200
@@ -33,7 +32,7 @@ target_config:
     # or from config_build_recipes.yaml for metasimulation
     # In homogeneous configurations, use this to set the hardware config deployed
     # for all simulators
-    default_hw_config: firesim_rocket_quadcore_nic_l2_llc4mb_ddr3
+    default_hw_config: firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3
 
     # Advanced: Specify any extra plusargs you would like to provide when
     # booting the simulator (in both FPGA-sim and metasim modes). This is

--- a/docs/Running-Simulations-Tutorial/DOCS_EXAMPLE_config_runtime.yaml
+++ b/docs/Running-Simulations-Tutorial/DOCS_EXAMPLE_config_runtime.yaml
@@ -25,7 +25,7 @@ run_farm:
     run_farm_hosts_to_use:
       - f1.16xlarge: 0
       - f1.4xlarge: 0
-      - f1.2xlarge: 0
+      - f1.2xlarge: 1
       - m4.16xlarge: 0
       - z1d.3xlarge: 0
       - z1d.6xlarge: 0

--- a/docs/Running-Simulations-Tutorial/DOCS_EXAMPLE_config_runtime.yaml
+++ b/docs/Running-Simulations-Tutorial/DOCS_EXAMPLE_config_runtime.yaml
@@ -41,9 +41,8 @@ metasimulation:
   metasimulation_only_vcs_plusargs: "+vcs+initreg+0 +vcs+initmem+0"
 
 target_config:
-    # Set topology: no_net_config to run without a network simulation
-    topology: example_8config
-    no_net_num_nodes: 2
+    topology: no_net_config
+    no_net_num_nodes: 1
     link_latency: 6405
     switching_latency: 10
     net_bandwidth: 200
@@ -53,7 +52,7 @@ target_config:
     # or from config_build_recipes.yaml for metasimulation
     # In homogeneous configurations, use this to set the hardware config deployed
     # for all simulators
-    default_hw_config: firesim_rocket_quadcore_nic_l2_llc4mb_ddr3
+    default_hw_config: firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3
 
     # Advanced: Specify any extra plusargs you would like to provide when
     # booting the simulator (in both FPGA-sim and metasim modes). This is

--- a/docs/Running-Simulations-Tutorial/Running-a-Cluster-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Cluster-Simulation.rst
@@ -69,6 +69,7 @@ For the 8-node cluster simulation, the defaults in this file are close to what
 we want but require slight modification. Let's outline the important parameters:
 
 * ``f1.16xlarges: 1``: Change this parameter. This tells the manager that we want to launch one ``f1.16xlarge`` when we call the ``launchrunfarm`` command.
+* ``f1.4xlarges: 0``: Change this parameter. This tells the manager to not launch any ``f1.4xlarge`` machines when we call the ``launchrunfarm`` command.
 * ``topology: example_8config``: This tells the manager to use the topology named ``example_8config`` which is defined in ``deploy/runtools/user_topology.py``. This topology simulates an 8-node cluster with one ToR switch.
 * ``link_latency: 6405``: This models a network with 6405 cycles of link latency. Since we are modeling processors running at 3.2 Ghz, 1 cycle = 1/3.2 ns, so 6405 cycles is roughly 2 microseconds.
 * ``switching_latency: 10``: This models switches with a minimum port-to-port latency of 10 cycles.

--- a/docs/Running-Simulations-Tutorial/Running-a-Cluster-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Cluster-Simulation.rst
@@ -66,7 +66,7 @@ you have not modified it):
    :code: yaml
 
 For the 8-node cluster simulation, the defaults in this file are close to what
-we want. Let's outline the important parameters:
+we want but require slight modification. Let's outline the important parameters:
 
 * ``f1.16xlarges: 1``: Change this parameter. This tells the manager that we want to launch one ``f1.16xlarge`` when we call the ``launchrunfarm`` command.
 * ``topology: example_8config``: This tells the manager to use the topology named ``example_8config`` which is defined in ``deploy/runtools/user_topology.py``. This topology simulates an 8-node cluster with one ToR switch.

--- a/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
@@ -79,10 +79,9 @@ You'll see other parameters in the ``run_farm`` mapping, like ``run_instance_mar
 AWS user, you can see what these do by looking at the
 :ref:`manager-configuration-files` section. Otherwise, don't change them.
 
-Now, let's change the ``target_config`` mapping to model the correct target design.
-By default, it is set to model an 8-node cluster with a cycle-accurate network.
-Instead, we want to model a single-node with no network. To do so, we will need
-to change a few items in this section:
+Now, let's verify that the ``target_config`` mapping will model the correct target design.
+By default, it is set to model a single-node with no network.
+It should look like the following:
 
 ::
 
@@ -100,13 +99,12 @@ to change a few items in this section:
         default_hw_config: firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3
 
 
-Note that we changed three of the parameters here: ``topology`` is now set to
+Note ``topology`` is set to
 ``no_net_config``, indicating that we do not want a network. Then,
 ``no_net_num_nodes`` is set to ``1``, indicating that we only want to simulate
-one node. Lastly, we changed ``default_hw_config`` from
-``firesim_rocket_quadcore_nic_l2_llc4mb_ddr3`` to
-``firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3``.  Notice the subtle difference in this
-last option? All we did is switch to a hardware configuration that does not
+one node. Lastly, the ``default_hw_config`` is
+``firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3``.  Notice the ``no_nic`` in this
+last option? This uses a hardware configuration that does not
 have a NIC. This hardware configuration models a Quad-core Rocket Chip with 4
 MB of L2 cache and 16 GB of DDR3, and **no** network interface card.
 

--- a/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
+++ b/docs/Running-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
@@ -103,8 +103,7 @@ Note ``topology`` is set to
 ``no_net_config``, indicating that we do not want a network. Then,
 ``no_net_num_nodes`` is set to ``1``, indicating that we only want to simulate
 one node. Lastly, the ``default_hw_config`` is
-``firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3``.  Notice the ``no_nic`` in this
-last option? This uses a hardware configuration that does not
+``firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3``. This uses a hardware configuration that does not
 have a NIC. This hardware configuration models a Quad-core Rocket Chip with 4
 MB of L2 cache and 16 GB of DDR3, and **no** network interface card.
 


### PR DESCRIPTION
For most users, the default setup needs to be changed from an 8-node cluster sim with NIC'ed targets to a single-node sim with no NIC targets. This PR makes this simulation setup the default and modifies the tutorial instructions accordingly.

- [x] Do we want to have the `f1.2xlarge` instance amount set by default? Right now it defaults to 0

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
