### PR TITLE
Relaxed restrictions on pipe channel types

### DIFF
--- a/sim/midas/src/main/scala/midas/core/Channel.scala
+++ b/sim/midas/src/main/scala/midas/core/Channel.scala
@@ -11,19 +11,17 @@ import freechips.rocketchip.tilelink.LFSR64 // Better than chisel's
 import chisel3._
 import chisel3.util._
 
-import midas.core.SimUtils.{ChLeafType}
-
 // Generates stateful assertions on the ports of channels to check that token
 // irrevocability constraints aren't be violated. Bridges that don not produce
 // token streams irrevocably will introduce simulation non-determinism.
 case object GenerateTokenIrrevocabilityAssertions extends Field[Boolean](false)
 
-class PipeChannelIO[T <: ChLeafType](gen: T)(implicit p: Parameters) extends Bundle {
+class PipeChannelIO[T <: Data](gen: T)(implicit p: Parameters) extends Bundle {
   val in    = Flipped(Decoupled(gen))
   val out   = Decoupled(gen)
 }
 
-class PipeChannel[T <: ChLeafType](
+class PipeChannel[T <: Data](
     val gen: T,
     latency: Int
   )(implicit p: Parameters) extends Module {

--- a/sim/midas/src/main/scala/midas/core/SimUtils.scala
+++ b/sim/midas/src/main/scala/midas/core/SimUtils.scala
@@ -10,11 +10,11 @@ import chisel3.experimental.DataMirror.directionOf
 import firrtl.annotations.ReferenceTarget
 
 import scala.collection.mutable.{ArrayBuffer}
+import scala.collection.immutable.{ListMap}
 
 // A collection of useful types and methods for moving between target and host-land interfaces
 object SimUtils {
-  type ChLeafType = Bits
-  type ChTuple = Tuple2[ChLeafType, String]
+  type ChTuple = Tuple2[Bits, String]
   type RVChTuple = Tuple2[ReadyValidIO[Data], String]
   type ParsePortsTuple = (List[ChTuple], List[ChTuple], List[RVChTuple], List[RVChTuple])
 
@@ -29,7 +29,7 @@ object SimUtils {
     def isLoopback(): Boolean = source != None && sink != None
   }
 
-  case class WirePortTuple(source: Option[ReadyValidIO[Data]], sink: Option[ReadyValidIO[Data]]) 
+  case class WirePortTuple(source: Option[ReadyValidIO[Data]], sink: Option[ReadyValidIO[Data]])
       extends PortTuple[ReadyValidIO[Data]]{
     require(source != None || sink != None)
   }
@@ -66,10 +66,9 @@ object SimUtils {
         b.elements foreach {case (n, e) => loop(prefixWith(name, n), e)}
       case v: Vec[_] =>
         v.zipWithIndex foreach {case (e, i) => loop(prefixWith(name, i), e)}
-      case b: ChLeafType => (directionOf(b): @unchecked) match {
+      case b: Bits => (directionOf(b): @unchecked) match {
         case Direction.Input => inputs += (b -> name)
         case Direction.Output => outputs += (b -> name)
-
       }
     }
     io.foreach({ case (name, port) => loop(name, port)})
@@ -95,5 +94,67 @@ object SimUtils {
     val (ins, outs, _, _) = SimUtils.parsePorts(bits)
     require (ins.isEmpty || outs.isEmpty, "Aggregate should be uni-directional")
     (ins ++ outs).map({ case (leafField, _) => leafField.toNamed.toTarget })
+  }
+
+  // Simple wrapper for nested bundles.
+  class BundleRecord(elms: Seq[(String, Data)]) extends Record {
+    override val elements = ListMap((elms.map { case (name, data) => name -> data.cloneType }):_*)
+    override def cloneType: this.type = new BundleRecord(elms).asInstanceOf[this.type]
+  }
+
+  /**
+    * Construct a type for a channel carrying the wires referenced by the list of targets.
+    *
+    * @param portTypeMap Mapping from port references to their types.
+    * @param refTargets List of fields in the channel. Must all point to sub-fields or sub-indices of the port.
+    */
+  def buildChannelType(portTypeMap: Map[ReferenceTarget, firrtl.ir.Port], refTargets: Seq[ReferenceTarget]): Data = {
+    require(!refTargets.isEmpty)
+
+    // Ensure all reference targets point to the same port and find it.
+    val portTarget = refTargets.head.copy(component = Seq())
+    require(refTargets.forall(_.copy(component = Seq()) == portTarget))
+    val portType = portTypeMap(portTarget).tpe
+
+    // Find the type of the field of the bundle.
+    val fieldName = refTargets.head.component.headOption match {
+      case Some(firrtl.annotations.TargetToken.Field(fName)) => fName
+      case _ => throw new RuntimeException("Expected only a bits field in ReferenceTarget's component.")
+    }
+    val bitsType = portType match {
+      case a: firrtl.ir.BundleType => a.fields.filter(_.name == fieldName).head.tpe
+      case _ => throw new RuntimeException("ReferenceTargets should point at the channel's bundle.")
+    }
+    // Reject all nested fields not referenced by a target.
+    val targetLeafNames = refTargets.map(_.component.tail).toSet
+
+    // Recursively map the FIRRTL type to chisel types representing the payload.
+    def loop(token: Seq[firrtl.annotations.TargetToken], tpe: firrtl.ir.Type): Option[Data] = tpe match {
+      case firrtl.ir.UIntType(width: firrtl.ir.IntWidth) =>
+        if (targetLeafNames.contains(token)) Some(UInt(width.width.toInt.W)) else None
+      case firrtl.ir.SIntType(width: firrtl.ir.IntWidth) =>
+        if (targetLeafNames.contains(token)) Some(SInt(width.width.toInt.W)) else None
+      case firrtl.ir.BundleType(fields) => {
+        val nested = fields
+          .map(field => {
+            val tokenName = token ++ List(firrtl.annotations.TargetToken.Field(field.name))
+            loop(tokenName, field.tpe).map { value =>
+              tokenName match {
+                case firrtl.annotations.TargetToken.Field(name) :: Nil => field.name.stripPrefix("bits_") -> value
+                case _ => field.name -> value
+              }
+            }
+          })
+          .collect({ case Some(field) => field })
+
+        nested match {
+          case Nil => None
+          case (name, value) :: Nil => Some(value)
+          case fields => Some(new BundleRecord(fields))
+        }
+      }
+    }
+
+    loop(List(), bitsType).get
   }
 }

--- a/sim/midas/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -54,7 +54,7 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
     // needs back pressure from reset queues
     io.idle := cycleHorizon === 0.U
 
-    def genWideReg(name: String, field: ChLeafType): Seq[UInt] = Seq.tabulate(
+    def genWideReg(name: String, field: Bits): Seq[UInt] = Seq.tabulate(
         (field.getWidth + ctrlWidth - 1) / ctrlWidth)({ i =>
       val chunkWidth = math.min(ctrlWidth, field.getWidth - (i * ctrlWidth))
       Reg(UInt(chunkWidth.W)).suggestName(s"target_${name}_{i}")
@@ -65,7 +65,7 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
     val outputPrecisePeekableFlags = mutable.ArrayBuffer[Bool]()
     val channelPokes           = mutable.ArrayBuffer[(Seq[Int], Bool)]()
 
-    def bindInputs(name: String, channel: DecoupledIO[ChLeafType]): Seq[Int] = {
+    def bindInputs(name: String, channel: DecoupledIO[Bits]): Seq[Int] = {
       val reg = genWideReg(name, channel.bits)
       // Track local-channel decoupling
       val cyclesAhead = SatUpDownCounter(key.maxChannelDecoupling)
@@ -97,7 +97,7 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
       regAddrs
     }
 
-    def bindOutputs(name: String, channel: DecoupledIO[ChLeafType]): Seq[Int] = {
+    def bindOutputs(name: String, channel: DecoupledIO[Bits]): Seq[Int] = {
       val reg = genWideReg(name, channel.bits)
       // Track local-channel decoupling
       val cyclesAhead = SatUpDownCounter(key.maxChannelDecoupling)


### PR DESCRIPTION
Eliminated ChLeafType and allowed pipe channels to carry arbitrary bundles. In SimWrapper, pipe channels can be built from multiple reference targets. When pipe channels are built by bridges, the logic is unchanged and bundles are still split into their constituent channels to avoid any performance degradation that might arise from the additional coupling.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

N/A

<!-- List any related issues here -->

#### UI / API Impact

N/A

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

N/A

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
