### PR TITLE
Disable CI check for Local FPGAs

### DIFF
--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -264,22 +264,23 @@ jobs:
       - name: Run linux-poweroff test w/ externally provisioned (AWS EC2) run farm
         run: .github/scripts/run-linux-poweroff-externally-provisioned.py
 
-  run-basic-linux-poweroff-vitis:
-    if: contains(github.event.pull_request.labels.*.name, 'ci:fpga-deploy')
-    name: run-basic-linux-poweroff-vitis
-    runs-on: local-fpga
-    env:
-      TERM: xterm-256-color
-    steps:
-      # This forces a fresh clone of the repo during the `checkout` step
-      # to resolve stale submodule URLs. See https://github.com/ucb-bar/chipyard/pull/1156.
-      - name: Delete old checkout
-        run: |
-          rm -rf ${{ github.workspace }}/* || true
-          rm -rf ${{ github.workspace }}/.* || true
-      - uses: actions/checkout@v2
-      - name: Run simple linux poweroff test w/ vitis
-        run: .github/scripts/run-linux-poweroff-vitis.py
+# AJG: disable temporarily due to local CI machine issues
+#  run-basic-linux-poweroff-vitis:
+#    if: contains(github.event.pull_request.labels.*.name, 'ci:fpga-deploy')
+#    name: run-basic-linux-poweroff-vitis
+#    runs-on: local-fpga
+#    env:
+#      TERM: xterm-256-color
+#    steps:
+#      # This forces a fresh clone of the repo during the `checkout` step
+#      # to resolve stale submodule URLs. See https://github.com/ucb-bar/chipyard/pull/1156.
+#      - name: Delete old checkout
+#        run: |
+#          rm -rf ${{ github.workspace }}/* || true
+#          rm -rf ${{ github.workspace }}/.* || true
+#      - uses: actions/checkout@v2
+#      - name: Run simple linux poweroff test w/ vitis
+#        run: .github/scripts/run-linux-poweroff-vitis.py
 
   documentation-check:
     name: documentation-check


### PR DESCRIPTION
The CI machine used for local FPGA simulation is currently broken and needs to be looked at closely (hopefully I can look at this by the EOW). Until that happens this check should be disabled so that PR's can be merged.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
