### PR TITLE
add back InfoStreamLogger on driver build run call to show live build status

### DIFF
--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -20,6 +20,7 @@ from runtools.run_farm import RunFarm
 from runtools.simulation_data_classes import TracerVConfig, AutoCounterConfig, HostDebugConfig, SynthPrintConfig
 from util.inheritors import inheritors
 from util.deepmerge import deep_merge
+from util.streamlogger import InfoStreamLogger
 from buildtools.bitbuilder import get_deploy_dir
 
 from typing import Optional, Dict, Any, List, Sequence, Tuple, TYPE_CHECKING
@@ -248,7 +249,7 @@ class RuntimeHWConfig:
         platform_config = triplet_pieces[2]
         rootLogger.info(f"Building {self.driver_type_message} driver for {str(self.get_deploytriplet_for_config())}")
 
-        with prefix(f'cd {get_deploy_dir()}/../'), \
+        with InfoStreamLogger('stdout'), prefix(f'cd {get_deploy_dir()}/../'), \
             prefix(f'export RISCV={os.getenv("RISCV", "")}'), \
             prefix(f'export PATH={os.getenv("PATH", "")}'), \
             prefix(f'export LD_LIBRARY_PATH={os.getenv("LD_LIBRARY_PATH", "")}'), \


### PR DESCRIPTION
This needs to be added back to match the functionality of our old driver build process with local().

Similar functionality also seems to have been removed (by accident?) during buildafis, there is now an issue for that here: https://github.com/firesim/firesim/issues/1271. This is not as critical imo so left to future work.

#### Related PRs / Issues

#1271 

#### UI / API Impact

Users now see the progress of a driver/metasim build, rather than just seeing the manager "hang" for 5-10 mins (or forever, if something prompts for input).

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
