### PR TITLE
fix vcs metasims

### DIFF
--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -307,6 +307,9 @@ class RuntimeBuildRecipeConfig(RuntimeHWConfig):
 
         self.additional_required_files = []
 
+        if self.metasim_host_simulator in ["vcs", "vcs-debug"]:
+            self.additional_required_files.append((self.get_local_driver_path() + ".daidir", ""))
+
     def get_boot_simulation_command(self,
             slotid: int,
             all_macs: Sequence[MacAddress],


### PR DESCRIPTION
VCS metasims were failing due to the manager not copying `FireSim.daidir/` that is generated by VCS. This PR fixes that.

I've tested that both `vcs` and `vcs-debug` metasims work now.

#### Related PRs / Issues

Fixes #1256 

#### UI / API Impact

VCS-based metasims work now.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
