### PR TITLE
Remove references to buildafi; replace with buildbitstream

### DIFF
--- a/deploy/firesim
+++ b/deploy/firesim
@@ -243,13 +243,8 @@ def runworkload(runtime_conf: RuntimeConfig) -> None:
     runtime_conf.run_workload()
 
 @register_task
-def buildafi(build_config_file: BuildConfigFile) -> None:
-    # shouldn't ever be able to get here because main() implements logging and redirecting to builtbitstream
-    raise NotImplementedError
-
-@register_task
 def buildbitstream(build_config_file: BuildConfigFile) -> None:
-    """ Starting from local Chisel, build an AFI for all of the specified
+    """ Starting from local Chisel, build a bitstream for all of the specified
     hardware configs. """
 
     # forced to build locally
@@ -416,7 +411,7 @@ def construct_firesim_argparser() -> argparse.ArgumentParser:
     parser.add_argument('-q', '--forceterminate', action='store_true',
                         help='For terminaterunfarm and buildbitstream, force termination without prompting user for confirmation. Defaults to False')
     parser.add_argument('-t', '--launchtime', type=str,
-                        help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildafi')
+                        help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildbitstream')
     parser.add_argument('--platform', type=str, choices=PLATFORM_LIST, default='f1',
                         help='Required argument for "managerinit" to specify which platform you will be using')
 
@@ -443,10 +438,6 @@ def main(args: argparse.Namespace) -> None:
     # we elastically spin instances up/down. we can easily get re-used IPs with
     # different keys. also, probably won't get MITM'd
     env.disable_known_hosts = True
-
-    if args.task == 'buildafi':
-        rootLogger.warning("From v1.14.0, 'buildafi' is renamed to 'buildbitstream' and will be removed in a future version")
-        args.task = 'buildbitstream'
 
     rootLogger.info("FireSim Manager. Docs: https://docs.fires.im\nRunning: %s\n", str(args.task))
 

--- a/deploy/sample-backup-configs/sample_config_build.yaml
+++ b/deploy/sample-backup-configs/sample_config_build.yaml
@@ -14,7 +14,7 @@ build_farm:
 
 builds_to_run:
     # this section references builds defined in config_build_recipes.yaml
-    # if you add a build here, it will be built when you run buildafi
+    # if you add a build here, it will be built when you run buildbitstream
 
     # Unnetworked designs use a three-domain configuration
     # Tiles: 1600 MHz

--- a/deploy/sample-backup-configs/sample_config_build_recipes.yaml
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.yaml
@@ -3,7 +3,7 @@
 
 # this file contains sections that describe hardware designs that /can/ be built.
 # edit config_build.yaml to actually "turn on" a config to be built when you run
-# buildafi
+# buildbitstream
 
 ###########
 # Schema:

--- a/deploy/tests/test_firesim_top.py
+++ b/deploy/tests/test_firesim_top.py
@@ -112,10 +112,6 @@ def test_main_dispatching(mocker: MockerFixture, task_mocker, tn: str):
     mocker.patch.dict('os.environ', {'FIRESIM_SOURCED': '1'})
     parser = firesim.construct_firesim_argparser()
 
-    # TODO: Remove after deprecation
-    if tn == 'buildafi':
-        tn = 'buildbitstream'
-
     task_mocker.patch(tn)
 
     args = parser.parse_args([tn])

--- a/deploy/tests/test_yaml_api.py
+++ b/deploy/tests/test_yaml_api.py
@@ -266,7 +266,7 @@ class TestConfigBuildAPI:
                                     ])
     def test_config_existence(self, task_mocker, build_yamls, firesim_parse_args, task_name, opt, non_existent_file):
         # TODO: Remove after deprecation
-        if task_name == "buildafi":
+        if task_name == "buildbitstream":
             task_name = "buildbitstream"
 
         m = task_mocker.patch(task_name, wrap_config=True)

--- a/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Dromajo.rst
+++ b/docs/Advanced-Usage/Debugging-and-Profiling-on-FPGA/Dromajo.rst
@@ -29,7 +29,7 @@ An example configuration with Dromajo is shown below:
       new WithFireSimConfigTweaks ++
       new chipyard.LargeBoomConfig)
 
-At this point, you should run the ``firesim buildafi`` command for the BOOM config wanted.
+At this point, you should run the ``firesim buildbitstream`` command for the BOOM config wanted.
 
 Running a FireSim Simulation
 ----------------------------

--- a/docs/Advanced-Usage/FAQs.rst
+++ b/docs/Advanced-Usage/FAQs.rst
@@ -16,7 +16,7 @@ To get the new default AGFI's you must run the manager initialization again by d
 Is there a good way to keep track of what AGFI corresponds to what FireSim commit?
 ----------------------------------------------------------------------------------
 
-When building an AGFI during ``firesim buildafi``, FireSim keeps track of what FireSim repository commit was used to build the AGFI.
+When building an AGFI during ``firesim buildbitstream``, FireSim keeps track of what FireSim repository commit was used to build the AGFI.
 To view a list of AGFI's that you have built and what you have access to, you can run the following command:
 
 ::

--- a/docs/Advanced-Usage/Manager/HELP_OUTPUT
+++ b/docs/Advanced-Usage/Manager/HELP_OUTPUT
@@ -4,12 +4,12 @@ usage: firesim [-h] [-c RUNTIMECONFIGFILE] [-b BUILDCONFIGFILE]
                [-g TERMINATESOMEF12] [-i TERMINATESOMEF14]
                [-m TERMINATESOMEM416] [--terminatesome TERMINATESOME] [-q]
                [-t LAUNCHTIME] [--platform {f1,vitis}]
-               {managerinit,infrasetup,boot,kill,runworkload,buildafi,buildbitstream,builddriver,tar2afi,runcheck,launchrunfarm,terminaterunfarm,shareagfi}
+               {managerinit,infrasetup,boot,kill,runworkload,buildbitstream,builddriver,tar2afi,runcheck,launchrunfarm,terminaterunfarm,shareagfi}
 
 FireSim Simulation Manager.
 
 positional arguments:
-  {managerinit,infrasetup,boot,kill,runworkload,buildafi,buildbitstream,builddriver,tar2afi,runcheck,launchrunfarm,terminaterunfarm,shareagfi}
+  {managerinit,infrasetup,boot,kill,runworkload,buildbitstream,builddriver,tar2afi,runcheck,launchrunfarm,terminaterunfarm,shareagfi}
                         Management task to run.
 
 optional arguments:
@@ -74,7 +74,7 @@ optional arguments:
   -t LAUNCHTIME, --launchtime LAUNCHTIME
                         Give the "Y-m-d--H-M-S" prefix of results-build
                         directory. Useful for tar2afi when finishing a partial
-                        buildafi
+                        buildbitstream
   --platform {f1,vitis}
                         Required argument for "managerinit" to specify which
                         platform you will be using

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -36,13 +36,6 @@ If you run this command by accident and didn't mean to overwrite your
 configuration files, you'll find backed-up versions in
 ``firesim/deploy/sample-backup-configs/backup*``.
 
-.. _firesim-buildafi:
-
-``firesim buildafi``
-----------------------
-
-.. Warning:: DEPRECATION: ``buildafi`` has been renamed to ``buildbitstream`` and will be removed in a future version
-
 .. _firesim-buildbitstream:
 
 ``firesim buildbitstream``

--- a/docs/Building-a-FireSim-AFI.rst
+++ b/docs/Building-a-FireSim-AFI.rst
@@ -55,7 +55,7 @@ end up with something like this (a line beginning with a ``#`` is a comment):
 
    builds_to_run:
        # this section references builds defined in config_build_recipes.ini
-       # if you add a build here, it will be built when you run buildafi
+       # if you add a build here, it will be built when you run buildbitstream
        - firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3
 
 


### PR DESCRIPTION
Completes deprecation of `firesim buildbitstream`
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

`firesim buildafi` will cease to function correctly. 

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

None
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
