### PR TITLE
Manager: Add back InfoStreamLoggers to buildbitstream related tasks

### DIFF
--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -12,6 +12,7 @@ from fabric.api import prefix, local, run, env, lcd, parallel, settings # type: 
 from fabric.contrib.console import confirm # type: ignore
 from fabric.contrib.project import rsync_project # type: ignore
 
+from util.streamlogger import InfoStreamLogger
 from awstools.afitools import firesim_tags_to_description, copy_afi_to_all_regions
 from awstools.awstools import send_firesim_notification, get_aws_userid, get_aws_region, auto_create_bucket, valid_aws_configure_creds, aws_resource_names, get_snsname_arn
 

--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -111,18 +111,21 @@ class F1BitBuilder(BitBuilder):
     def replace_rtl(self) -> None:
         rootLogger.info(f"Building Verilog for {self.build_config.get_chisel_triplet()}")
 
-        with prefix(f'cd {get_deploy_dir()}/../'), \
+        with InfoStreamLogger('stdout'), \
+            prefix(f'cd {get_deploy_dir()}/../'), \
             prefix(f'export RISCV={os.getenv("RISCV", "")}'), \
             prefix(f'export PATH={os.getenv("PATH", "")}'), \
             prefix(f'export LD_LIBRARY_PATH={os.getenv("LD_LIBRARY_PATH", "")}'), \
             prefix('source sourceme-f1-manager.sh --skip-ssh-setup'), \
+            InfoStreamLogger('stdout'), \
             prefix('cd sim/'):
             run(self.build_config.make_recipe("PLATFORM=f1 replace-rtl"))
 
     def build_driver(self) -> None:
         rootLogger.info(f"Building FPGA driver for {self.build_config.get_chisel_triplet()}")
 
-        with prefix(f'cd {get_deploy_dir()}/../'), \
+        with InfoStreamLogger('stdout'), \
+            prefix(f'cd {get_deploy_dir()}/../'), \
             prefix(f'export RISCV={os.getenv("RISCV", "")}'), \
             prefix(f'export PATH={os.getenv("PATH", "")}'), \
             prefix(f'export LD_LIBRARY_PATH={os.getenv("LD_LIBRARY_PATH", "")}'), \
@@ -226,7 +229,7 @@ class F1BitBuilder(BitBuilder):
         fpga_frequency = self.build_config.get_frequency()
         build_strategy = self.build_config.get_strategy().name
 
-        with settings(warn_only=True):
+        with InfoStreamLogger('stdout'), settings(warn_only=True):
             vivado_result = run(f"{cl_dir}/build-bitstream.sh --cl_dir {cl_dir} --frequency {fpga_frequency} --strategy {build_strategy}").return_code
 
         # put build results in the result-build area
@@ -380,7 +383,8 @@ class VitisBitBuilder(BitBuilder):
     def replace_rtl(self):
         rootLogger.info(f"Building Verilog for {self.build_config.get_chisel_triplet()}")
 
-        with prefix(f'cd {get_deploy_dir()}/../'), \
+        with InfoStreamLogger('stdout'), \
+            prefix(f'cd {get_deploy_dir()}/../'), \
             prefix(f'export RISCV={os.getenv("RISCV", "")}'), \
             prefix(f'export PATH={os.getenv("PATH", "")}'), \
             prefix(f'export LD_LIBRARY_PATH={os.getenv("LD_LIBRARY_PATH", "")}'), \
@@ -391,7 +395,8 @@ class VitisBitBuilder(BitBuilder):
     def build_driver(self):
         rootLogger.info("Building FPGA driver for {}".format(str(self.build_config.get_chisel_triplet())))
 
-        with prefix(f'cd {get_deploy_dir()}/../'), \
+        with InfoStreamLogger('stdout'), \
+            prefix(f'cd {get_deploy_dir()}/../'), \
             prefix(f'export RISCV={os.getenv("RISCV", "")}'), \
             prefix(f'export PATH={os.getenv("PATH", "")}'), \
             prefix(f'export LD_LIBRARY_PATH={os.getenv("LD_LIBRARY_PATH", "")}'), \
@@ -491,7 +496,7 @@ class VitisBitBuilder(BitBuilder):
         fpga_frequency = self.build_config.get_frequency()
         build_strategy = self.build_config.get_strategy().name
 
-        with settings(warn_only=True):
+        with InfoStreamLogger('stdout'), settings(warn_only=True):
             vitis_result = run(f"{cl_dir}/build-bitstream.sh --build_dir {cl_dir} --device {self.device} --frequency {fpga_frequency} --strategy {build_strategy}").return_code
 
         # put build results in the result-build area


### PR DESCRIPTION
In practice i've found it really annoying to have to dig through the logs, which tend proliferate. More over, these tasks tend to fail often and show signs of failing early so i'd rather just get it blasted to stdout as well. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
