### PR TITLE
Regenerate AGFIs to fix references to removed FXXMHz classes

### DIFF
--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -274,7 +274,9 @@ jobs:
   run-basic-linux-poweroff:
     if: contains(github.event.pull_request.labels.*.name, 'ci:fpga-deploy')
     name: run-basic-linux-poweroff
-    needs: [build-default-workloads]
+    # Building the driver can cause concurrency issues with SBT, so serialize
+    # this behind the scalatest train. Remove once we're off SBT.
+    needs: [build-default-workloads, run-chipyard-tests]
     runs-on: aws-${{ github.run_id }}
     env:
       TERM: xterm-256-color

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -11,39 +11,23 @@
 
 # DOCREF START: Example HWDB Entry
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-06ba7c84d860d03fa
+    agfi: agfi-0a0dec4eabe31cce8
     deploy_triplet_override: null
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0ac8c494fd62b8e2c
+    agfi: agfi-0e8bcd0d7c959ae38
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0ad7926bface872f3
+    agfi: agfi-04c56ed97499d4b76
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0fc5aa0feadf563cf
+    agfi: agfi-0887c06cb5cd14456
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-0c0b97c446af82c74
-    deploy_triplet_override: null
-    custom_runtime_config: null
-firesim_rocket_singlecore_no_nic_l2_lbp:
-    agfi: agfi-02eb57a6b5f19b45b
-    deploy_triplet_override: null
-    custom_runtime_config: null
-firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0c16fdec246d5744b
-    deploy_triplet_override: null
-    custom_runtime_config: null
-firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0cbaac427a3ffed80
-    deploy_triplet_override: null
-    custom_runtime_config: null
-firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
-    agfi: agfi-0b2364562f988653c
+    agfi: agfi-02b8f45c73097bf08
     deploy_triplet_override: null
     custom_runtime_config: null


### PR DESCRIPTION
I stripped out the Frequency provider classes but did not regenerate AGFIs. This provides a workaround for the prebuilt images, which are used in CI, until the next regeneration happens. 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues
Should fix CI issue in #1299 

<!-- List any related issues here -->

#### UI / API Impact
None

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
