### PR TITLE
Move XDC circuit paths to config

### DIFF
--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -74,6 +74,12 @@ case object HostTransforms extends Field[Seq[TransformDependency]](Seq())
 // Directory into which output files are dumped. Set by -td when invoking the Stage
 case object OutputDir extends Field[File]
 
+// Provides the absolute paths to firrtl-emitted module in the context of the
+// FPGA project before and after linking. If the firrtl-emitted module is the
+// top-level, set the path to None.
+case object PreLinkCircuitPath extends Field[Option[String]](None)
+case object PostLinkCircuitPath extends Field[Option[String]](None)
+
 // Alias WithoutTLMonitors into this package so that it can be used in config strings
 class WithoutTLMonitors extends freechips.rocketchip.subsystem.WithoutTLMonitors
 
@@ -108,6 +114,8 @@ class F1Config extends Config(new Config((site, here, up) => {
     beatBytes = 8,
     idBits    = 16)
   case HostMemNumChannels => 4
+  case PreLinkCircuitPath => Some("firesim_top")
+  case PostLinkCircuitPath => Some("WRAPPER_INST/CL/firesim_top")
 }) ++ new SimConfig)
 
 class VitisConfig extends Config(new Config((site, here, up) => {
@@ -140,6 +148,11 @@ class VitisConfig extends Config(new Config((site, here, up) => {
   // This could be as many as four on a U250, but support for the other
   // channels requires adding address offsets in the shim (TODO).
   case HostMemNumChannels => 1
+  // We don't need to provide circuit paths because
+  // 1) The Shim module is the top-level of the kernel
+  // 2) Implementation constraints are scoped to the kernel level in our vitis flow
+  case PreLinkCircuitPath => None
+  case PostLinkCircuitPath => None
 }) ++ new SimConfig)
 
 // Turns on all additional synthesizable debug features for checking the

--- a/sim/midas/src/main/scala/midas/platform/F1Shim.scala
+++ b/sim/midas/src/main/scala/midas/platform/F1Shim.scala
@@ -50,7 +50,5 @@ class F1Shim(implicit p: Parameters) extends PlatformShim {
           |`define USE_DDR_CHANNEL_D ${channelInUse(3)}
           |""".stripMargin,
       fileSuffix = ".defines.vh")
-
-    SpecifyXDCCircuitPaths(Some("firesim_top"), Some("WRAPPER_INST/CL/firesim_top"))
   }
 }

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -12,6 +12,8 @@ import midas.core._
 import midas.passes.fame.{FAMEChannelConnectionAnnotation}
 import midas.widgets.{CStrLit, UInt32, BridgeIOAnnotation}
 import midas.widgets.CppGenerationUtils._
+import midas.targetutils.xdc.SpecifyXDCCircuitPaths
+import midas.{PreLinkCircuitPath, PostLinkCircuitPath}
 
 /**
   * Generates the platform wrapper (which includes most of the chisel-generated
@@ -43,4 +45,9 @@ abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
 
     top.module.headerConsts map vMacro foreach sb.append
   }
+
+  // Emit a `XDCPathToCircuitAnnotation` with the pre- and post-link circuit
+  // paths provided in the configuration. These locate the design within the
+  // context of the larger FPGA design.
+  SpecifyXDCCircuitPaths(p(PreLinkCircuitPath), p(PostLinkCircuitPath))
 }

--- a/sim/midas/src/main/scala/midas/platform/VitisShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/VitisShim.scala
@@ -109,9 +109,5 @@ class VitisShim(implicit p: Parameters) extends PlatformShim {
       fileSuffix = ".defines.vh",
     )
     GoldenGateOutputFileAnnotation.annotateFromChisel(s"# Currenty unused", ".env.tcl")
-    // We don't need to provide paths because
-    // 1) The Shim module is the top-level of the kernel
-    // 2) Implementation constraints are scoped to the kernel level in our vitis flow
-    SpecifyXDCCircuitPaths(None, None)
   }
 }


### PR DESCRIPTION
We would like to be able to tell what the pre- and post-link circuit paths of the design are going to be without having to elaborate the `PlatformShim` to get at the corresponding `XDCPathToCircuitAnnotation`.

This commit adds the two new config options `PreLinkCircuitPath` and `PostLinkCircuitPath`, and moves the platform-specific paths out from `F1Shim` and `VitisShim` and into the corresponding `F1Config` and `VitisConfig`, respectively. This allows other parts of the codebase to determine these paths purely from the config. Since the platform- specific shim code now no longer has to specify these paths directly, the `SpecifyXDCCircuitPaths` is moved up into the parent `PlatformShim` class which annotates the paths provided by the config.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->
None.

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->
Unaffected.

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->
Unaffected.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] ~~Did you add at least one test demonstrating the PR?~~
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] ~~If applicable, did you regenerate and publicly share default AGFIs?~~
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] ~~If applicable, did you apply the `ci:fpga-deploy` label?~~
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] ~~If applicable, did you apply the `Please Backport` label?~~

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
