### PR TITLE
Remove raw pointers from bridge port address creation

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/blockdev.h
+++ b/sim/firesim-lib/src/main/cc/bridges/blockdev.h
@@ -39,7 +39,7 @@ public:
              const std::vector<std::string> &args,
              uint32_t num_trackers,
              uint32_t latency_bits,
-             BLOCKDEVBRIDGEMODULE_struct *mmio_addrs,
+             const BLOCKDEVBRIDGEMODULE_struct &mmio_addrs,
              int blkdevno);
   ~blockdev_t();
 
@@ -55,7 +55,7 @@ public:
   virtual void finish(){};
 
 private:
-  BLOCKDEVBRIDGEMODULE_struct *mmio_addrs;
+  const BLOCKDEVBRIDGEMODULE_struct mmio_addrs;
 
   // Set if, on the previous tick, we couldn't write back all of our response
   // data

--- a/sim/firesim-lib/src/main/cc/bridges/serial.h
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.h
@@ -24,10 +24,9 @@ struct serial_data_t {
 // Bridge Driver Instantiation Template
 // Casts are required for now since the emitted type can change
 #define INSTANTIATE_SERIAL(FUNC, IDX)                                          \
-  SERIALBRIDGEMODULE_##IDX##_substruct_create;                                 \
   FUNC(new serial_t(this,                                                      \
                     args,                                                      \
-                    SERIALBRIDGEMODULE_##IDX##_substruct,                      \
+                    SERIALBRIDGEMODULE_##IDX##_substruct_create,               \
                     IDX,                                                       \
                     SERIALBRIDGEMODULE_##IDX##_has_memory,                     \
                     SERIALBRIDGEMODULE_##IDX##_memory_offset));
@@ -37,7 +36,7 @@ class serial_t : public bridge_driver_t {
 public:
   serial_t(simif_t *sim,
            const std::vector<std::string> &args,
-           SERIALBRIDGEMODULE_struct *mmio_addrs,
+           const SERIALBRIDGEMODULE_struct &mmio_addrs,
            int serialno,
            bool has_mem,
            int64_t mem_host_offset);
@@ -49,7 +48,7 @@ public:
   virtual void finish(){};
 
 private:
-  SERIALBRIDGEMODULE_struct *mmio_addrs;
+  const SERIALBRIDGEMODULE_struct mmio_addrs;
   simif_t *sim;
   firesim_tsi_t *fesvr;
   bool has_mem;

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.cc
@@ -50,16 +50,15 @@ static void simplify_frac(int n, int d, int *nn, int *dd) {
 
 simplenic_t::simplenic_t(simif_t *sim,
                          std::vector<std::string> &args,
-                         SIMPLENICBRIDGEMODULE_struct *mmio_addrs,
+                         const SIMPLENICBRIDGEMODULE_struct &mmio_addrs,
                          int simplenicno,
                          const int stream_to_cpu_idx,
                          const int stream_to_cpu_depth,
                          const int stream_from_cpu_idx,
                          const int stream_from_cpu_depth)
-    : bridge_driver_t(sim), stream_to_cpu_idx(stream_to_cpu_idx),
+    : bridge_driver_t(sim), mmio_addrs(mmio_addrs),
+      stream_to_cpu_idx(stream_to_cpu_idx),
       stream_from_cpu_idx(stream_from_cpu_idx) {
-  this->mmio_addrs = mmio_addrs;
-
   const char *niclogfile = NULL;
   const char *shmemportname = NULL;
   int netbw = MAX_BANDWIDTH, netburst = 8;
@@ -220,18 +219,17 @@ simplenic_t::~simplenic_t() {
       munmap(pcis_write_bufs[j], BUFBYTES + EXTRABYTES);
     }
   }
-  free(this->mmio_addrs);
 }
 
 #define ceil_div(n, d) (((n)-1) / (d) + 1)
 
 void simplenic_t::init() {
-  write(mmio_addrs->macaddr_upper, (mac_lendian >> 32) & 0xFFFF);
-  write(mmio_addrs->macaddr_lower, mac_lendian & 0xFFFFFFFF);
-  write(mmio_addrs->rlimit_settings,
+  write(mmio_addrs.macaddr_upper, (mac_lendian >> 32) & 0xFFFF);
+  write(mmio_addrs.macaddr_lower, mac_lendian & 0xFFFFFFFF);
+  write(mmio_addrs.rlimit_settings,
         (rlimit_inc << 16) | ((rlimit_period - 1) << 8) | rlimit_size);
-  write(mmio_addrs->pause_threshold, pause_threshold);
-  write(mmio_addrs->pause_times,
+  write(mmio_addrs.pause_threshold, pause_threshold);
+  write(mmio_addrs.pause_times,
         (pause_refresh << 16) | (pause_quanta & 0xffff));
 
   // In lieu of reading "count", check that the stream is empty by doing a pull.

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.h
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.h
@@ -12,10 +12,9 @@
 #ifdef SIMPLENICBRIDGEMODULE_struct_guard
 
 #define INSTANTIATE_SIMPLENIC(FUNC, IDX)                                       \
-  SIMPLENICBRIDGEMODULE_##IDX##_substruct_create;                              \
   FUNC(new simplenic_t(this,                                                   \
                        args,                                                   \
-                       SIMPLENICBRIDGEMODULE_##IDX##_substruct,                \
+                       SIMPLENICBRIDGEMODULE_##IDX##_substruct_create,         \
                        IDX,                                                    \
                        SIMPLENICBRIDGEMODULE_##IDX##_to_cpu_stream_idx,        \
                        SIMPLENICBRIDGEMODULE_##IDX##_to_cpu_stream_depth,      \
@@ -26,7 +25,7 @@ class simplenic_t : public bridge_driver_t {
 public:
   simplenic_t(simif_t *sim,
               std::vector<std::string> &args,
-              SIMPLENICBRIDGEMODULE_struct *addrs,
+              const SIMPLENICBRIDGEMODULE_struct &addrs,
               int simplenicno,
               const int stream_to_cpu_idx,
               const int stream_to_cpu_depth,
@@ -41,6 +40,7 @@ public:
   virtual void finish(){};
 
 private:
+  const SIMPLENICBRIDGEMODULE_struct mmio_addrs;
   uint64_t mac_lendian;
   char *pcis_read_bufs[2];
   char *pcis_write_bufs[2];
@@ -53,7 +53,6 @@ private:
   // IMPORTANT: this must be a multiple of 7
   int LINKLATENCY;
   FILE *niclog;
-  SIMPLENICBRIDGEMODULE_struct *mmio_addrs;
   bool loopback;
 
   // checking for token loss

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.h
@@ -12,10 +12,9 @@
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_TRACERV(FUNC, IDX)                                         \
-  TRACERVBRIDGEMODULE_##IDX##_substruct_create;                                \
   FUNC(new tracerv_t(this,                                                     \
                      args,                                                     \
-                     TRACERVBRIDGEMODULE_##IDX##_substruct,                    \
+                     TRACERVBRIDGEMODULE_##IDX##_substruct_create,             \
                      TRACERVBRIDGEMODULE_##IDX##_to_cpu_stream_idx,            \
                      TRACERVBRIDGEMODULE_##IDX##_to_cpu_stream_depth,          \
                      TRACERVBRIDGEMODULE_##IDX##_max_core_ipc,                 \
@@ -30,7 +29,7 @@ class tracerv_t : public bridge_driver_t
 public:
   tracerv_t(simif_t *sim,
             std::vector<std::string> &args,
-            TRACERVBRIDGEMODULE_struct *mmio_addrs,
+            const TRACERVBRIDGEMODULE_struct &mmio_addrs,
             const int stream_idx,
             const int stream_depth,
             const unsigned int max_core_ipc,
@@ -47,7 +46,7 @@ public:
   virtual void finish() { flush(); };
 
 private:
-  TRACERVBRIDGEMODULE_struct *mmio_addrs;
+  const TRACERVBRIDGEMODULE_struct mmio_addrs;
   const int stream_idx;
   const int stream_depth;
   const int max_core_ipc;

--- a/sim/firesim-lib/src/main/cc/bridges/uart.h
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.h
@@ -17,7 +17,7 @@
 #ifdef UARTBRIDGEMODULE_struct_guard
 class uart_t : public bridge_driver_t {
 public:
-  uart_t(simif_t *sim, UARTBRIDGEMODULE_struct *mmio_addrs, int uartno);
+  uart_t(simif_t *sim, const UARTBRIDGEMODULE_struct &mmio_addrs, int uartno);
   ~uart_t();
   virtual void tick();
   // Our UART bridge's initialzation and teardown procedures don't
@@ -32,7 +32,7 @@ public:
   virtual int exit_code() { return 0; }
 
 private:
-  UARTBRIDGEMODULE_struct *mmio_addrs;
+  const UARTBRIDGEMODULE_struct &mmio_addrs;
   serial_data_t<char> data;
   int inputfd;
   int outputfd;

--- a/sim/midas/src/main/cc/bridges/autocounter.cc
+++ b/sim/midas/src/main/cc/bridges/autocounter.cc
@@ -18,7 +18,7 @@
 
 autocounter_t::autocounter_t(simif_t *sim,
                              std::vector<std::string> &args,
-                             AUTOCOUNTERBRIDGEMODULE_struct *mmio_addrs,
+                             const AUTOCOUNTERBRIDGEMODULE_struct &mmio_addrs,
                              AddressMap addr_map,
                              const uint32_t event_count,
                              const char *const *event_types,
@@ -88,14 +88,14 @@ See the AutoCounter documentation on Reset And Timing Considerations for discuss
   emit_autocounter_header();
 }
 
-autocounter_t::~autocounter_t() { free(this->mmio_addrs); }
+autocounter_t::~autocounter_t() {}
 
 void autocounter_t::init() {
   // Decrement the readrate by one to simplify the HW a little bit
   write(addr_map.w_registers.at("readrate_low"),
         (readrate - 1) & ((1ULL << 32) - 1));
   write(addr_map.w_registers.at("readrate_high"), this->readrate >> 32);
-  write(mmio_addrs->init_done, 1);
+  write(mmio_addrs.init_done, 1);
 }
 
 std::string

--- a/sim/midas/src/main/cc/bridges/autocounter.h
+++ b/sim/midas/src/main/cc/bridges/autocounter.h
@@ -12,11 +12,10 @@ constexpr int autocounter_csv_format_version = 1;
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_AUTOCOUNTER(FUNC, IDX)                                     \
-  AUTOCOUNTERBRIDGEMODULE_##IDX##_substruct_create;                            \
   FUNC(new autocounter_t(                                                      \
       this,                                                                    \
       args,                                                                    \
-      AUTOCOUNTERBRIDGEMODULE_##IDX##_substruct,                               \
+      AUTOCOUNTERBRIDGEMODULE_##IDX##_substruct_create,                        \
       AddressMap(                                                              \
           AUTOCOUNTERBRIDGEMODULE_##IDX##_R_num_registers,                     \
           (const unsigned int *)AUTOCOUNTERBRIDGEMODULE_##IDX##_R_addrs,       \
@@ -42,7 +41,7 @@ class autocounter_t : public bridge_driver_t {
 public:
   autocounter_t(simif_t *sim,
                 std::vector<std::string> &args,
-                AUTOCOUNTERBRIDGEMODULE_struct *mmio_addrs,
+                const AUTOCOUNTERBRIDGEMODULE_struct &mmio_addrs,
                 AddressMap addr_map,
                 const uint32_t event_count,
                 const char *const *event_types,
@@ -65,8 +64,7 @@ public:
   virtual void finish();
 
 private:
-  simif_t *sim;
-  AUTOCOUNTERBRIDGEMODULE_struct *mmio_addrs;
+  const AUTOCOUNTERBRIDGEMODULE_struct mmio_addrs;
   AddressMap addr_map;
   const uint32_t event_count;
   std::vector<std::string> event_types;

--- a/sim/midas/src/main/cc/bridges/plusargs.cc
+++ b/sim/midas/src/main/cc/bridges/plusargs.cc
@@ -23,7 +23,7 @@
  */
 plusargs_t::plusargs_t(simif_t *sim,
                        std::vector<std::string> &args,
-                       PLUSARGSBRIDGEMODULE_struct *mmio_addrs,
+                       const PLUSARGSBRIDGEMODULE_struct &mmio_addrs,
                        const std::string_view name_orig,
                        const char *default_value,
                        const uint32_t bit_width,
@@ -82,7 +82,7 @@ plusargs_t::plusargs_t(simif_t *sim,
   }
 }
 
-plusargs_t::~plusargs_t() { free(this->mmio_addrs); }
+plusargs_t::~plusargs_t() { }
 
 /**
  * Check if the overriden value was driven.
@@ -126,7 +126,7 @@ void plusargs_t::init() {
   }
 
   // after all registers are handled, set this
-  write(this->mmio_addrs->initDone, 1);
+  write(mmio_addrs.initDone, 1);
 }
 
 #endif

--- a/sim/midas/src/main/cc/bridges/plusargs.h
+++ b/sim/midas/src/main/cc/bridges/plusargs.h
@@ -11,18 +11,14 @@
 #include <string_view>
 
 #define INSTANTIATE_PLUSARGS(FUNC, IDX)                                        \
-  FUNC(new plusargs_t(                                                         \
-      this,                                                                    \
-      args,                                                                    \
-      []() {                                                                   \
-        PLUSARGSBRIDGEMODULE_##IDX##_substruct_create;                         \
-        return PLUSARGSBRIDGEMODULE_##IDX##_substruct;                         \
-      }(),                                                                     \
-      PLUSARGSBRIDGEMODULE_##IDX##_name,                                       \
-      PLUSARGSBRIDGEMODULE_##IDX##_default,                                    \
-      PLUSARGSBRIDGEMODULE_##IDX##_width,                                      \
-      PLUSARGSBRIDGEMODULE_##IDX##_slice_count,                                \
-      PLUSARGSBRIDGEMODULE_##IDX##_slice_addrs));
+  FUNC(new plusargs_t(this,                                                    \
+                      args,                                                    \
+                      PLUSARGSBRIDGEMODULE_##IDX##_substruct_create,           \
+                      PLUSARGSBRIDGEMODULE_##IDX##_name,                       \
+                      PLUSARGSBRIDGEMODULE_##IDX##_default,                    \
+                      PLUSARGSBRIDGEMODULE_##IDX##_width,                      \
+                      PLUSARGSBRIDGEMODULE_##IDX##_slice_count,                \
+                      PLUSARGSBRIDGEMODULE_##IDX##_slice_addrs));
 
 /**
  * @brief PlusArgs Bridge Driver class
@@ -37,7 +33,7 @@ class plusargs_t : public bridge_driver_t {
 public:
   plusargs_t(simif_t *sim,
              std::vector<std::string> &args,
-             PLUSARGSBRIDGEMODULE_struct *mmio_addrs,
+             const PLUSARGSBRIDGEMODULE_struct &mmio_addrs,
              const std::string_view name,
              const char *default_value,
              const uint32_t bit_width,
@@ -53,7 +49,7 @@ public:
   bool get_overridden();
 
 private:
-  PLUSARGSBRIDGEMODULE_struct *mmio_addrs;
+  const PLUSARGSBRIDGEMODULE_struct mmio_addrs;
   mpz_t value;            // either the default or the PlusArg value
   bool overriden = false; // true if the PlusArg was found and parsed
   const uint32_t slice_count = 0;

--- a/sim/midas/src/main/cc/bridges/reset_pulse.cc
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.cc
@@ -4,7 +4,7 @@
 
 reset_pulse_t::reset_pulse_t(simif_t *sim,
                              std::vector<std::string> &args,
-                             RESETPULSEBRIDGEMODULE_struct *mmio_addrs,
+                             const RESETPULSEBRIDGEMODULE_struct &mmio_addrs,
                              unsigned int max_pulse_length,
                              unsigned int default_pulse_length,
                              int reset_index)
@@ -33,8 +33,8 @@ reset_pulse_t::reset_pulse_t(simif_t *sim,
 }
 
 void reset_pulse_t::init() {
-  write(this->mmio_addrs->pulseLength, this->pulse_length);
-  write(this->mmio_addrs->doneInit, 1);
+  write(mmio_addrs.pulseLength, this->pulse_length);
+  write(mmio_addrs.doneInit, 1);
 }
 
 #endif // RESETPULSEBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/reset_pulse.h
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.h
@@ -9,10 +9,9 @@
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_RESET_PULSE(FUNC, IDX)                                     \
-  RESETPULSEBRIDGEMODULE_##IDX##_substruct_create;                             \
   FUNC(new reset_pulse_t(this,                                                 \
                          args,                                                 \
-                         RESETPULSEBRIDGEMODULE_##IDX##_substruct,             \
+                         RESETPULSEBRIDGEMODULE_##IDX##_substruct_create,      \
                          RESETPULSEBRIDGEMODULE_##IDX##_max_pulse_length,      \
                          RESETPULSEBRIDGEMODULE_##IDX##_default_pulse_length,  \
                          IDX));
@@ -22,7 +21,7 @@ class reset_pulse_t : public bridge_driver_t {
 public:
   reset_pulse_t(simif_t *sim,
                 std::vector<std::string> &args,
-                RESETPULSEBRIDGEMODULE_struct *mmio_addrs,
+                const RESETPULSEBRIDGEMODULE_struct &mmio_addrs,
                 unsigned int max_pulse_length,
                 unsigned int default_pulse_length,
                 int reset_index);
@@ -34,7 +33,7 @@ public:
   virtual void finish(){};
 
 private:
-  RESETPULSEBRIDGEMODULE_struct *mmio_addrs;
+  const RESETPULSEBRIDGEMODULE_struct mmio_addrs;
   const unsigned int max_pulse_length;
   const unsigned int default_pulse_length;
 

--- a/sim/midas/src/main/cc/bridges/synthesized_assertions.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_assertions.cc
@@ -7,7 +7,7 @@
 synthesized_assertions_t::synthesized_assertions_t(
     simif_t *sim,
     std::vector<std::string> &args,
-    ASSERTBRIDGEMODULE_struct *mmio_addrs,
+    const ASSERTBRIDGEMODULE_struct &mmio_addrs,
     const char *const *msgs)
     : bridge_driver_t(sim), mmio_addrs(mmio_addrs), msgs(msgs) {
   for (auto &arg : args) {
@@ -16,23 +16,21 @@ synthesized_assertions_t::synthesized_assertions_t(
   }
 }
 
-synthesized_assertions_t::~synthesized_assertions_t() {
-  free(this->mmio_addrs);
-}
+synthesized_assertions_t::~synthesized_assertions_t() {}
 
 void synthesized_assertions_t::init() {
-  write(this->mmio_addrs->enable, this->enable);
+  write(mmio_addrs.enable, this->enable);
 }
 
 void synthesized_assertions_t::tick() {
   if (!enable)
     return;
 
-  if (read(this->mmio_addrs->fire)) {
+  if (read(mmio_addrs.fire)) {
     // Read assertion information
-    assert_cycle = read(this->mmio_addrs->cycle_low);
-    assert_cycle |= ((uint64_t)read(this->mmio_addrs->cycle_high)) << 32;
-    assert_id = read(this->mmio_addrs->id);
+    assert_cycle = read(mmio_addrs.cycle_low);
+    assert_cycle |= ((uint64_t)read(mmio_addrs.cycle_high)) << 32;
+    assert_id = read(mmio_addrs.id);
     std::cerr << this->msgs[assert_id];
     std::cerr << " at cycle: " << assert_cycle << std::endl;
     assert_fired = true;
@@ -41,7 +39,7 @@ void synthesized_assertions_t::tick() {
 
 void synthesized_assertions_t::resume() {
   assert_fired = false;
-  write(this->mmio_addrs->resume, 1);
+  write(mmio_addrs.resume, 1);
 }
 
 #endif // ASSERTBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/synthesized_assertions.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_assertions.h
@@ -9,7 +9,7 @@ class synthesized_assertions_t : public bridge_driver_t {
 public:
   synthesized_assertions_t(simif_t *sim,
                            std::vector<std::string> &args,
-                           ASSERTBRIDGEMODULE_struct *mmio_addrs,
+                           const ASSERTBRIDGEMODULE_struct &mmio_addrs,
                            const char *const *msgs);
   ~synthesized_assertions_t();
   virtual void init();
@@ -25,7 +25,7 @@ private:
   bool enable = true;
   int assert_id;
   uint64_t assert_cycle;
-  ASSERTBRIDGEMODULE_struct *mmio_addrs;
+  const ASSERTBRIDGEMODULE_struct mmio_addrs;
   const char *const *msgs;
 };
 

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.cc
@@ -5,22 +5,23 @@
 
 #include "synthesized_prints.h"
 
-synthesized_prints_t::synthesized_prints_t(simif_t *sim,
-                                           std::vector<std::string> &args,
-                                           PRINTBRIDGEMODULE_struct *mmio_addrs,
-                                           unsigned int print_count,
-                                           unsigned int token_bytes,
-                                           unsigned int idle_cycles_mask,
-                                           const unsigned int *print_offsets,
-                                           const char *const *format_strings,
-                                           const unsigned int *argument_counts,
-                                           const unsigned int *argument_widths,
-                                           unsigned int stream_idx,
-                                           unsigned int stream_depth,
-                                           const char *const clock_domain_name,
-                                           const unsigned int clock_multiplier,
-                                           const unsigned int clock_divisor,
-                                           int printno)
+synthesized_prints_t::synthesized_prints_t(
+    simif_t *sim,
+    std::vector<std::string> &args,
+    const PRINTBRIDGEMODULE_struct &mmio_addrs,
+    unsigned int print_count,
+    unsigned int token_bytes,
+    unsigned int idle_cycles_mask,
+    const unsigned int *print_offsets,
+    const char *const *format_strings,
+    const unsigned int *argument_counts,
+    const unsigned int *argument_widths,
+    unsigned int stream_idx,
+    unsigned int stream_depth,
+    const char *const clock_domain_name,
+    const unsigned int clock_multiplier,
+    const unsigned int clock_divisor,
+    int printno)
     : bridge_driver_t(sim), mmio_addrs(mmio_addrs), print_count(print_count),
       token_bytes(token_bytes), idle_cycles_mask(idle_cycles_mask),
       print_offsets(print_offsets), format_strings(format_strings),
@@ -138,7 +139,6 @@ synthesized_prints_t::synthesized_prints_t(simif_t *sim,
 };
 
 synthesized_prints_t::~synthesized_prints_t() {
-  free(this->mmio_addrs);
   for (size_t i = 0; i < print_count; i++) {
     delete masks[i];
   }
@@ -146,11 +146,11 @@ synthesized_prints_t::~synthesized_prints_t() {
 
 void synthesized_prints_t::init() {
   // Set the bounds in the widget
-  write(this->mmio_addrs->startCycleL, this->start_cycle);
-  write(this->mmio_addrs->startCycleH, this->start_cycle >> 32);
-  write(this->mmio_addrs->endCycleL, this->end_cycle);
-  write(this->mmio_addrs->endCycleH, this->end_cycle >> 32);
-  write(this->mmio_addrs->doneInit, 1);
+  write(mmio_addrs.startCycleL, this->start_cycle);
+  write(mmio_addrs.startCycleH, this->start_cycle >> 32);
+  write(mmio_addrs.endCycleL, this->end_cycle);
+  write(mmio_addrs.endCycleH, this->end_cycle >> 32);
+  write(mmio_addrs.doneInit, 1);
 }
 
 // Accepts the format string, and the masked arguments, and emits the formatted
@@ -313,7 +313,7 @@ void synthesized_prints_t::flush() {
   // If multiple tokens are being packed into a single stream beat, force the
   // widget to write out any incomplete beat
   if (token_bytes < beat_bytes) {
-    write(mmio_addrs->flushNarrowPacket, 1);
+    write(mmio_addrs.flushNarrowPacket, 1);
 
     // On an FPGA reading from the stream will have enough latency that
     // process_tokens will return non-zero on the first attempt, introducing no

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.h
@@ -13,10 +13,9 @@
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_PRINTF(FUNC, IDX)                                          \
-  PRINTBRIDGEMODULE_##IDX##_substruct_create;                                  \
   FUNC(new synthesized_prints_t(this,                                          \
                                 args,                                          \
-                                PRINTBRIDGEMODULE_##IDX##_substruct,           \
+                                PRINTBRIDGEMODULE_##IDX##_substruct_create,    \
                                 PRINTBRIDGEMODULE_##IDX##_print_count,         \
                                 PRINTBRIDGEMODULE_##IDX##_token_bytes,         \
                                 PRINTBRIDGEMODULE_##IDX##_idle_cycles_mask,    \
@@ -46,7 +45,7 @@ class synthesized_prints_t : public bridge_driver_t {
 public:
   synthesized_prints_t(simif_t *sim,
                        std::vector<std::string> &args,
-                       PRINTBRIDGEMODULE_struct *mmio_addrs,
+                       const PRINTBRIDGEMODULE_struct &mmio_addrs,
                        unsigned int print_count,
                        unsigned int token_bytes,
                        unsigned int idle_cycles_mask,
@@ -69,7 +68,7 @@ public:
   void finish() { flush(); };
 
 private:
-  PRINTBRIDGEMODULE_struct *mmio_addrs;
+  const PRINTBRIDGEMODULE_struct mmio_addrs;
   const unsigned int print_count;
   const unsigned int token_bytes;
   const unsigned int idle_cycles_mask;

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -56,9 +56,9 @@ private:
   // random numbers
   uint64_t seed;
   std::mt19937_64 gen;
-  SIMULATIONMASTER_struct *master_mmio_addrs;
-  LOADMEMWIDGET_struct *loadmem_mmio_addrs;
-  CLOCKBRIDGEMODULE_struct *clock_bridge_mmio_addrs;
+  const SIMULATIONMASTER_struct master_mmio_addrs;
+  const LOADMEMWIDGET_struct loadmem_mmio_addrs;
+  const CLOCKBRIDGEMODULE_struct clock_bridge_mmio_addrs;
   midas_time_t start_time, end_time;
   uint64_t start_hcycle = -1;
   uint64_t end_hcycle = 0;
@@ -69,9 +69,9 @@ private:
 public:
   // Simulation APIs
   virtual void init(int argc, char **argv);
-  inline bool done() { return read(this->master_mmio_addrs->DONE); }
+  inline bool done() { return read(master_mmio_addrs.DONE); }
   inline void take_steps(size_t n, bool blocking) {
-    write(this->master_mmio_addrs->STEP, n);
+    write(master_mmio_addrs.STEP, n);
     if (blocking)
       while (!done())
         ;

--- a/sim/midas/src/main/scala/midas/widgets/Lib.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Lib.scala
@@ -248,14 +248,11 @@ class MCRFileMap(bytesPerAddress: Int) {
     sb append s"#define ${prefix}_PRESENT\n"
 
     // emit macro to create a version of this struct with values filled in
-    sb append s"#define ${prefix}_substruct_create \\\n"
-    // assume the widget destructor will free this
-    sb append s"${prefix_no_num}_struct * ${prefix}_substruct = (${prefix_no_num}_struct *) malloc(sizeof(${prefix_no_num}_struct)); \\\n"
+    sb append s"#define ${prefix}_substruct_create (${prefix_no_num}_struct{ \\\n"
     filteredRegs foreach { case (regName, localAddress) =>
-      val address = base + localAddress
-      sb append s"${prefix}_substruct->${regName} = ${address}; \\\n"
+      sb append s"${base + localAddress}, \\\n"
     }
-    sb append s"\n"
+    sb append s"})\n"
   }
 
   // A variation of above which dumps the register map as a series of arrays

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -50,43 +50,33 @@ firesim_top_t::firesim_top_t(int argc, char **argv) {
   // Golden Gate emits a <BridgeModuleClassName>_<id>_PRESENT macro for each
   // instance which you may use to conditionally instantiate your driver
 #ifdef UARTBRIDGEMODULE_0_PRESENT
-  // Create an instance of the constructor argument (this has all of
-  // addresses of the BridgeModule's memory mapped registers)
-  UARTBRIDGEMODULE_0_substruct_create;
   // Instantiate the driver; register it in the main simulation class
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_0_substruct, 0));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_0_substruct_create, 0));
 #endif
 
 // Repeat the code above with modified indices as many times as necessary
 // to support the maximum expected number of bridge instances
 #ifdef UARTBRIDGEMODULE_1_PRESENT
-  UARTBRIDGEMODULE_1_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_1_substruct, 1));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_1_substruct_create, 1));
 #endif
   // DOC include end: UART Bridge Driver Registration
 #ifdef UARTBRIDGEMODULE_2_PRESENT
-  UARTBRIDGEMODULE_2_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_2_substruct, 2));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_2_substruct_create, 2));
 #endif
 #ifdef UARTBRIDGEMODULE_3_PRESENT
-  UARTBRIDGEMODULE_3_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_3_substruct, 3));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_3_substruct_create, 3));
 #endif
 #ifdef UARTBRIDGEMODULE_4_PRESENT
-  UARTBRIDGEMODULE_4_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_4_substruct, 4));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_4_substruct_create, 4));
 #endif
 #ifdef UARTBRIDGEMODULE_5_PRESENT
-  UARTBRIDGEMODULE_5_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_5_substruct, 5));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_5_substruct_create, 5));
 #endif
 #ifdef UARTBRIDGEMODULE_6_PRESENT
-  UARTBRIDGEMODULE_6_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_6_substruct, 6));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_6_substruct_create, 6));
 #endif
 #ifdef UARTBRIDGEMODULE_7_PRESENT
-  UARTBRIDGEMODULE_7_substruct_create;
-  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_7_substruct, 7));
+  add_bridge_driver(new uart_t(this, UARTBRIDGEMODULE_7_substruct_create, 7));
 #endif
 
 #ifdef FASEDMEMORYTIMINGMODEL_0
@@ -189,75 +179,67 @@ firesim_top_t::firesim_top_t(int argc, char **argv) {
 
 #ifdef BLOCKDEVBRIDGEMODULE_struct_guard
 #ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
-  BLOCKDEVBRIDGEMODULE_0_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_0_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_0_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_0_substruct,
+                                   BLOCKDEVBRIDGEMODULE_0_substruct_create,
                                    0));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_1_PRESENT
-  BLOCKDEVBRIDGEMODULE_1_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_1_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_1_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_1_substruct,
+                                   BLOCKDEVBRIDGEMODULE_1_substruct_create,
                                    1));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_2_PRESENT
-  BLOCKDEVBRIDGEMODULE_2_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_2_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_2_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_2_substruct,
+                                   BLOCKDEVBRIDGEMODULE_2_substruct_create,
                                    2));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_3_PRESENT
-  BLOCKDEVBRIDGEMODULE_3_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_3_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_3_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_3_substruct,
+                                   BLOCKDEVBRIDGEMODULE_3_substruct_create,
                                    3));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_4_PRESENT
-  BLOCKDEVBRIDGEMODULE_4_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_4_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_4_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_4_substruct,
+                                   BLOCKDEVBRIDGEMODULE_4_substruct_create,
                                    4));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_5_PRESENT
-  BLOCKDEVBRIDGEMODULE_5_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_5_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_5_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_5_substruct,
+                                   BLOCKDEVBRIDGEMODULE_5_substruct_create,
                                    5));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_6_PRESENT
-  BLOCKDEVBRIDGEMODULE_6_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_6_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_6_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_6_substruct,
+                                   BLOCKDEVBRIDGEMODULE_6_substruct_create,
                                    6));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_7_PRESENT
-  BLOCKDEVBRIDGEMODULE_7_substruct_create;
   add_bridge_driver(new blockdev_t(this,
                                    args,
                                    BLOCKDEVBRIDGEMODULE_7_num_trackers,
                                    BLOCKDEVBRIDGEMODULE_7_latency_bits,
-                                   BLOCKDEVBRIDGEMODULE_7_substruct,
+                                   BLOCKDEVBRIDGEMODULE_7_substruct_create,
                                    7));
 #endif
 #endif
@@ -390,7 +372,6 @@ firesim_top_t::firesim_top_t(int argc, char **argv) {
 
 #ifdef DROMAJOBRIDGEMODULE_struct_guard
 #ifdef DROMAJOBRIDGEMODULE_0_PRESENT
-  DROMAJOBRIDGEMODULE_0_substruct_create;
     add_bridge_driver(new dromajo_t(
             this, args,
             DROMAJOBRIDGEMODULE_0_iaddr_width,
@@ -399,7 +380,7 @@ firesim_top_t::firesim_top_t(int argc, char **argv) {
             DROMAJOBRIDGEMODULE_0_cause_width,
             DROMAJOBRIDGEMODULE_0_tval_width,
             DROMAJOBRIDGEMODULE_0_num_traces,
-            DROMAJOBRIDGEMODULE_0_substruct,
+            DROMAJOBRIDGEMODULE_0_substruct_create,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_dma_address,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_count_address,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_full_address)
@@ -408,44 +389,36 @@ firesim_top_t::firesim_top_t(int argc, char **argv) {
 
 #ifdef GROUNDTESTBRIDGEMODULE_struct_guard
 #ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
-    GROUNDTESTBRIDGEMODULE_0_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_0_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_0_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_1_PRESENT
-    GROUNDTESTBRIDGEMODULE_1_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_1_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_1_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_2_PRESENT
-    GROUNDTESTBRIDGEMODULE_2_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_2_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_2_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_3_PRESENT
-    GROUNDTESTBRIDGEMODULE_3_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_3_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_3_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_4_PRESENT
-    GROUNDTESTBRIDGEMODULE_4_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_4_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_4_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_5_PRESENT
-    GROUNDTESTBRIDGEMODULE_5_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_5_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_5_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_6_PRESENT
-    GROUNDTESTBRIDGEMODULE_6_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_6_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_6_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_7_PRESENT
-    GROUNDTESTBRIDGEMODULE_7_substruct_create;
     add_bridge_driver(new groundtest_t(
-            this, args, GROUNDTESTBRIDGEMODULE_7_substruct));
+            this, args, GROUNDTESTBRIDGEMODULE_7_substruct_create));
 #endif
 #endif
 
@@ -475,51 +448,43 @@ firesim_top_t::firesim_top_t(int argc, char **argv) {
 #endif
 
 #ifdef ASSERTBRIDGEMODULE_0_PRESENT
-    ASSERTBRIDGEMODULE_0_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_0_substruct,
+                                                   ASSERTBRIDGEMODULE_0_substruct_create,
                                                    ASSERTBRIDGEMODULE_0_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_1_PRESENT
-    ASSERTBRIDGEMODULE_1_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_1_substruct,
+                                                   ASSERTBRIDGEMODULE_1_substruct_create,
                                                    ASSERTBRIDGEMODULE_1_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_2_PRESENT
-    ASSERTBRIDGEMODULE_2_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_2_substruct,
+                                                   ASSERTBRIDGEMODULE_2_substruct_create,
                                                    ASSERTBRIDGEMODULE_2_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_3_PRESENT
-    ASSERTBRIDGEMODULE_3_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_3_substruct,
+                                                   ASSERTBRIDGEMODULE_3_substruct_create,
                                                    ASSERTBRIDGEMODULE_3_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_4_PRESENT
-    ASSERTBRIDGEMODULE_4_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_4_substruct,
+                                                   ASSERTBRIDGEMODULE_4_substruct_create,
                                                    ASSERTBRIDGEMODULE_4_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_5_PRESENT
-    ASSERTBRIDGEMODULE_5_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_5_substruct,
+                                                   ASSERTBRIDGEMODULE_5_substruct_create,
                                                    ASSERTBRIDGEMODULE_5_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_6_PRESENT
-    ASSERTBRIDGEMODULE_6_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_6_substruct,
+                                                   ASSERTBRIDGEMODULE_6_substruct_create,
                                                    ASSERTBRIDGEMODULE_6_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_7_PRESENT
-    ASSERTBRIDGEMODULE_7_substruct_create
     add_bridge_driver(new synthesized_assertions_t(this, args,
-                                                   ASSERTBRIDGEMODULE_7_substruct,
+                                                   ASSERTBRIDGEMODULE_7_substruct_create,
                                                    ASSERTBRIDGEMODULE_7_assert_messages));
 #endif
 

--- a/sim/src/main/cc/midasexamples/AssertModule.h
+++ b/sim/src/main/cc/midasexamples/AssertModule.h
@@ -7,12 +7,11 @@ class AssertModule_t : public simif_peek_poke_t {
 public:
   synthesized_assertions_t *assert_endpoint;
   AssertModule_t(int argc, char **argv) {
-    ASSERTBRIDGEMODULE_0_substruct_create;
     std::vector<std::string> args(argv + 1, argv + argc);
     assert_endpoint =
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_0_substruct,
+                                     ASSERTBRIDGEMODULE_0_substruct_create,
                                      ASSERTBRIDGEMODULE_0_assert_messages);
   };
   void run() {

--- a/sim/src/main/cc/midasexamples/AssertTorture.h
+++ b/sim/src/main/cc/midasexamples/AssertTorture.h
@@ -11,59 +11,59 @@ public:
   AssertTorture_t(int argc, char **argv) {
     std::vector<std::string> args(argv + 1, argv + argc);
 #ifdef ASSERTBRIDGEMODULE_0_PRESENT
-    ASSERTBRIDGEMODULE_0_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_0_substruct,
+                                     ASSERTBRIDGEMODULE_0_substruct_create,
                                      ASSERTBRIDGEMODULE_0_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_1_PRESENT
-    ASSERTBRIDGEMODULE_1_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_1_substruct,
+                                     ASSERTBRIDGEMODULE_1_substruct_create,
                                      ASSERTBRIDGEMODULE_1_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_2_PRESENT
-    ASSERTBRIDGEMODULE_2_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_2_substruct,
+                                     ASSERTBRIDGEMODULE_2_substruct_create,
                                      ASSERTBRIDGEMODULE_2_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_3_PRESENT
-    ASSERTBRIDGEMODULE_3_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_3_substruct,
+                                     ASSERTBRIDGEMODULE_3_substruct_create,
                                      ASSERTBRIDGEMODULE_3_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_4_PRESENT
-    ASSERTBRIDGEMODULE_4_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_4_substruct,
+                                     ASSERTBRIDGEMODULE_4_substruct_create,
                                      ASSERTBRIDGEMODULE_4_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_5_PRESENT
-    ASSERTBRIDGEMODULE_5_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_5_substruct,
+                                     ASSERTBRIDGEMODULE_5_substruct_create,
                                      ASSERTBRIDGEMODULE_5_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_6_PRESENT
-    ASSERTBRIDGEMODULE_6_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_6_substruct,
+                                     ASSERTBRIDGEMODULE_6_substruct_create,
                                      ASSERTBRIDGEMODULE_6_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_7_PRESENT
-    ASSERTBRIDGEMODULE_7_substruct_create assert_endpoints.push_back(
+    assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_7_substruct,
+                                     ASSERTBRIDGEMODULE_7_substruct_create,
                                      ASSERTBRIDGEMODULE_7_assert_messages));
 #endif
   };

--- a/sim/src/main/cc/midasexamples/MulticlockAssertModule.h
+++ b/sim/src/main/cc/midasexamples/MulticlockAssertModule.h
@@ -10,17 +10,15 @@ public:
   synthesized_assertions_t *half_rate_assert_ep;
   MulticlockAssertModule_t(int argc, char **argv) {
     std::vector<std::string> args(argv + 1, argv + argc);
-    ASSERTBRIDGEMODULE_0_substruct_create;
-    ASSERTBRIDGEMODULE_1_substruct_create;
     full_rate_assert_ep =
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_0_substruct,
+                                     ASSERTBRIDGEMODULE_0_substruct_create,
                                      ASSERTBRIDGEMODULE_0_assert_messages);
     half_rate_assert_ep =
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_1_substruct,
+                                     ASSERTBRIDGEMODULE_1_substruct_create,
                                      ASSERTBRIDGEMODULE_1_assert_messages);
     assert_endpoints.push_back(full_rate_assert_ep);
     assert_endpoints.push_back(half_rate_assert_ep);

--- a/sim/src/main/cc/midasexamples/TerminationModule.h
+++ b/sim/src/main/cc/midasexamples/TerminationModule.h
@@ -9,11 +9,10 @@ class TerminationModule_t : public simif_peek_poke_t {
 public:
   termination_t *terminator;
   TerminationModule_t(int argc, char **argv) {
-    TERMINATIONBRIDGEMODULE_0_substruct_create;
     std::vector<std::string> args(argv + 1, argv + argc);
     terminator = new termination_t(this,
                                    args,
-                                   TERMINATIONBRIDGEMODULE_0_substruct,
+                                   TERMINATIONBRIDGEMODULE_0_substruct_create,
                                    TERMINATIONBRIDGEMODULE_0_message_count,
                                    TERMINATIONBRIDGEMODULE_0_message_type,
                                    TERMINATIONBRIDGEMODULE_0_message);

--- a/sim/src/main/cc/midasexamples/TriggerWiringModule.h
+++ b/sim/src/main/cc/midasexamples/TriggerWiringModule.h
@@ -8,17 +8,15 @@ public:
   std::vector<synthesized_assertions_t *> assert_endpoints;
   TriggerWiringModule_t(int argc, char **argv) {
     std::vector<std::string> args(argv + 1, argv + argc);
-    ASSERTBRIDGEMODULE_0_substruct_create;
-    ASSERTBRIDGEMODULE_1_substruct_create;
     assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_0_substruct,
+                                     ASSERTBRIDGEMODULE_0_substruct_create,
                                      ASSERTBRIDGEMODULE_0_assert_messages));
     assert_endpoints.push_back(
         new synthesized_assertions_t(this,
                                      args,
-                                     ASSERTBRIDGEMODULE_1_substruct,
+                                     ASSERTBRIDGEMODULE_1_substruct_create,
                                      ASSERTBRIDGEMODULE_1_assert_messages));
   };
   bool simulation_complete() {

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.cc
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.cc
@@ -4,10 +4,8 @@
 
 #include "simif_peek_poke.h"
 
-simif_peek_poke_t::simif_peek_poke_t() {
-  PEEKPOKEBRIDGEMODULE_0_substruct_create;
-  this->defaultiowidget_mmio_addrs = PEEKPOKEBRIDGEMODULE_0_substruct;
-}
+simif_peek_poke_t::simif_peek_poke_t()
+    : defaultiowidget_mmio_addrs(PEEKPOKEBRIDGEMODULE_0_substruct_create) {}
 
 void simif_peek_poke_t::target_reset(int pulse_length) {
   poke(reset, 1);

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.h
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.h
@@ -53,7 +53,7 @@ private:
   uint64_t t = 0;
   uint64_t fail_t = 0;
 
-  PEEKPOKEBRIDGEMODULE_struct *defaultiowidget_mmio_addrs;
+  const PEEKPOKEBRIDGEMODULE_struct defaultiowidget_mmio_addrs;
 
   bool wait_on(size_t flag_addr, double timeout) {
     midas_time_t start = timestamp();
@@ -64,11 +64,11 @@ private:
   }
 
   bool wait_on_ready(double timeout) {
-    return wait_on(this->defaultiowidget_mmio_addrs->READY, timeout);
+    return wait_on(defaultiowidget_mmio_addrs.READY, timeout);
   }
 
   bool wait_on_stable_peeks(double timeout) {
-    return wait_on(this->defaultiowidget_mmio_addrs->PRECISE_PEEKABLE, timeout);
+    return wait_on(defaultiowidget_mmio_addrs.PRECISE_PEEKABLE, timeout);
   }
 
   std::string blocking_fail = "The test environment has starved the simulator, "


### PR DESCRIPTION
Minor cleanup to help fix memory leaks and avoid raw pointers.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Macros instantiating bridge parameters are removed in favour of a single macro creating a structure as a value, which is then passed on to constructor and saved in the bridges themselves. With this method, ownership is clear and missing calls to `free` no longer lead to leaks.

#### Related PRs / Issues

N/A

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

Changed the `*_substruct_create` macro to directly instantiate an value containing all ports.

#### Verilog / AGFI Compatibility

N/A

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
