### PR TITLE
CI Rework: More Aggressive Culling Of FPGA Resources, Slack/PR Notifications

### DIFF
--- a/.github/scripts/ci_variables.py
+++ b/.github/scripts/ci_variables.py
@@ -1,89 +1,97 @@
 import os
+from typing import TypedDict
 
 # This package contains utilities that rely on environment variable
 # definitions present only on the CI container instance.
 
-# Create a env. dict that is populated from the environment or from defaults
-ci_env = {}
+# environment variables needed by CI
+class CIEnvironment(TypedDict):
+    # If not running under a CI pipeline defaults are provided that
+    # will suffice to run scripts that do not use GHA API calls.
+    # To manually provide environment variable settings, export GITHUB_ACTIONS=true, and provide
+    # values for all of the environment variables listed.
+    GITHUB_ACTIONS: str
 
-# If not running under a CI pipeline defaults are provided that
-# will suffice to run scripts that do not use GHA API calls.
-# To manually provide environment variable settings, export GITHUB_ACTIONS=true, and provide
-# values for all of the environment variables below.
-ci_env['GITHUB_ACTIONS'] = os.environ.get('GITHUB_ACTIONS', "false")
-RUN_LOCAL = ci_env['GITHUB_ACTIONS'] == 'false'
+    # This is used as a unique tag for all instances launched in a workflow
+    GITHUB_RUN_ID: str
+
+    GITHUB_SHA: str
+
+    # Multiple clones of the FireSim repository exists on manager. We expect state
+    # to persist between jobs in a workflow and faciliate that by having jobs run
+    # out of a centralized clone (MANAGER_FIRESIM_LOCATION)-- not the default clones setup by
+    # the GHA runners (GITHUB_WORKSPACE)
+
+    # This is the location of the clone setup by the GHA runner infrastructure by default
+    # expanduser to replace the ~ present in the default, for portability
+    GITHUB_WORKSPACE: str
+
+    # This is the location of the reused clone. CI scripts should refer variables
+    # derived from this path so that they may be reused across workflows that may
+    # initialize the FireSim repository differently (e.g., as a submodule of a
+    # larger project.)
+    MANAGER_FIRESIM_LOCATION: str
+
+    GITHUB_TOKEN: str
+    PERSONAL_ACCESS_TOKEN: str
+    GITHUB_API_URL: str
+
+    # We look this up, instead of hardcoding "firesim/firesim", to support running
+    # this CI pipeline under forks.
+    GITHUB_REPOSITORY: str
+
+    GITHUB_EVENT_PATH: str
+
+    # The following are environment variables used by AWS and AZURE to setup the corresponding
+    # self-hosted Github Actions Runners
+    AWS_ACCESS_KEY_ID: str
+    AWS_SECRET_ACCESS_KEY: str
+    AWS_DEFAULT_REGION: str
+    AZURE_CLIENT_ID: str
+    AZURE_CLIENT_SECRET: str
+    AZURE_TENANT_ID: str
+    AZURE_SUBSCRIPTION_ID: str
+    AZURE_DEFAULT_REGION: str
+    AZURE_RESOURCE_GROUP: str
+    AZURE_CI_SUBNET_ID: str
+    AZURE_CI_NSG_ID: str
+
+    FIRESIM_PEM: str
+    FIRESIM_PEM_PUBLIC: str
+
+RUN_LOCAL = os.environ.get('GITHUB_ACTIONS', 'false') == 'false'
 # When running locally (not in a CI pipeline) run commands out of the clone hosting this file.
 local_fsim_dir = os.path.normpath((os.path.realpath(__file__)) + "/../../..")
 
-# Add list of env. variables to the ci_env dict
-def add_env_vars(env_vars, default_value = ""):
-    for k, v in os.environ.items():
-        if k in env_vars:
-            ci_env[k] = v if not RUN_LOCAL else default_value
+def get_ci_value(env_var: str, default_value: str = "") -> str:
+    if RUN_LOCAL:
+        return default_value
+    else:
+        return os.environ[env_var]
 
-# CI instance environment variables
-
-gh_env_vars = {
-    # This is used as a unique tag for all instances launched in a workflow
-    'GITHUB_RUN_ID',
-    'GITHUB_SHA',
-    }
-add_env_vars(gh_env_vars, 0)
-
-# Multiple clones of the FireSim repository exists on manager. We expect state
-# to persist between jobs in a workflow and faciliate that by having jobs run
-# out of a centralized clone (MANAGER_FIRESIM_LOCATION)-- not the default clones setup by
-# the GHA runners (GITHUB_WORKSPACE)
-
-# This is the location of the clone setup by the GHA runner infrastructure by default
-# expanduser to replace the ~ present in the default, for portability
-ci_env['GITHUB_WORKSPACE'] = os.path.expanduser(os.environ['GITHUB_WORKSPACE']) if not RUN_LOCAL else local_fsim_dir
-
-# This is the location of the reused clone. CI scripts should refer variables
-# derived from this path so that they may be reused across workflows that may
-# initialize the FireSim repository differently (e.g., as a submodule of a
-# larger project.)
-ci_env['MANAGER_FIRESIM_LOCATION'] = os.path.expanduser(os.environ['MANAGER_FIRESIM_LOCATION']) if not RUN_LOCAL else local_fsim_dir
-
-gh_env_vars = {
-    'GITHUB_TOKEN',
-    'PERSONAL_ACCESS_TOKEN',
-    }
-add_env_vars(gh_env_vars, 0)
-
-gh_env_vars = {
-    'GITHUB_API_URL',
-    # We look this up, instead of hardcoding "firesim/firesim", to support running
-    # this CI pipeline under forks.
-    'GITHUB_REPOSITORY',
-    'GITHUB_EVENT_PATH',
-    }
-add_env_vars(gh_env_vars)
-
-# The following are environment variables used by AWS and AZURE to setup the corresponding
-# self-hosted Github Actions Runners
-
-aws_env_vars = {
-    'AWS_ACCESS_KEY_ID',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_DEFAULT_REGION',
-    }
-add_env_vars(aws_env_vars)
-
-azure_env_vars = {
-    'AZURE_CLIENT_ID',
-    'AZURE_CLIENT_SECRET',
-    'AZURE_TENANT_ID',
-    'AZURE_SUBSCRIPTION_ID',
-    'AZURE_DEFAULT_REGION',
-    'AZURE_RESOURCE_GROUP',
-    'AZURE_CI_SUBNET_ID',
-    'AZURE_CI_NSG_ID',
-    }
-add_env_vars(azure_env_vars)
-
-pem_env_vars = {
-    'FIRESIM_PEM',
-    'FIRESIM_PEM_PUBLIC',
-    }
-add_env_vars(pem_env_vars)
+# Create a env. dict that is populated from the environment or from defaults
+ci_env: CIEnvironment = {
+    'GITHUB_ACTIONS': 'false' if RUN_LOCAL else 'true',
+    'GITHUB_RUN_ID': get_ci_value('GITHUB_RUN_ID'),
+    'GITHUB_SHA': get_ci_value('GITHUB_RUN_ID'),
+    'GITHUB_WORKSPACE': os.path.expanduser(os.environ['GITHUB_WORKSPACE']) if not RUN_LOCAL else local_fsim_dir,
+    'MANAGER_FIRESIM_LOCATION': os.path.expanduser(os.environ['MANAGER_FIRESIM_LOCATION']) if not RUN_LOCAL else local_fsim_dir,
+    'GITHUB_TOKEN': get_ci_value('GITHUB_TOKEN'),
+    'PERSONAL_ACCESS_TOKEN': get_ci_value('PERSONAL_ACCESS_TOKEN'),
+    'GITHUB_API_URL': get_ci_value('GITHUB_API_URL'),
+    'GITHUB_REPOSITORY': get_ci_value('GITHUB_REPOSITORY'),
+    'GITHUB_EVENT_PATH': get_ci_value('GITHUB_EVENT_PATH'),
+    'AWS_ACCESS_KEY_ID': get_ci_value('AWS_ACCESS_KEY_ID'),
+    'AWS_SECRET_ACCESS_KEY': get_ci_value('AWS_SECRET_ACCESS_KEY'),
+    'AWS_DEFAULT_REGION': get_ci_value('AWS_DEFAULT_REGION'),
+    'AZURE_CLIENT_ID': get_ci_value('AZURE_CLIENT_ID'),
+    'AZURE_CLIENT_SECRET': get_ci_value('AZURE_CLIENT_SECRET'),
+    'AZURE_TENANT_ID': get_ci_value('AZURE_TENANT_ID'),
+    'AZURE_SUBSCRIPTION_ID': get_ci_value('AZURE_SUBSCRIPTION_ID'),
+    'AZURE_DEFAULT_REGION': get_ci_value('AZURE_DEFAULT_REGION'),
+    'AZURE_RESOURCE_GROUP': get_ci_value('AZURE_RESOURCE_GROUP'),
+    'AZURE_CI_SUBNET_ID': get_ci_value('AZURE_CI_SUBNET_ID'),
+    'AZURE_CI_NSG_ID': get_ci_value('AZURE_CI_NSG_ID'),
+    'FIRESIM_PEM': get_ci_value('FIRESIM_PEM'),
+    'FIRESIM_PEM_PUBLIC': get_ci_value('FIRESIM_PEM_PUBLIC'),
+}

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -1,21 +1,16 @@
-import math
 from fabric.api import *
 import requests
-from ci_variables import ci_gha_api_url, ci_repo_name, ci_firesim_dir
 
-from typing import Dict, List, Any
+from typing import Dict
 
 from platform_lib import PlatformLib, AWSPlatformLib, AzurePlatformLib, Platform
-
-# Github URL related constants
-gha_api_url         = f"{ci_gha_api_url}/repos/{ci_repo_name}/actions"
-gha_runners_api_url = f"{gha_api_url}/runners"
-gha_runs_api_url    = f"{gha_api_url}/runs"
+from ci_variables import ci_env
+from github_common import deregister_runners
 
 # Remote paths
 manager_home_dir = "/home/centos"
 manager_fsim_pem = manager_home_dir + "/firesim.pem"
-manager_fsim_dir = ci_firesim_dir
+manager_fsim_dir = ci_env['MANAGER_FIRESIM_LOCATION']
 manager_marshal_dir = manager_fsim_dir + "/sw/firesim-software"
 manager_ci_dir = manager_fsim_dir + "/.github/scripts"
 
@@ -27,47 +22,8 @@ env.connection_attempts = 10
 env.disable_known_hosts = True
 env.keepalive = 60 # keep long SSH connections running
 
-def set_fabric_firesim_pem():
+def set_fabric_firesim_pem() -> None:
     env.key_filename = manager_fsim_pem
-
-def get_header(gh_token: str) -> Dict[str, str]:
-    return {"Authorization": f"token {gh_token.strip()}", "Accept": "application/vnd.github+json"}
-
-def get_runners(gh_token: str) -> List:
-    r = requests.get(gha_runners_api_url, headers=get_header(gh_token))
-    if r.status_code != 200:
-        raise Exception(f"Unable to retrieve count of GitHub Actions Runners\nFull Response Below:\n{r}")
-    res_dict = r.json()
-    runner_count = res_dict["total_count"]
-
-    runners = []
-    for page_idx in range(math.ceil(runner_count / 30)):
-        r = requests.get(gha_runners_api_url, params={"per_page" : 30, "page" : page_idx + 1}, headers=get_header(gh_token))
-        if r.status_code != 200:
-            raise Exception(f"Unable to retrieve (sub)list of GitHub Actions Runners\nFull Response Below\n{r}")
-        res_dict = r.json()
-        runners = runners + res_dict["runners"]
-
-    return runners
-
-def delete_runner(gh_token: str, runner: Dict[str, Any]) -> bool:
-    r = requests.delete(f"""{gha_runners_api_url}/{runner["id"]}""", headers=get_header(gh_token))
-    if r.status_code != 204:
-        print(f"""Unable to delete runner {runner["name"]} with id: {runner["id"]}\nFull Response Below\n{r}""")
-        return False
-    return True
-
-def deregister_offline_runners(gh_token: str) -> None:
-    runners = get_runners(gh_token)
-    for runner in runners:
-        if runner["status"] == "offline":
-            delete_runner(gh_token, runner)
-
-def deregister_runners(gh_token: str, runner_name: str) -> None:
-    runners = get_runners(gh_token)
-    for runner in runners:
-        if runner_name in runner["name"]:
-            delete_runner(gh_token, runner)
 
 aws_platform_lib = AWSPlatformLib(deregister_runners)
 #azure_platform_lib = AzurePlatformLib(deregister_runners)

--- a/.github/scripts/cull-old-ci-instances.py
+++ b/.github/scripts/cull-old-ci-instances.py
@@ -40,11 +40,11 @@ def cull_aws_instances(current_time: DateTime) -> None:
     # Grab all instances with a CI-generated tag
     aws_platform_lib = get_platform_lib(Platform.AWS)
     all_ci_instances = aws_platform_lib.find_all_ci_instances()
-    select_ci_instances = aws_platform_lib.find_select_ci_instances()
+    run_farm_ci_instances = aws_platform_lib.find_run_farm_ci_instances()
 
     client = boto3.client('ec2')
 
-    instances_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), select_ci_instances))
+    instances_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), run_farm_ci_instances))
     instances_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), all_ci_instances))
     instances_to_terminate = list(set(instances_to_terminate))
 
@@ -60,10 +60,10 @@ def cull_aws_instances(current_time: DateTime) -> None:
 def cull_azure_resources(current_time: DateTime) -> None:
     azure_platform_lib = get_platform_lib(Platform.AZURE)
     all_azure_ci_vms = azure_platform_lib.find_all_ci_instances()
-    select_azure_ci_vms = azure_platform_lib.find_select_ci_instances()
+    run_farm_azure_ci_vms = azure_platform_lib.find_run_farm_ci_instances()
 
     vms_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, \
-        map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), select_azure_ci_vms))
+        map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), run_farm_azure_ci_vms))
     vms_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS, current_time, \
         map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), all_azure_ci_vms))
     vms_to_terminate = list(set(vms_to_terminate))

--- a/.github/scripts/cull-old-ci-instances.py
+++ b/.github/scripts/cull-old-ci-instances.py
@@ -9,17 +9,21 @@ from xmlrpc.client import DateTime
 import pytz
 import boto3
 import sys
+
 from platform_lib import Platform
-from common import deregister_runners, get_platform_lib
+from common import get_platform_lib
+from github_common import deregister_runners
 
 # Reuse manager utilities
-from ci_variables import ci_workdir, ci_personal_api_token, ci_workflow_run_id, ci_azure_sub_id
-sys.path.append(ci_workdir + "/deploy")
+from ci_variables import ci_env
+sys.path.append(ci_env['GITHUB_WORKSPACE'] + "/deploy")
 
-# The number of hours an instance may exist since its initial launch time
+# The number of hours a manager instance may exist since its initial launch time
 INSTANCE_LIFETIME_LIMIT_HOURS = 8
+# The number of hours a fpga instance may exist since its initial launch time
+FPGA_INSTANCE_LIFETIME_LIMIT_HOURS = 1
 
-def find_timed_out_resources(current_time: DateTime, resource_list: Iterable[Tuple]) -> list:
+def find_timed_out_resources(hr_limit: int, current_time: DateTime, resource_list: Iterable[Tuple]) -> list:
     """
     Because of the differences in how AWS and Azure store time tags, the resource_list
     in this case is a list of tuples with the 0 index being the instance/vm and the 1 index
@@ -28,7 +32,7 @@ def find_timed_out_resources(current_time: DateTime, resource_list: Iterable[Tup
     timed_out = []
     for resource_tuple in resource_list:
         lifetime_secs = (current_time - resource_tuple[1]).total_seconds()
-        if lifetime_secs > (INSTANCE_LIFETIME_LIMIT_HOURS * 3600):
+        if lifetime_secs > (hr_limit * 3600):
             timed_out.append(resource_tuple[0])
     return timed_out
 
@@ -36,28 +40,41 @@ def cull_aws_instances(current_time: DateTime) -> None:
     # Grab all instances with a CI-generated tag
     aws_platform_lib = get_platform_lib(Platform.AWS)
     all_ci_instances = aws_platform_lib.find_all_ci_instances()
+    select_ci_instances = aws_platform_lib.find_select_ci_instances()
 
     client = boto3.client('ec2')
 
-    instances_to_terminate = find_timed_out_resources(current_time, map(lambda x: (x, x['LaunchTime']), all_ci_instances))
+    instances_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), select_ci_instances))
+    instances_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), all_ci_instances))
+    instances_to_terminate = list(set(instances_to_terminate))
 
     print("Terminated Instances:")
     for inst in instances_to_terminate:
-        deregister_runners(ci_personal_api_token, f"aws-{ci_workflow_run_id}")
+        deregister_runners(ci_env['PERSONAL_ACCESS_TOKEN'], f"aws-{ci_env['GITHUB_RUN_ID']}")
         client.terminate_instances(InstanceIds=[inst['InstanceId']])
         print("  " + inst['InstanceId'])
+
+    if len(instances_to_terminate > 0):
+        exit(1)
 
 def cull_azure_resources(current_time: DateTime) -> None:
     azure_platform_lib = get_platform_lib(Platform.AZURE)
     all_azure_ci_vms = azure_platform_lib.find_all_ci_instances()
+    select_azure_ci_vms = azure_platform_lib.find_select_ci_instances()
 
-    vms_to_terminate = find_timed_out_resources(current_time, \
+    vms_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, \
+        map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), select_azure_ci_vms))
+    vms_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS, current_time, \
         map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), all_azure_ci_vms))
+    vms_to_terminate = list(set(vms_to_terminate))
 
-    print("VMs:")
+    print("Terminated VMs:")
     for vm in vms_to_terminate:
-        deregister_runners(ci_personal_api_token, f"azure-{ci_workflow_run_id}")
+        deregister_runners(ci_env['PERSONAL_ACCESS_TOKEN'], f"azure-{ci_env['GITHUB_RUN_ID']}")
         azure_platform_lib.terminate_azure_vms([vm]) #prints are handled in here
+
+    if len(vms_to_terminate > 0):
+        exit(1)
 
 def main():
     # Get a timezone-aware datetime instance

--- a/.github/scripts/cull-old-ci-instances.py
+++ b/.github/scripts/cull-old-ci-instances.py
@@ -54,7 +54,7 @@ def cull_aws_instances(current_time: DateTime) -> None:
         client.terminate_instances(InstanceIds=[inst['InstanceId']])
         print("  " + inst['InstanceId'])
 
-    if len(instances_to_terminate > 0):
+    if len(instances_to_terminate) > 0:
         exit(1)
 
 def cull_azure_resources(current_time: DateTime) -> None:
@@ -73,7 +73,7 @@ def cull_azure_resources(current_time: DateTime) -> None:
         deregister_runners(ci_env['PERSONAL_ACCESS_TOKEN'], f"azure-{ci_env['GITHUB_RUN_ID']}")
         azure_platform_lib.terminate_azure_vms([vm]) #prints are handled in here
 
-    if len(vms_to_terminate > 0):
+    if len(vms_to_terminate) > 0:
         exit(1)
 
 def main():

--- a/.github/scripts/cull-old-ci-instances.py
+++ b/.github/scripts/cull-old-ci-instances.py
@@ -4,13 +4,12 @@
 # instances that have exceeded a lifetime limit
 
 import datetime
-from typing import Iterable, Tuple, Any
 from xmlrpc.client import DateTime
 import pytz
 import boto3
 import sys
 
-from platform_lib import Platform
+from platform_lib import Platform, find_timed_out_resources
 from common import get_platform_lib
 from github_common import deregister_runners
 
@@ -23,38 +22,30 @@ INSTANCE_LIFETIME_LIMIT_HOURS = 8
 # The number of hours a fpga instance may exist since its initial launch time
 FPGA_INSTANCE_LIFETIME_LIMIT_HOURS = 1
 
-def find_timed_out_resources(hr_limit: int, current_time: DateTime, resource_list: Iterable[Tuple]) -> list:
-    """
-    Because of the differences in how AWS and Azure store time tags, the resource_list
-    in this case is a list of tuples with the 0 index being the instance/vm and the 1 index
-    a datetime object corresponding to the time
-    """
-    timed_out = []
-    for resource_tuple in resource_list:
-        lifetime_secs = (current_time - resource_tuple[1]).total_seconds()
-        if lifetime_secs > (hr_limit * 3600):
-            timed_out.append(resource_tuple[0])
-    return timed_out
-
 def cull_aws_instances(current_time: DateTime) -> None:
     # Grab all instances with a CI-generated tag
     aws_platform_lib = get_platform_lib(Platform.AWS)
-    all_ci_instances = aws_platform_lib.find_all_ci_instances()
-    run_farm_ci_instances = aws_platform_lib.find_run_farm_ci_instances()
 
     client = boto3.client('ec2')
 
-    instances_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), run_farm_ci_instances))
-    instances_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS, current_time, map(lambda x: (x, x['LaunchTime']), all_ci_instances))
-    instances_to_terminate = list(set(instances_to_terminate))
+    run_farm_ci_instances = aws_platform_lib.find_run_farm_ci_instances()
+    instances_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS * 60, current_time, map(lambda x: (x, x['LaunchTime']), run_farm_ci_instances))
+    run_farm_instances_to_terminate = list(set(instances_to_terminate))
+    print("Terminated Run Farm Instances:")
+    for inst in run_farm_instances_to_terminate:
+        client.terminate_instances(InstanceIds=[inst['InstanceId']])
+        print("  " + inst['InstanceId'])
 
-    print("Terminated Instances:")
-    for inst in instances_to_terminate:
+    all_ci_instances = aws_platform_lib.find_all_ci_instances()
+    instances_to_terminate = find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS * 60, current_time, map(lambda x: (x, x['LaunchTime']), all_ci_instances))
+    manager_instances_to_terminate = list(set(instances_to_terminate))
+    print("Terminated Manager Instances:")
+    for inst in manager_instances_to_terminate:
         deregister_runners(ci_env['PERSONAL_ACCESS_TOKEN'], f"aws-{ci_env['GITHUB_RUN_ID']}")
         client.terminate_instances(InstanceIds=[inst['InstanceId']])
         print("  " + inst['InstanceId'])
 
-    if len(instances_to_terminate) > 0:
+    if len(manager_instances_to_terminate) > 0 or len(run_farm_instances_to_terminate) > 0:
         exit(1)
 
 def cull_azure_resources(current_time: DateTime) -> None:
@@ -62,9 +53,9 @@ def cull_azure_resources(current_time: DateTime) -> None:
     all_azure_ci_vms = azure_platform_lib.find_all_ci_instances()
     run_farm_azure_ci_vms = azure_platform_lib.find_run_farm_ci_instances()
 
-    vms_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS, current_time, \
+    vms_to_terminate = find_timed_out_resources(FPGA_INSTANCE_LIFETIME_LIMIT_HOURS * 60, current_time, \
         map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), run_farm_azure_ci_vms))
-    vms_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS, current_time, \
+    vms_to_terminate += find_timed_out_resources(INSTANCE_LIFETIME_LIMIT_HOURS * 60, current_time, \
         map(lambda x: (x, datetime.datetime.strptime(x['LaunchTime'],'%Y-%m-%d %H:%M:%S.%f%z')), all_azure_ci_vms))
     vms_to_terminate = list(set(vms_to_terminate))
 

--- a/.github/scripts/cull-old-ci-runners.py
+++ b/.github/scripts/cull-old-ci-runners.py
@@ -3,14 +3,14 @@
 # Runs periodically in it's own workflow in the CI/CD environment to teardown
 # runners that are offline
 
-from common import deregister_offline_runners
+from github_common import deregister_offline_runners
 
 # Reuse manager utilities
-from ci_variables import ci_personal_api_token
+from ci_variables import ci_env
 
 def main():
     # deregister all offline runners
-    deregister_offline_runners(ci_personal_api_token)
+    deregister_offline_runners(ci_env['PERSONAL_ACCESS_TOKEN'])
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/github_common.py
+++ b/.github/scripts/github_common.py
@@ -53,12 +53,17 @@ def deregister_runners(gh_token: str, runner_name: str) -> None:
         if runner_name in runner["name"]:
             delete_runner(gh_token, runner)
 
-def issue_post(gh_token: str, body: str) -> None:
+# obtain issue number separately since workflow-monitor shouldn't query the GH-A runner area
+# since it's separate from it
+def get_issue_number() -> int:
     with open(ci_env['GITHUB_EVENT_PATH']) as f:
         event_payload = json.load(f)
         gh_issue_id = event_payload["number"]
+        return gh_issue_id
+    raise Exception(f"Unable to return an issue number using {ci_env['GITHUB_EVENT_PATH']}")
 
-    res = requests.post(f"{gh_issues_api_url}/{gh_issue_id}/comments",
+def issue_post(gh_token: str, issue_num: int, body: str) -> None:
+    res = requests.post(f"{gh_issues_api_url}/{issue_num}/comments",
             json={"body": body}, headers=get_header(gh_token))
     if res.status_code != 201:
         raise Exception(f"HTTP POST error: {res} {res.json()}\nUnable to post GitHub PR comment.")

--- a/.github/scripts/github_common.py
+++ b/.github/scripts/github_common.py
@@ -1,0 +1,64 @@
+import math
+from fabric.api import *
+import requests
+from ci_variables import ci_env
+import json
+
+from typing import Dict, List, Any
+
+# Github URL related constants
+gh_repo_api_url      = f"{ci_env['GITHUB_API_URL']}/repos/{ci_env['GITHUB_REPOSITORY']}"
+gh_issues_api_url    = f"{gh_repo_api_url}/issues"
+gha_api_url          = f"{gh_repo_api_url}/actions"
+gha_runners_api_url  = f"{gha_api_url}/runners"
+gha_runs_api_url     = f"{gha_api_url}/runs"
+gha_workflow_api_url = f"{gha_runs_api_url}/{ci_env['GITHUB_RUN_ID']}"
+
+def get_header(gh_token: str) -> Dict[str, str]:
+    return {"Authorization": f"token {gh_token.strip()}", "Accept": "application/vnd.github+json"}
+
+def get_runners(gh_token: str) -> List:
+    r = requests.get(gha_runners_api_url, headers=get_header(gh_token))
+    if r.status_code != 200:
+        raise Exception(f"Unable to retrieve count of GitHub Actions Runners\nFull Response Below:\n{r}")
+    res_dict = r.json()
+    runner_count = res_dict["total_count"]
+
+    runners = []
+    for page_idx in range(math.ceil(runner_count / 30)):
+        r = requests.get(gha_runners_api_url, params={"per_page" : 30, "page" : page_idx + 1}, headers=get_header(gh_token))
+        if r.status_code != 200:
+            raise Exception(f"Unable to retrieve (sub)list of GitHub Actions Runners\nFull Response Below\n{r}")
+        res_dict = r.json()
+        runners = runners + res_dict["runners"]
+
+    return runners
+
+def delete_runner(gh_token: str, runner: Dict[str, Any]) -> bool:
+    r = requests.delete(f"""{gha_runners_api_url}/{runner["id"]}""", headers=get_header(gh_token))
+    if r.status_code != 204:
+        print(f"""Unable to delete runner {runner["name"]} with id: {runner["id"]}\nFull Response Below\n{r}""")
+        return False
+    return True
+
+def deregister_offline_runners(gh_token: str) -> None:
+    runners = get_runners(gh_token)
+    for runner in runners:
+        if runner["status"] == "offline":
+            delete_runner(gh_token, runner)
+
+def deregister_runners(gh_token: str, runner_name: str) -> None:
+    runners = get_runners(gh_token)
+    for runner in runners:
+        if runner_name in runner["name"]:
+            delete_runner(gh_token, runner)
+
+def issue_post(gh_token: str, body: str) -> None:
+    with open(ci_env['GITHUB_EVENT_PATH']) as f:
+        event_payload = json.load(f)
+        gh_issue_id = event_payload["number"]
+
+    res = requests.post(f"{gh_issues_api_url}/{gh_issue_id}/comments",
+            json={"body": body}, headers=get_header(gh_token))
+    if res.status_code != 201:
+        raise Exception(f"HTTP POST error: {res} {res.json()}\nUnable to post GitHub PR comment.")

--- a/.github/scripts/initialize-repo.py
+++ b/.github/scripts/initialize-repo.py
@@ -4,7 +4,7 @@ from fabric.api import *
 
 from common import manager_home_dir, manager_fsim_dir, manager_marshal_dir, set_fabric_firesim_pem
 # This is expected to be launch from the ci container
-from ci_variables import ci_workdir
+from ci_variables import ci_env
 
 def initialize_repo():
     """ Initializes firesim repo: clones, runs build-setup, and intializes marshal submodules """
@@ -12,7 +12,7 @@ def initialize_repo():
     with cd(manager_home_dir):
         run("rm -rf {}".format(manager_fsim_dir))
         # copy ci version of the repo into the new globally accessible location
-        run("git clone {} {}".format(ci_workdir, manager_fsim_dir))
+        run("git clone {} {}".format(ci_env['GITHUB_WORKSPACE'], manager_fsim_dir))
 
     with cd(manager_fsim_dir):
         run("./build-setup.sh --skip-validate")

--- a/.github/scripts/install-firesim-pem.py
+++ b/.github/scripts/install-firesim-pem.py
@@ -3,7 +3,7 @@
 from fabric.api import *
 import os
 
-from ci_variables import ci_firesim_pem
+from ci_variables import ci_env
 from common import manager_home_dir, manager_fsim_pem, set_fabric_firesim_pem
 
 def install_firesim_pem():
@@ -12,7 +12,7 @@ def install_firesim_pem():
     with cd(manager_home_dir):
         # add firesim.pem
         with open(manager_fsim_pem, "w") as pem_file:
-            pem_file.write(ci_firesim_pem)
+            pem_file.write(ci_env['FIRESIM_PEM'])
         local("chmod 600 {}".format(manager_fsim_pem))
 
 if __name__ == "__main__":

--- a/.github/scripts/launch-azure-vm.py
+++ b/.github/scripts/launch-azure-vm.py
@@ -36,7 +36,7 @@ def main():
 
     workflow_id = ci_env['GITHUB_RUN_ID']
 
-    # Netowrking related variables
+    # Networking related variables
     ip_name = workflow_id + "-ip"
     ip_config_name = ip_name + "-config"
     nic_name = workflow_id + "-nic"

--- a/.github/scripts/launch-manager-instance.py
+++ b/.github/scripts/launch-manager-instance.py
@@ -5,19 +5,19 @@
 import sys
 
 # This must run in the CI container
-from ci_variables import ci_workflow_run_id, ci_commit_sha1, ci_workdir
+from ci_variables import ci_env
 from common import aws_platform_lib
 
 # Reuse manager utilities
-sys.path.append(ci_workdir + "/deploy")
+sys.path.append(ci_env['GITHUB_WORKSPACE'] + "/deploy")
 import awstools.awstools
 
 def main():
     """ Spins up a new manager instance for our CI run """
 
-    if aws_platform_lib.check_manager_exists(ci_workflow_run_id):
+    if aws_platform_lib.check_manager_exists(ci_env['GITHUB_RUN_ID']):
         print("There is an existing manager instance for this CI workflow:")
-        print(aws_platform_lib.get_manager_metadata_string(ci_workflow_run_id))
+        print(aws_platform_lib.get_manager_metadata_string(ci_env['GITHUB_RUN_ID']))
         sys.exit(0)
 
     print("Launching a fresh manager instance. This will take a couple minutes")
@@ -27,12 +27,12 @@ def main():
         '--market', 'spot',
         '--int_behavior', 'terminate',
         '--block_devices', str([{'DeviceName':'/dev/sda1','Ebs':{'VolumeSize':300,'VolumeType':'gp2'}}]),
-        '--tags', str(aws_platform_lib.get_manager_tag_dict(ci_commit_sha1, ci_workflow_run_id)),
-        '--user_data_file', ci_workdir + "/scripts/machine-launch-script.sh"
+        '--tags', str(aws_platform_lib.get_manager_tag_dict(ci_env['GITHUB_SHA'], ci_env['GITHUB_RUN_ID'])),
+        '--user_data_file', ci_env['GITHUB_WORKSPACE'] + "/scripts/machine-launch-script.sh"
     ])
 
     print("Instance ready.")
-    print(aws_platform_lib.get_manager_metadata_string(ci_workflow_run_id))
+    print(aws_platform_lib.get_manager_metadata_string(ci_env['GITHUB_RUN_ID']))
     sys.stdout.flush()
 
 if __name__ == "__main__":

--- a/.github/scripts/platform_lib.py
+++ b/.github/scripts/platform_lib.py
@@ -429,7 +429,7 @@ class AzurePlatformLib(PlatformLib):
                 print(f"Succeeded in deleting VM {vm['name']}")
 
     def check_and_terminate_select_instances(self, timeout: int, workflow_tag: str) -> None:
-        return
+        raise NotImplementedError
 
     def find_select_ci_instances(self, workflow_tag: str = '*') -> List:
-        return
+        raise NotImplementedError

--- a/.github/scripts/platform_lib.py
+++ b/.github/scripts/platform_lib.py
@@ -188,7 +188,7 @@ class AWSPlatformLib(PlatformLib):
     def find_run_farm_ci_instances(self, workflow_tag: str = '*') -> List:
         # on AWS run farm instances are marked with 'fsimcluster'
         instances_filter = [
-                {'Name': 'tag:fsimcluster', 'Values': f'*{workflow_tag}*'},
+                {'Name': 'tag:fsimcluster', 'Values': [f'*{workflow_tag}*']},
                 {'Name': 'instance-type', 'Values': ['f1.2xlarge', 'f1.4xlarge', 'f1.16xlarge']},
                 ]
         ci_instances = get_instances_with_filter(instances_filter, allowed_states=['*'])

--- a/.github/scripts/platform_lib.py
+++ b/.github/scripts/platform_lib.py
@@ -275,7 +275,7 @@ class AWSPlatformLib(PlatformLib):
         instances = self.find_run_farm_ci_instances(workflow_tag)
         terminated_insts = False
         for inst in instances:
-            if (datetime.datetime.now() - inst.launch_time) >= datetime.timedelta(minutes=timeout):
+            if (datetime.datetime.now() - inst['LaunchTime']) >= datetime.timedelta(minutes=timeout):
                 print("Uncaught run farm instance shutdown detected")
 
                 instids = [ inst.instance_id ]

--- a/.github/scripts/run-aws-configure.py
+++ b/.github/scripts/run-aws-configure.py
@@ -4,15 +4,16 @@ from fabric.api import *
 import os
 
 from common import manager_fsim_dir, set_fabric_firesim_pem
+from ci_variables import ci_env
 
 def run_aws_configure() -> None:
     """ Runs AWS configure on the CI manager """
 
     with cd(manager_fsim_dir), prefix("source ./sourceme-f1-manager.sh"):
         run(".github/scripts/firesim-managerinit.expect {} {} {}".format(
-            os.environ["AWS_ACCESS_KEY_ID"],
-            os.environ["AWS_SECRET_ACCESS_KEY"],
-            os.environ["AWS_DEFAULT_REGION"]))
+            ci_env['AWS_ACCESS_KEY_ID'],
+            ci_env['AWS_SECRET_ACCESS_KEY'],
+            ci_env['AWS_DEFAULT_REGION']))
 
 if __name__ == "__main__":
     set_fabric_firesim_pem()

--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from fabric.api import *
 
 from common import manager_fsim_dir, set_fabric_firesim_pem
-from ci_variables import ci_workdir, ci_workflow_run_id
-sys.path.append(ci_workdir + "/deploy")
+from ci_variables import ci_env
+sys.path.append(ci_env['GITHUB_WORKSPACE'] + "/deploy")
 from awstools.awstools import get_instances_with_filter, get_private_ips_for_instances
 from util.filelineswap import file_line_swap
 
@@ -27,7 +27,7 @@ def run_linux_poweroff_externally_provisioned():
             workload_full = workload_path + "/" + workload
             log_tail_length = 100
             script_name = Path(__file__).stem
-            rf_prefix = f"{ci_workflow_run_id}-{script_name}"
+            rf_prefix = f"{ci_env['GITHUB_RUN_ID']}-{script_name}"
 
             # unique tag based on the ci workflow and filename is needed to ensure
             # run farm is unique to each linux-poweroff test

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -3,7 +3,7 @@
 import sys
 
 from fabric.api import *
-from ci_variables import ci_workdir
+from ci_variables import ci_env
 
 def run_linux_poweroff_vitis():
     """ Runs Base Vitis Build """
@@ -14,9 +14,9 @@ def run_linux_poweroff_vitis():
 
     # repo should already be checked out
 
-    with prefix(f'cd {ci_workdir}'):
+    with prefix(f"cd {ci_env['GITHUB_WORKSPACE']}"):
         run("./build-setup.sh --skip-validate")
-        with prefix('source sourceme-f1-manager.sh'):
+        with prefix('source sourceme-f1-manager.sh --skip-ssh-setup'):
             # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
             with prefix('cd sw/firesim-software'):
                 run("./init-submodules.sh")
@@ -56,7 +56,7 @@ def run_linux_poweroff_vitis():
                 else:
                     print(f"Workload {workload} successful.")
 
-            run_w_timeout(f"{ci_workdir}/.github/scripts/vitis-test", "linux-poweroff-singlenode", "30m")
+            run_w_timeout(f"{ci_env['GITHUB_WORKSPACE']}/.github/scripts/vitis-test", "linux-poweroff-singlenode", "30m")
 
 if __name__ == "__main__":
     execute(run_linux_poweroff_vitis, hosts=["localhost"])

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from fabric.api import *
 
 from common import manager_fsim_dir, set_fabric_firesim_pem
-from ci_variables import ci_workflow_run_id
+from ci_variables import ci_env
 
 def run_linux_poweroff():
     """ Runs Linux poweroff workloads """
@@ -22,13 +22,13 @@ def run_linux_poweroff():
             # unique tag based on the ci workflow and filename is needed to ensure
             # run farm is unique to each linux-poweroff test
             script_name = Path(__file__).stem
-            with prefix(f"export FIRESIM_RUNFARM_PREFIX={ci_workflow_run_id}-{script_name}"):
+            with prefix(f"export FIRESIM_RUNFARM_PREFIX={ci_env['GITHUB_RUN_ID']}-{script_name}"):
                 rc = 0
                 with settings(warn_only=True):
                     # avoid logging excessive amounts to prevent GH-A masking secrets (which slows down log output)
                     # pty=False needed to avoid issues with screen -ls stalling in fabric
                     rc = run(f"timeout {timeout} ./deploy/workloads/run-workload.sh {workload} --withlaunch &> {workload}.log", pty=False).return_code
-                    print(f" Printing last {log_tail_length} lines of log. See {workload}.log for full info.")
+                    print(f"Printing last {log_tail_length} lines of log. See {workload}.log for full info.")
                     run(f"tail -n {log_tail_length} {workload}.log")
 
                     # This is a janky solution to the fact the manager does not

--- a/.github/scripts/run-managerinit.py
+++ b/.github/scripts/run-managerinit.py
@@ -3,7 +3,7 @@
 from fabric.api import *
 import os
 
-from ci_variables import ci_aws_access_key_id, ci_aws_secret_access_key, ci_aws_default_region
+from ci_variables import ci_env
 from common import manager_fsim_dir, set_fabric_firesim_pem
 
 def run_managerinit() -> None:
@@ -11,9 +11,9 @@ def run_managerinit() -> None:
 
     with cd(manager_fsim_dir), prefix("source ./sourceme-f1-manager.sh"):
         run(".github/scripts/firesim-managerinit.expect {} {} {}".format(
-            ci_aws_access_key_id,
-            ci_aws_secret_access_key,
-            ci_aws_default_region))
+            ci_env['AWS_ACCESS_KEY_ID'],
+            ci_env['AWS_SECRET_ACCESS_KEY'],
+            ci_env['AWS_DEFAULT_REGION']))
 
 if __name__ == "__main__":
     set_fabric_firesim_pem()

--- a/.github/scripts/setup-workflow-monitor.py
+++ b/.github/scripts/setup-workflow-monitor.py
@@ -7,6 +7,7 @@ import os
 
 from common import manager_ci_dir, set_fabric_firesim_pem
 from platform_lib import Platform, get_platform_enum
+from github_common import get_issue_number
 from ci_variables import RUN_LOCAL, ci_env
 
 def setup_workflow_monitor(platform: Platform, max_runtime: int) -> None:
@@ -36,7 +37,7 @@ def setup_workflow_monitor(platform: Platform, max_runtime: int) -> None:
             run((f"screen -S ttl -dm bash -c \'sleep {int(max_runtime) * 3600};"
                 f"./change-workflow-instance-states.py {platform} {ci_env['GITHUB_RUN_ID']} terminate {ci_env['PERSONAL_ACCESS_TOKEN']}\'")
                 , pty=False)
-            run((f"screen -S workflow-monitor -L -Logfile {workflow_log} -dm bash -c \'./workflow-monitor.py {platform}\'")
+            run((f"screen -S workflow-monitor -L -Logfile {workflow_log} -dm bash -c \'./workflow-monitor.py {platform} {get_issue_number()}\'")
                 , pty=False)
 
         time.sleep(30)

--- a/.github/scripts/setup-workflow-monitor.py
+++ b/.github/scripts/setup-workflow-monitor.py
@@ -2,18 +2,12 @@
 
 from fabric.api import *
 import argparse
+import time
+import os
 
 from common import manager_ci_dir, set_fabric_firesim_pem
 from platform_lib import Platform, get_platform_enum
-from ci_variables import ci_azure_sub_id, ci_azure_client_id, ci_azure_tenant_id, ci_azure_client_secret, \
-    ci_workflow_run_id, ci_personal_api_token
-
-def generate_azure_credited_env():
-    run(f"echo 'export AZURE_CREDITED_ENV=true' >> ~/azure_env.sh")
-    run(f"echo 'export AZURE_SUBSCRIPTION_ID={ci_azure_sub_id}' >> ~/azure_env.sh")
-    run(f"echo 'export AZURE_CLIENT_ID={ci_azure_client_id}' >> ~/azure_env.sh")
-    run(f"echo 'export AZURE_TENANT_ID={ci_azure_tenant_id}' >> ~/azure_env.sh")
-    run(f"echo 'export AZURE_CLIENT_SECRET={ci_azure_client_secret}' >> ~/azure_env.sh")
+from ci_variables import RUN_LOCAL, ci_env
 
 def setup_workflow_monitor(platform: Platform, max_runtime: int) -> None:
     """ Performs the prerequisite tasks for all CI jobs that will run on the manager instance
@@ -29,27 +23,39 @@ def setup_workflow_monitor(platform: Platform, max_runtime: int) -> None:
         # This generates a file that can be sourced to get all the right keys / ids to run any of the
         # Azure jobs. On testing, the environment variables did not correctly pass themselves to the
         # screen job on
+        assert not RUN_LOCAL, "Workflow monitor setup only works running under GH-A"
 
-        if platform == Platform.AZURE:
-            generate_azure_credited_env()
-            azure_source_string = 'source azure_env.sh;'
-        else:
-            azure_source_string = ''
-
-        # Put a baseline time-to-live bound on the manager.
-        # Instances will be terminated (since they are spot requests) and cleaned up in a nightly job.
-
-        # Setting pty=False is required to stop the screen from being
-        # culled when the SSH session associated with the run command ends.
-
+        workflow_log = f"{manager_ci_dir}/workflow-monitor-screen.log"
 
         run("echo 'zombie kr' >> ~/.screenrc") # for testing purposes, keep the screen on even after it dies
-        run((f"screen -S ttl -dm bash -c \'{azure_source_string}sleep {int(max_runtime) * 3600};"
-            f"./change-workflow-instance-states.py {platform} {ci_workflow_run_id} terminate {ci_personal_api_token}\'")
-            , pty=False)
-        run((f"screen -S workflow-monitor -L -dm bash -c"
-            f"\'{azure_source_string}./workflow-monitor.py {platform} {ci_workflow_run_id} {ci_personal_api_token}\'")
-            , pty=False)
+        with shell_env(**ci_env):
+            # Put a baseline time-to-live bound on the manager.
+            # Instances will be terminated (since they are spot requests) or will cleaned up in a nightly job.
+            # Setting pty=False is required to stop the screen from being
+            # culled when the SSH session associated with the run command ends.
+            run((f"screen -S ttl -dm bash -c \'sleep {int(max_runtime) * 3600};"
+                f"./change-workflow-instance-states.py {platform} {ci_env['GITHUB_RUN_ID']} terminate {ci_env['PERSONAL_ACCESS_TOKEN']}\'")
+                , pty=False)
+            run((f"screen -S workflow-monitor -L -Logfile {workflow_log} -dm bash -c \'./workflow-monitor.py {platform}\'")
+                , pty=False)
+
+        time.sleep(30)
+
+        # verify the screen sessions are running
+        ls_out = run("screen -ls")
+        if not ("ttl" in ls_out and "workflow-monitor" in ls_out):
+            print("Error: Unable to find 'ttl' or 'workflow-monitor' screen sessions in 'screen -ls' after spawn.")
+            print("'screen -ls' output:")
+            print(ls_out)
+            exit(1)
+
+        # verify the workflow monitor started correctly
+        log_out = run(f"cat {workflow_log}")
+        if not "Workflow monitor started" in log_out:
+            print("Error: Workflow monitor not started properly.")
+            print("Workflow monitor log output:")
+            print(log_out)
+            exit(1)
 
 if __name__ == "__main__":
     set_fabric_firesim_pem()

--- a/.github/scripts/setup-workflow-monitor.py
+++ b/.github/scripts/setup-workflow-monitor.py
@@ -27,7 +27,7 @@ def setup_workflow_monitor(platform: Platform, max_runtime: int) -> None:
 
         workflow_log = f"{manager_ci_dir}/workflow-monitor-screen.log"
 
-        run("echo 'zombie kr' >> ~/.screenrc") # for testing purposes, keep the screen on even after it dies
+        #run("echo 'zombie kr' >> ~/.screenrc") # for testing purposes, keep the screen on even after it dies
         with shell_env(**ci_env):
             # Put a baseline time-to-live bound on the manager.
             # Instances will be terminated (since they are spot requests) or will cleaned up in a nightly job.

--- a/.github/scripts/workflow-monitor.py
+++ b/.github/scripts/workflow-monitor.py
@@ -14,12 +14,15 @@
 # Other states to consider: not_run, on_hold, unauthorized
 
 import time
-import sys
 import argparse
 import requests
+import traceback
 
-from common import get_platform_lib, gha_runs_api_url
+from common import get_platform_lib
+from github_common import gha_runs_api_url, issue_post, get_header, gha_workflow_api_url
 from platform_lib import Platform, get_platform_enum
+from ci_variables import ci_env
+
 # Time between HTTPS requests to github
 POLLING_INTERVAL_SECONDS = 60
 # Number of failed requests before stopping the instances
@@ -32,44 +35,71 @@ TERMINATE_STATES = ["cancelled", "success", "skipped", "stale", "failure", "time
 STOP_STATES = []
 NOP_STATES = ["action_required"] # TODO: unsure when this happens
 
-def main(platform: Platform, workflow_id: str, gha_ci_personal_token: str):
+def wrap_in_code(wrap: str):
+    return f"\n```\n{wrap}\n```"
 
+def main(platform: Platform):
     consecutive_failures = 0
-    headers = {'Authorization': "token {}".format(gha_ci_personal_token.strip())}
-    gha_workflow_api_url = f"{gha_runs_api_url}/{workflow_id}"
 
+    print("Workflow monitor started")
     platform_lib = get_platform_lib(platform)
-    while True:
-        time.sleep(POLLING_INTERVAL_SECONDS)
 
-        res = requests.get(gha_workflow_api_url, headers=headers)
-        if res.status_code == 200:
-            consecutive_failures = 0
-            res_dict = res.json()
-            state_status = res_dict["status"]
-            state_concl = res_dict["conclusion"]
+    try:
+        print("Sending startup message")
+        issue_post(ci_env['PERSONAL_ACCESS_TOKEN'], f"Workflow monitor started for CI run: {ci_env['GITHUB_RUN_ID']}")
 
-            print("Workflow {} status: {} {}".format(workflow_id, state_status, state_concl))
-            if state_status in ['completed']:
-                if state_concl in TERMINATE_STATES:
-                    platform_lib.terminate_instances(gha_ci_personal_token, workflow_id)
-                    exit(0)
-                elif state_concl in STOP_STATES:
-                    platform_lib.stop_instances(gha_ci_personal_token, workflow_id)
-                    exit(0)
-                elif state_concl not in NOP_STATES:
-                    print("Unexpected Workflow State On Completed: {}".format(state_concl))
+        print("Beginning polling loop")
+        while True:
+            time.sleep(POLLING_INTERVAL_SECONDS)
+
+            res = requests.get(gha_workflow_api_url, headers=get_header(ci_env['PERSONAL_ACCESS_TOKEN']))
+            if res.status_code == 200:
+                consecutive_failures = 0
+                res_dict = res.json()
+                state_status = res_dict["status"]
+                state_concl = res_dict["conclusion"]
+
+                print(f"Workflow {ci_env['GITHUB_RUN_ID']} status: {state_status} {state_concl}")
+
+                # check that select instances are terminated on time
+                platform_lib.check_and_terminate_select_instances(45, ci_env['GITHUB_RUN_ID'])
+
+                if state_status in ['completed']:
+                    if state_concl in TERMINATE_STATES:
+                        platform_lib.terminate_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
+                        return
+                    elif state_concl in STOP_STATES:
+                        platform_lib.stop_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
+                        return
+                    elif state_concl not in NOP_STATES:
+                        print(f"Unexpected Workflow State On Completed: {state_concl}")
+                        raise ValueError
+                elif state_status not in ['in_progress', 'queued', 'waiting', 'requested']:
+                    print(f"Unexpected Workflow State: {state_status}")
                     raise ValueError
-            elif state_status not in ['in_progress', 'queued', 'waiting', 'requested']:
-                print("Unexpected Workflow State: {}".format(state_status))
-                raise ValueError
 
-        else:
-            print("HTTP GET error: {}. Retrying.".format(res.json()))
-            consecutive_failures = consecutive_failures + 1
-            if consecutive_failures == QUERY_FAILURE_THRESHOLD:
-                platform_lib.stop_instances(gha_ci_personal_token, workflow_id)
-                exit(1)
+            else:
+                print(f"HTTP GET error: {res.json()}. Retrying.")
+                consecutive_failures = consecutive_failures + 1
+                if consecutive_failures == QUERY_FAILURE_THRESHOLD:
+                    print("Consecutive HTTP GET errors. Terminating and exiting.")
+                    platform_lib.terminate_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
+                    raise ValueError
+    except BaseException as e:
+        post_str  = f"Something went wrong in the workflow monitor for CI run {ci_env['GITHUB_RUN_ID']}. Verify CI instances are terminated properly. Must be checked before submitting the PR.\n\n"
+        post_str += f"**Exception Message:**{wrap_in_code(e)}\n"
+        post_str += f"**Traceback Message:**{wrap_in_code(traceback.format_exc())}"
+
+        issue_post(ci_env['PERSONAL_ACCESS_TOKEN'], post_str)
+
+        platform_lib.check_and_terminate_select_instances(0, ci_env['GITHUB_RUN_ID'])
+        platform_lib.terminate_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
+
+        post_str = f"Instances for CI run {ci_env['GITHUB_RUN_ID']} were supposedly terminated. Verify termination manually.\n"
+
+        issue_post(ci_env['PERSONAL_ACCESS_TOKEN'], post_str)
+
+        exit(1)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -78,11 +108,7 @@ if __name__ == "__main__":
     parser.add_argument('platform',
                         choices = platform_choices,
                         help = "The platform CI is being run on")
-    parser.add_argument('workflow_id',
-                        help='ID of the workflow that is used to query the CI instance')
-    parser.add_argument('gha_ci_personal_token',
-                        help="GitHub personal access token used to query GitHub REST API")
     args = parser.parse_args()
     platform = get_platform_enum(args.platform)
 
-    main(platform, args.workflow_id, args.gha_ci_personal_token)
+    main(platform)

--- a/.github/workflows/firesim-cleanup.yml
+++ b/.github/workflows/firesim-cleanup.yml
@@ -2,7 +2,7 @@ name: firesim-cleanup
 
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0,30 */1 * * *"
 
 env:
   PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_A_PERSONAL_ACCESS_TOKEN }}
@@ -32,6 +32,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/repo-setup-aws
       - run: .github/scripts/cull-old-ci-instances.py
+      - if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+            SLACK_CHANNEL: firesim-github-update
+            SLACK_COLOR: ${{ job.status }}
+            SLACK_TITLE: "CULLED CI INSTANCES (PLEASE VERIFY CI IS WORKING CORRECTLY!)"
+            SLACK_MESSAGE: "@channel. Please verify: https://github.com/firesim/firesim/actions/workflows/firesim-cleanup.yml"
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   cull-old-ci-runners:
     name: cull-old-ci-runners

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -129,7 +129,7 @@ jobs:
         if: ${{ (env.CI_LABEL_DEBUG != 'true') }}
         uses: ./.github/actions/setup-workflow-monitor
         with:
-          max-runtime-hours: 10
+          max-runtime-hours: 4
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
       - name: Catch potentially orphaned manager

--- a/scripts/run-py-typecheck.sh
+++ b/scripts/run-py-typecheck.sh
@@ -3,6 +3,13 @@
 # Run type checking on manager Python files
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DEPLOY_DIR=$SCRIPT_DIR/../deploy
+FSIM_DIR=$SCRIPT_DIR/..
 
-mypy --no-incremental $DEPLOY_DIR/awstools/ $DEPLOY_DIR/buildtools/ $DEPLOY_DIR/runtools/ $DEPLOY_DIR/util/ $DEPLOY_DIR/firesim
+mypy --no-incremental \
+    $FSIM_DIR/deploy/awstools/ \
+    $FSIM_DIR/deploy/buildtools/ \
+    $FSIM_DIR/deploy/runtools/ \
+    $FSIM_DIR/deploy/util/ \
+    $FSIM_DIR/deploy/firesim \
+    $FSIM_DIR/.github/scripts/ci_variables.py
+


### PR DESCRIPTION
This PR attempts to fix/alleviate some CI issues that have caused resource leakages (of both manager and FPGA instances).

Existing issues found:
- The workflow monitor did not start properly (a combination of needing all env. variables, and other small oversights). However, this wasn't apparent since there was no logging/notification of something going wrong.
- FPGA instances were left alive for too long (workflow monitor was failing is one reason for this).

It does the following:

- `workflow_monitor.py` and `setup_workflow_monitor.py`
  - The monitor needs access to all environment variables used in `ci_variables.py`. Thus, instead of setting an `env.sh` file that holds needed env. variables, a new `ci_env` dict is created (see the `ci_variables.py` changes) and set for the corresponding `run()` calls.
  - Now there are 2 verification steps to ensure that the workflow monitor at least started properly (the workflow monitor has it's own check to ensure it is properly running)
  - Since the workflow monitor has access to all env. variables needed, it doesn't have the args anymore.
  - The workflow monitor now sends PR comments when starting + failing
  - The workflow monitor now has a `check_and_terminate_select_instances` that has a 45m timeout on FPGA instances (see `platform_lib.py` for more info).
  - The workflow monitor now has a `try/catch` to check if failures happen (at least it should hopefully send the PR comment if something fails).
- `ci_variables.py` - A new `ci_env` dict is populated with all env. variables used throughout CI. Instead of using python variable names for environment variables (which don't have the same naming convention) use the env. variable name for the key in the dict. All code locations are changed to account for this. This dict is type checked so that all keys are considered present. Future CI type checking will happen in a followup PR.
- `firesim-cleanup.yml` - This workflow now sends a Slack message if something goes wrong. This is tied to the `cull-instances` script now returning an error if it culls something it expected not to cull.
- `cull-old-ci-insts.py` - This now explicitly checks for FPGA instances that are live for over 1hr. Also now exits non-zero if something was terminated unexpectedly (triggers a slack message).
- `{github_}common.py` - Moved GitHub specific items to a new file `github_common.py` to avoid a circular dependency with the `platform_lib` file. A new issues URL and issue function is added for PR comment posts.
- `platform_lib.py`:
  - New `find_select_ci_instances` func. for each platform to find "select" CI instances (i.e. FPGA instances) and return them.
  - New `check_and_terminate_select_instances` func. to find "select" instances and terminate them. If instances are terminated then it sends a PR comment.

There are now multiple checks for FPGA instances (for extra extra extra security):
- Linux test timeout - 30m timeout
- Workflow Monitor - 45m timeout
- Cull CI Instances - 1h timeout

#### Related PRs / Issues

N/A

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
