### PR TITLE
Move termination to Run Farm `Inst` + `monitor_jobs` small rework

### DIFF
--- a/deploy/workloads/linux-poweroff-all-no-nic.yaml
+++ b/deploy/workloads/linux-poweroff-all-no-nic.yaml
@@ -38,7 +38,7 @@ autocounter:
 
 workload:
     workload_name: linux-poweroff-uniform.json
-    terminate_on_completion: no
+    terminate_on_completion: yes
     suffix_tag: null
 
 host_debug:

--- a/deploy/workloads/linux-poweroff-nic.yaml
+++ b/deploy/workloads/linux-poweroff-nic.yaml
@@ -36,7 +36,7 @@ autocounter:
 
 workload:
     workload_name: linux-poweroff-uniform.json
-    terminate_on_completion: no
+    terminate_on_completion: yes
     suffix_tag: null
 
 host_debug:


### PR DESCRIPTION
This PR addresses #1289.

It contains a few parts:
1. Changes the `linux-poweroff-*` workloads to auto-terminate with `terminate_on_completion`. This allows this code path to be tested in CI and further avoids FPGA runtime in CI.
2. The run farm deploy manager code for terminating an instance has been moved to the run farm `Inst` object's new `terminate_self` function. This keeps the boto3 object tracking strictly in the run farm instead of passing references to it throughout the codebase.
3. The `monitor_jobs_instance` is now changed to avoid the following scenario/bug: an instance would immediate terminate (due to `terminate_on_completion`), then the monitor jobs loop would be called again which would attempt to copy results off, however since the instance was terminated previously there would be a stall. 
  * The function signature is roughly the same with small changes + 1 addition: `completed_jobs -> prior_completed_jobs`, `teardown -> is_networked`, and a new `is_final_loop`. This `is_final_loop` is used in combination w/ the `is_networked` flag to potentially terminate the instance on the final loop of a networked simulation (instead of earlier) to avoid the issue mentioned.
  * The `instance_logger` now has a `debug` flag to dump to the debug logger
  * Variable renaming, statement re-organization. Happy to revert if need be. I found this easier to read... but since this is subjective I can revert to make the diff easier to read.

#### Related PRs / Issues

Fixes #1289

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
