### PR TITLE
Add an Assert-mode for TerminationBridge; expand testing

### DIFF
--- a/sim/midas/src/main/cc/bridges/termination.cc
+++ b/sim/midas/src/main/cc/bridges/termination.cc
@@ -32,8 +32,8 @@ void termination_t::tick() { // reads the MMIOs at tick-rate
       this->fail = this->is_err[msg_id];
       test_done = true;
       std::cerr << "Termination Bridge detected exit on cycle "
-                << this->cycle_count() << " with message " << this->msgs[msg_id]
-                << std::endl;
+                << this->cycle_count() << " with message:" << std::endl
+                << this->msgs[msg_id] << std::endl;
     }
     tick_counter = 0;
   } else {

--- a/sim/midas/src/main/cc/bridges/termination.h
+++ b/sim/midas/src/main/cc/bridges/termination.h
@@ -7,6 +7,15 @@
 
 #include "bridge_driver.h"
 
+// Bridge Driver Instantiation Template
+#define INSTANTIATE_TERMINATION(FUNC, IDX)                                     \
+  FUNC(new termination_t(this,                                                 \
+                         args,                                                 \
+                         TERMINATIONBRIDGEMODULE_##IDX##_substruct_create,     \
+                         TERMINATIONBRIDGEMODULE_##IDX##_message_count,        \
+                         TERMINATIONBRIDGEMODULE_##IDX##_message_type,         \
+                         TERMINATIONBRIDGEMODULE_##IDX##_message));
+
 class termination_t : public bridge_driver_t {
 public:
   termination_t(simif_t *sim,

--- a/sim/midas/src/main/cc/constructor.h
+++ b/sim/midas/src/main/cc/constructor.h
@@ -492,19 +492,50 @@ INSTANTIATE_TRACERV(add_bridge_driver, 31)
 #endif
 
 #ifdef TERMINATIONBRIDGEMODULE_0_PRESENT
-    add_bridge_driver(new termination_t(simif,
-                                         args,
-                                         TERMINATIONBRIDGEMODULE_0_substruct_create,
-                                         TERMINATIONBRIDGEMODULE_0_message_count,
-                                         TERMINATIONBRIDGEMODULE_0_message_type,
-                                         TERMINATIONBRIDGEMODULE_0_message));
+  INSTANTIATE_TERMINATION(add_bridge_driver, 0)
 #endif
-
 #ifdef TERMINATIONBRIDGEMODULE_1_PRESENT
-    add_bridge_driver(new termination_t(simif,
-                                         args,
-                                         TERMINATIONBRIDGEMODULE_1_substruct_create,
-                                         TERMINATIONBRIDGEMODULE_1_message_count,
-                                         TERMINATIONBRIDGEMODULE_1_message_type,
-                                         TERMINATIONBRIDGEMODULE_1_message));
+  INSTANTIATE_TERMINATION(add_bridge_driver, 1)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_2_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 2)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_3_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 3)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_4_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 4)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_5_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 5)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_6_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 6)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_7_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 7)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_8_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 8)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_9_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 9)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_10_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 10)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_11_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 11)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_12_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 12)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_13_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 13)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_14_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 14)
+#endif
+#ifdef TERMINATIONBRIDGEMODULE_15_PRESENT
+  INSTANTIATE_TERMINATION(add_bridge_driver, 15)
 #endif

--- a/sim/midas/src/main/scala/midas/widgets/TerminationBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/TerminationBridge.scala
@@ -15,6 +15,14 @@ import freechips.rocketchip.util.{DecoupledHelper}
 **/
 case class TerminationCondition(isErr: Boolean, message : String)
 
+/** Sugar for constructing instances of [[TerminationCondition]]s */
+object TerminationCondition {
+  def error(message: String) = TerminationCondition(true,  message)
+  def pass(message: String)  = TerminationCondition(false, message)
+
+  val dummyCondition = TerminationCondition(true, "DUMMY CONDITION: THIS MESSAGE SHOULD NOT PRINT.")
+}
+
 /** A seq of termination conditions one for each concurrently running program
  */
 case class TerminationBridgeParams(
@@ -28,9 +36,9 @@ class TerminationBridgeTargetIO(params: TerminationBridgeParams) extends Bundle 
 }
 
 class TerminationBridgeHostIO(params: TerminationBridgeParams)
-                              (private val targetIO : TerminationBridgeTargetIO = new TerminationBridgeTargetIO(params)) 
+                              (private val targetIO : TerminationBridgeTargetIO = new TerminationBridgeTargetIO(params))
                                extends Bundle with ChannelizedHostPortIO{
-  def targetClockRef = targetIO.clock 
+  def targetClockRef = targetIO.clock
   //It is just inputs from the target to indicate test completion
   //The HostPort annotation would not work with aggregates so creating individual channels.
   val terminationCodeH = InputChannel(targetIO.terminationCode)
@@ -50,23 +58,35 @@ class TerminationBridge(params: TerminationBridgeParams) extends BlackBox
 object TerminationBridge {
 
   private def annotateTerminationBridge(clock: Clock, reset: Reset, conditionBools: Seq[Bool], params: TerminationBridgeParams): TerminationBridge = {
-    val finish = conditionBools.reduce(_||_)
-    val errMessageID = PriorityEncoder(conditionBools)
-    require(params.conditionInfo.size==conditionBools.size)
-    val terminationBridgeTarget = Module(new TerminationBridge(params))
-    terminationBridgeTarget.io.terminationCode := errMessageID
-    terminationBridgeTarget.io.valid := finish && !reset.asBool
-    terminationBridgeTarget.io.clock := clock 
-    terminationBridgeTarget  
+    require(conditionBools.nonEmpty, "Termination Bridge must be instantiated with at least one exit condition.")
+    require(params.conditionInfo.size == conditionBools.size,
+      "Must provide exactly as many TerminationConditions as Bool predicates. Got ${conditionBools.size} bools and ${params.conditionInfo.size} conditions."
+    )
+
+    // Hack: ensuring at least two conditions prevents GG from optimizing away the
+    // index (const-propping a zero-into the blackbox), breaking ReferenceTarget renaming
+    // I tried DontTouch-ing multiple different things to no effect.
+    val (paddedBools, paddedParams) = if (conditionBools.size == 1) {
+      (conditionBools :+ false.B, params.copy(conditionInfo = params.conditionInfo :+ TerminationCondition.dummyCondition))
+    } else {
+      (conditionBools, params)
+    }
+
+    val terminationBridgeTarget = Module(new TerminationBridge(paddedParams))
+    val finish = paddedBools.reduce(_||_)
+    terminationBridgeTarget.io.valid := finish && !reset.asBool && !GlobalResetCondition.produceSink()
+    terminationBridgeTarget.io.clock := clock
+    terminationBridgeTarget.io.terminationCode := PriorityEncoder(paddedBools)
+    terminationBridgeTarget
   }
 
-/** Instatiates the target side of the Bridge, selects one of 
- *  the available finish conditions and passes on the corresponding 
+/** Instantiates the target side of the Bridge, selects one of
+ *  the available finish conditions and passes on the corresponding
  *  error message.
  *  @param clock: Clock to the bridge which it must run on.
  *  @param reset: local reset for the bridge.
  *  @param conditionBools: Seq of finished conditions indicated by running programs
- *  @param params: Possible list of message info to be returned by simulator  
+ *  @param params: Possible list of message info to be returned by simulator
  */
 
   def apply(clock: Clock, reset: Reset, conditionBools: Seq[Bool], params: TerminationBridgeParams): TerminationBridge = {
@@ -79,6 +99,22 @@ object TerminationBridge {
     annotateTerminationBridge(Module.clock, Module.reset, conditionBools, params)
   }
 
+  /** A stand-in for a single synthesized assertion.
+    *
+    * In the future this may be subsumed by annotations on existing Assert statements.
+    *
+    * @param condition
+    *   The invariant that should remain true (except possibly under reset).
+    *   Mirrors what you'd pass to chisel3.assert
+    *
+    * @param message
+    *   The message to print when the assertion fails to hold.
+    *   Mirrors what you'd pass to chisel3.assert
+    */
+  def assert(condition: Bool, message: String): TerminationBridge = {
+    val params = TerminationBridgeParams(Seq(TerminationCondition.error(message)))
+    annotateTerminationBridge(Module.clock, Module.reset, Seq(!condition), params)
+  }
 }
 
 class TerminationBridgeModule(params: TerminationBridgeParams)(implicit p: Parameters) extends BridgeModule[TerminationBridgeHostIO]()(p) {
@@ -86,13 +122,13 @@ class TerminationBridgeModule(params: TerminationBridgeParams)(implicit p: Param
 
     val io = IO(new WidgetIO())
     val hPort = IO(new TerminationBridgeHostIO(params)())
-    
+
     val statusDone = Queue(hPort.validH)
     val terminationCode = Queue(hPort.terminationCodeH)
 
     val cycleCountWidth = 64
 
-    val tokenCounter = genWideRORegInit(0.U(cycleCountWidth.W), "out_counter") 
+    val tokenCounter = genWideRORegInit(0.U(cycleCountWidth.W), "out_counter")
 
     val noTermination = !statusDone.bits
 

--- a/sim/midas/targetutils/src/main/scala/midas/InstrumentationPredication.scala
+++ b/sim/midas/targetutils/src/main/scala/midas/InstrumentationPredication.scala
@@ -2,7 +2,7 @@
 
 package midas.targetutils
 
-import chisel3.dontTouch
+import chisel3._
 import chisel3.experimental.{ChiselAnnotation, annotate}
 
 import firrtl.annotations._
@@ -69,4 +69,21 @@ object GlobalResetCondition {
   def sink(target: chisel3.Bool): Unit = annotate(new ChiselAnnotation {
     def toFirrtl = GlobalResetConditionSink(target.toTarget)
   })
+
+  /**
+    * Generates a bool that will be driven by the global reset condition.
+    *
+    * Due to pecularities with when GG can run the wiring transform, this method
+    * must be used to produce a wire if a port cannot be annotated.
+    */
+  def produceSink(): chisel3.Bool = {
+    val globalResetConditionSinkModule = Module(new Module {
+      val in  = IO(Input(Bool()))
+      val out = IO(Output(Bool()))
+      out := in
+      GlobalResetCondition.sink(out)
+    })
+    globalResetConditionSinkModule.in := false.B
+    globalResetConditionSinkModule.out
+  }
 }

--- a/sim/src/main/cc/midasexamples/TestTerminationModuleAssert.cc
+++ b/sim/src/main/cc/midasexamples/TestTerminationModuleAssert.cc
@@ -1,0 +1,70 @@
+// See LICENSE for license details.
+
+#include "TestHarness.h"
+
+#include "simif_peek_poke.h"
+
+class TestTerminationModuleAssert final : public TestHarness {
+public:
+  using TestHarness::TestHarness;
+
+  std::unique_ptr<termination_t> terminator;
+  void add_bridge_driver(termination_t *bridge) override {
+    assert(!terminator && "multiple bridges registered");
+    terminator.reset(bridge);
+  }
+
+  int expected_cycle_at_bridge = 0;
+
+  // Steps the DUT assuming the termination bridge should not call for teardown
+  void step_assume_continue(int count) {
+    step(count, false);
+    expected_cycle_at_bridge += count;
+    while (!done()) {
+      terminator->tick();
+      assert(!terminator->terminate() && "Unexpected termination signaled.");
+    }
+  }
+
+  // Assumes termination should occur in the current cycle
+  void step_once_and_wait_on_terminate(int tick_attempts = 10) {
+    step(1);
+    // Call this repeated to give the sim time to have a poke propagate to the
+    // bridge
+    for (int i = 0; i < tick_attempts; i++) {
+      terminator->tick();
+    }
+    expect(terminator->terminate(),
+           "Termination bridge correctly calls for termination.");
+  }
+
+  void run_test() override {
+    // Check that the termination bridge doesn't call for teardown before reset
+    // is asserted
+    poke(reset, 0);
+    poke(io_globalResetCondition, 1);
+    poke(io_shouldBeTrue, 0);
+    step_assume_continue(10);
+
+    // Check that the termination bridge doesn't call for teardown while the
+    // local reset is asserted
+    poke(reset, 1);
+    poke(io_globalResetCondition, 0);
+    step_assume_continue(10);
+
+    // Now proceed with regularly scheduled content
+    poke(reset, 0);
+    poke(io_shouldBeTrue, 1);
+    step_assume_continue(10);
+
+    poke(io_shouldBeTrue, 0);
+    step_once_and_wait_on_terminate();
+
+    expect(terminator->cycle_count() == expected_cycle_at_bridge,
+           "Termination bridge provides correct exit cycle");
+    expect(terminator->exit_code() == 1,
+           "Termination bridge returns non-zero when used in assert mode");
+  };
+};
+
+TEST_MAIN(TestTerminationModuleAssert)

--- a/sim/src/main/scala/midasexamples/Termination.scala
+++ b/sim/src/main/scala/midasexamples/Termination.scala
@@ -7,6 +7,7 @@ import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 import midas.widgets._
+import midas.targetutils.GlobalResetCondition
 
 class TerminationModuleIO(val params: TerminationBridgeParams) extends Bundle {
   val msgInCycle = Input(UInt(16.W))  //Cycle when error is valid
@@ -28,4 +29,17 @@ class TerminationModuleDUT extends Module {
 
 }
 
-class TerminationModule(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new TerminationModuleDUT)
+object TerminationModuleConstants {
+  val assertMessage = "TerminationBridge-implemented assertion failed"
+}
+
+class TerminationModuleAssertDUT extends Module {
+  val io = IO(new Bundle {
+    val shouldBeTrue = Input(Bool())
+    val globalResetCondition = Input(Bool())
+  })
+  GlobalResetCondition(io.globalResetCondition)
+  TerminationBridge.assert(io.shouldBeTrue, TerminationModuleConstants.assertMessage)
+}
+
+class TerminationModuleAssert(implicit p: Parameters) extends PeekPokeMidasExampleHarness(() => new TerminationModuleAssertDUT)

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -416,6 +416,8 @@ class TerminationF1Test extends TutorialSuite("TerminationModule") {
   1 to 10 foreach {x => runTest(backendSimulator, args = Seq("+termination-bridge-tick-rate=10", s"+seed=${x}"), shouldPass = true)}
 }
 
+class TerminationAssertF1Test extends TutorialSuite("TerminationModuleAssert")
+
 class CustomConstraintsF1Test extends TutorialSuite("CustomConstraints") {
   def readLines(filename: String): List[String] = {
     val file = new File(genDir, s"/${filename}")
@@ -449,6 +451,7 @@ class ChiselExampleDesigns extends Suites(
   new CustomConstraintsF1Test,
   // This test is known to fail non-deterministically. See https://github.com/firesim/firesim/issues/1147
   // new TerminationF1Test
+  new TerminationAssertF1Test,
 )
 
 class PrintfSynthesisCITests extends Suites(


### PR DESCRIPTION
Adds a mode that permits using the TerminationBridge as though it were a single Synthesized Assertion. In the long run, we'll have support for richer assertions s.t. assertion synthesis can run more selectively. 

Also plumbs the Global Reset Condition through to the Termination Bridge. This is a prerequisite for using this thing correctly  -- it was an oversight to omit it in the first place. To deploy it i had to add a new method to `GlobalResetCondition` to allow it to be deployed in the target generator (to date, it was only used internally). 

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues


#### UI / API Impact

Adds a couple new target-exposed APIs.

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
N/A, the termination bridge is not deployed in Chipyard targets.

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
