### PR TITLE
Moved MMIO struct type definitions to headers

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/blockdev.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/blockdev.cc
@@ -1,5 +1,4 @@
 // See LICENSE for license details
-#ifdef BLOCKDEVBRIDGEMODULE_struct_guard
 
 #include "blockdev.h"
 #include <inttypes.h>
@@ -414,5 +413,3 @@ void blockdev_t::tick() {
   /* Write state back to block device widget */
   this->send();
 }
-
-#endif // BLOCKDEVBRIDGEMODULE_struct_guard

--- a/sim/firesim-lib/src/main/cc/bridges/blockdev.h
+++ b/sim/firesim-lib/src/main/cc/bridges/blockdev.h
@@ -8,6 +8,39 @@
 
 #include "bridges/bridge_driver.h"
 
+typedef struct BLOCKDEVBRIDGEMODULE_struct {
+  uint64_t read_latency;
+  uint64_t write_latency;
+  uint64_t bdev_nsectors;
+  uint64_t bdev_max_req_len;
+  uint64_t bdev_req_valid;
+  uint64_t bdev_req_write;
+  uint64_t bdev_req_offset;
+  uint64_t bdev_req_len;
+  uint64_t bdev_req_tag;
+  uint64_t bdev_req_ready;
+  uint64_t bdev_data_valid;
+  uint64_t bdev_data_data_upper;
+  uint64_t bdev_data_data_lower;
+  uint64_t bdev_data_tag;
+  uint64_t bdev_data_ready;
+  uint64_t bdev_rresp_data_upper;
+  uint64_t bdev_rresp_data_lower;
+  uint64_t bdev_rresp_tag;
+  uint64_t bdev_rresp_valid;
+  uint64_t bdev_rresp_ready;
+  uint64_t bdev_wack_tag;
+  uint64_t bdev_wack_valid;
+  uint64_t bdev_wack_ready;
+  uint64_t bdev_reqs_pending;
+  uint64_t bdev_wack_stalled;
+  uint64_t bdev_rresp_stalled;
+} BLOCKDEVBRIDGEMODULE_struct;
+
+#ifdef BLOCKDEVBRIDGEMODULE_checks
+BLOCKDEVBRIDGEMODULE_checks;
+#endif // BLOCKDEVBRIDGEMODULE_checks
+
 #define SECTOR_SIZE 512
 #define SECTOR_SHIFT 9
 #define SECTOR_BEATS (SECTOR_SIZE / 8)
@@ -32,7 +65,6 @@ struct blkdev_write_tracker {
   uint64_t data[MAX_REQ_LEN * SECTOR_BEATS];
 };
 
-#ifdef BLOCKDEVBRIDGEMODULE_struct_guard
 class blockdev_t : public bridge_driver_t {
 public:
   blockdev_t(simif_t *sim,
@@ -83,6 +115,5 @@ private:
   uint32_t read_latency = 4096;
   uint32_t write_latency = 4096;
 };
-#endif // BLOCKDEVBRIDGEMODULE_struct_guard
 
 #endif // __BLOCKDEV_H

--- a/sim/firesim-lib/src/main/cc/bridges/dromajo.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/dromajo.cc
@@ -1,5 +1,4 @@
 // See LICENSE for license details
-#ifdef DROMAJOBRIDGEMODULE_struct_guard
 
 #include "dromajo.h"
 
@@ -9,7 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "dromajo_params.h"
+#ifdef DROMAJOBRIDGEMODULE_0_PRESENT
 
 // The maximum number of beats available in the FPGA-side FIFO
 #define STREAM_WIDTH_B BridgeConstants::STREAM_WIDTH_BYTES;
@@ -31,10 +30,11 @@ dromajo_t::dromajo_t(simif_t *sim,
                      int cause_width,
                      int tval_width,
                      int num_traces,
-                     DROMAJOBRIDGEMODULE_struct *mmio_addrs,
+                     const DROMAJOBRIDGEMODULE_struct &mmio_addrs,
                      int stream_idx,
                      int stream_depth)
-    : bridge_driver_t(sim), stream_idx(stream_idx), stream_depth(stream_depth) {
+    : bridge_driver_t(sim), stream_idx(stream_idx), stream_depth(stream_depth),
+      mmio_addrs(mmio_addrs) {
   // setup max constants given from the RTL
   this->_num_traces = num_traces;
 
@@ -59,7 +59,6 @@ dromajo_t::dromajo_t(simif_t *sim,
   this->_tval_offset = this->_cause_offset + this->_cause_width;
 
   // setup misc. state variables
-  this->_mmio_addrs = mmio_addrs;
   this->_dma_addr = dma_addr;
   this->_trace_idx = 0;
   this->dromajo_failed = false;
@@ -112,8 +111,6 @@ dromajo_t::dromajo_t(simif_t *sim,
  * Destructor for Dromajo
  */
 dromajo_t::~dromajo_t() {
-  free(this->_mmio_addrs);
-
   if (this->dromajo_state != NULL)
     dromajo_cosim_fini(this->dromajo_state);
 }
@@ -315,4 +312,4 @@ void dromajo_t::flush() {
     ;
 }
 
-#endif // DROMAJOBRIDGEMODULE_struct_guard
+#endif

--- a/sim/firesim-lib/src/main/cc/bridges/dromajo.h
+++ b/sim/firesim-lib/src/main/cc/bridges/dromajo.h
@@ -7,7 +7,12 @@
 #include <string>
 #include <vector>
 
-#ifdef DROMAJOBRIDGEMODULE_struct_guard
+#ifdef DROMAJOBRIDGEMODULE_0_PRESENT
+
+typedef struct DROMAJOBRIDGEMODULE_struct {
+
+} DROMAJOBRIDGEMODULE_struct;
+
 class dromajo_t : public bridge_driver_t {
 public:
   dromajo_t(simif_t *sim,
@@ -18,7 +23,7 @@ public:
             int cause_width,
             int tval_width,
             int num_traces,
-            DROMAJOBRIDGEMODULE_struct *mmio_addrs,
+            const DROMAJOBRIDGEMODULE_struct &mmio_addrs,
             int stream_idx,
             int stream_depth);
   ~dromajo_t();
@@ -30,7 +35,7 @@ public:
   virtual void finish() { this->flush(); };
 
 private:
-  DROMAJOBRIDGEMODULE_struct *_mmio_addrs;
+  const DROMAJOBRIDGEMODULE_struct mmio_addrs;
   simif_t *_sim;
 
   int invoke_dromajo(uint8_t *buf);
@@ -77,6 +82,5 @@ private:
   std::string dromajo_bin;
   dromajo_cosim_state_t *dromajo_state;
 };
-#endif // DROMAJOBRIDGEMODULE_struct_guard
-
+#endif // DROMAJOBRIDGEMODULE_0_PRESENT
 #endif // __DROMAJO_H

--- a/sim/firesim-lib/src/main/cc/bridges/groundtest.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/groundtest.cc
@@ -1,17 +1,14 @@
 // See LICENSE for license details
-#ifdef GROUNDTESTBRIDGEMODULE_struct_guard
 
 #include "groundtest.h"
 
 groundtest_t::groundtest_t(simif_t *sim,
                            const std::vector<std::string> &args,
-                           GROUNDTESTBRIDGEMODULE_struct *mmio_addrs)
+                           const GROUNDTESTBRIDGEMODULE_struct &mmio_addrs)
     : bridge_driver_t(sim), sim(sim), mmio_addrs(mmio_addrs) {}
 
-groundtest_t::~groundtest_t() { free(this->mmio_addrs); }
+groundtest_t::~groundtest_t() {}
 
 void groundtest_t::init() {}
 
-void groundtest_t::tick() { _success = read(this->mmio_addrs->success); }
-
-#endif
+void groundtest_t::tick() { _success = read(this->mmio_addrs.success); }

--- a/sim/firesim-lib/src/main/cc/bridges/groundtest.h
+++ b/sim/firesim-lib/src/main/cc/bridges/groundtest.h
@@ -4,12 +4,15 @@
 
 #include "bridges/bridge_driver.h"
 
-#ifdef GROUNDTESTBRIDGEMODULE_struct_guard
+typedef struct GROUNDTESTBRIDGEMODULE_struct {
+  uint64_t success;
+} GROUNDTESTBRIDGEMODULE_struct;
+
 class groundtest_t : public bridge_driver_t {
 public:
   groundtest_t(simif_t *sim,
                const std::vector<std::string> &args,
-               GROUNDTESTBRIDGEMODULE_struct *mmio_addrs);
+               const GROUNDTESTBRIDGEMODULE_struct &mmio_addrs);
   ~groundtest_t();
 
   virtual void init();
@@ -21,8 +24,7 @@ public:
 private:
   bool _success = false;
   simif_t *sim;
-  GROUNDTESTBRIDGEMODULE_struct *mmio_addrs;
+  const GROUNDTESTBRIDGEMODULE_struct mmio_addrs;
 };
-#endif
 
 #endif

--- a/sim/firesim-lib/src/main/cc/bridges/serial.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.cc
@@ -1,5 +1,4 @@
 // See LICENSE for license details
-#ifdef SERIALBRIDGEMODULE_struct_guard
 
 #include "serial.h"
 #include <assert.h>
@@ -162,5 +161,3 @@ void serial_t::tick() {
     go();
   }
 }
-
-#endif // SERIALBRIDGEMODULE_struct_guard

--- a/sim/firesim-lib/src/main/cc/bridges/serial.h
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.h
@@ -21,6 +21,22 @@ struct serial_data_t {
   } out;
 };
 
+typedef struct SERIALBRIDGEMODULE_struct {
+  uint64_t in_bits;
+  uint64_t in_valid;
+  uint64_t in_ready;
+  uint64_t out_bits;
+  uint64_t out_valid;
+  uint64_t out_ready;
+  uint64_t step_size;
+  uint64_t done;
+  uint64_t start;
+} SERIALBRIDGEMODULE_struct;
+
+#ifdef SERIALBRIDGEMODULE_checks
+SERIALBRIDGEMODULE_checks;
+#endif // SERIALBRIDGEMODULE_checks
+
 // Bridge Driver Instantiation Template
 // Casts are required for now since the emitted type can change
 #define INSTANTIATE_SERIAL(FUNC, IDX)                                          \
@@ -31,7 +47,6 @@ struct serial_data_t {
                     SERIALBRIDGEMODULE_##IDX##_has_memory,                     \
                     SERIALBRIDGEMODULE_##IDX##_memory_offset));
 
-#ifdef SERIALBRIDGEMODULE_struct_guard
 class serial_t : public bridge_driver_t {
 public:
   serial_t(simif_t *sim,
@@ -67,6 +82,5 @@ private:
   void handle_loadmem_write(firesim_loadmem_t loadmem);
   void serial_bypass_via_loadmem();
 };
-#endif // SERIALBRIDGEMODULE_struct_guard
 
 #endif // __SERIAL_H

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.cc
@@ -1,5 +1,4 @@
 // See LICENSE for license details
-#ifdef SIMPLENICBRIDGEMODULE_struct_guard
 
 #include "simplenic.h"
 
@@ -397,5 +396,3 @@ void simplenic_t::tick() {
     currentround = (currentround + 1) % 2;
   }
 }
-
-#endif // #ifdef SIMPLENICBRIDGEMODULE_struct_guard

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.h
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.h
@@ -9,7 +9,18 @@
 // TODO this should not be hardcoded here.
 #define MAX_BANDWIDTH 200
 
-#ifdef SIMPLENICBRIDGEMODULE_struct_guard
+typedef struct SIMPLENICBRIDGEMODULE_struct {
+  uint64_t macaddr_upper;
+  uint64_t macaddr_lower;
+  uint64_t rlimit_settings;
+  uint64_t pause_threshold;
+  uint64_t pause_times;
+  uint64_t done;
+} SIMPLENICBRIDGEMODULE_struct;
+
+#ifdef SIMPLENICBRIDGEMODULE_checks
+SIMPLENICBRIDGEMODULE_checks;
+#endif // SIMPLENICBRIDGEMODULE_checks
 
 #define INSTANTIATE_SIMPLENIC(FUNC, IDX)                                       \
   FUNC(new simplenic_t(simif,                                                  \
@@ -62,6 +73,5 @@ private:
   const int stream_to_cpu_idx;
   const int stream_from_cpu_idx;
 };
-#endif // SIMPLENICBRIDGEMODULE_struct_guard
 
 #endif // __SIMPLENIC_H

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
@@ -1,5 +1,4 @@
 // See LICENSE for license details
-#ifdef TRACERVBRIDGEMODULE_struct_guard
 
 #include "tracerv.h"
 
@@ -296,4 +295,3 @@ void tracerv_t::flush() {
   while (this->trace_enabled && (process_tokens(this->stream_depth, 0) > 0))
     ;
 }
-#endif // TRACERVBRIDGEMODULE_struct_guard

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.h
@@ -8,7 +8,27 @@
 #include "bridges/tracerv/tracerv_processing.h"
 #include <vector>
 
-#ifdef TRACERVBRIDGEMODULE_struct_guard
+typedef struct TRACERVBRIDGEMODULE_struct {
+  uint64_t initDone;
+  uint64_t traceEnable;
+  uint64_t hostTriggerPCStartHigh;
+  uint64_t hostTriggerPCStartLow;
+  uint64_t hostTriggerPCEndHigh;
+  uint64_t hostTriggerPCEndLow;
+  uint64_t hostTriggerCycleCountStartHigh;
+  uint64_t hostTriggerCycleCountStartLow;
+  uint64_t hostTriggerCycleCountEndHigh;
+  uint64_t hostTriggerCycleCountEndLow;
+  uint64_t hostTriggerStartInst;
+  uint64_t hostTriggerStartInstMask;
+  uint64_t hostTriggerEndInst;
+  uint64_t hostTriggerEndInstMask;
+  uint64_t triggerSelector;
+} TRACERVBRIDGEMODULE_struct;
+
+#ifdef TRACERVBRIDGEMODULE_checks
+TRACERVBRIDGEMODULE_checks;
+#endif // TRACERVBRIDGEMODULE_checks
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_TRACERV(FUNC, IDX)                                         \
@@ -83,6 +103,5 @@ private:
   int beats_available_stable();
   void flush();
 };
-#endif // TRACERVBRIDGEMODULE_struct_guard
 
 #endif // __TRACERV_H

--- a/sim/firesim-lib/src/main/cc/bridges/uart.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.cc
@@ -1,8 +1,5 @@
 // See LICENSE for license details
 
-// Note: struct_guards just as in the headers
-#ifdef UARTBRIDGEMODULE_struct_guard
-
 #include "uart.h"
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -165,5 +162,3 @@ void uart_t::tick() {
     data.in.valid = false;
   } while (data.in.fire() || data.out.fire());
 }
-
-#endif // UARTBRIDGEMODULE_struct_guard

--- a/sim/firesim-lib/src/main/cc/bridges/uart.h
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.h
@@ -1,4 +1,5 @@
 // See LICENSE for license details
+
 #ifndef __UART_H
 #define __UART_H
 
@@ -7,16 +8,24 @@
 
 #include "serial.h"
 
-// The definition of the primary constructor argument for a bridge is generated
-// by Golden Gate at compile time _iff_ the bridge is instantiated in the
-// target. As a result, all bridge driver definitions conditionally remove
-// their sources if the constructor class has been defined (the
-// <cname>_struct_guard macros are generated along side the class definition.)
-//
-// The name of this class and its guards are always BridgeModule class name, in
-// all-caps, suffixed with "_struct" and "_struct_guard" respectively.
+/**
+ * Structure carrying the addresses of all fixed MMIO ports.
+ *
+ * This structure is instantiated when all bridges are populated based on
+ * the target configuration.
+ */
+typedef struct UARTBRIDGEMODULE_struct {
+  uint64_t out_bits;
+  uint64_t out_valid;
+  uint64_t out_ready;
+  uint64_t in_bits;
+  uint64_t in_valid;
+  uint64_t in_ready;
+} UARTBRIDGEMODULE_struct;
 
-#ifdef UARTBRIDGEMODULE_struct_guard
+#ifdef UARTBRIDGEMODULE_checks
+UARTBRIDGEMODULE_checks;
+#endif // UARTBRIDGEMODULE_checks
 
 /**
  * Base class for callbacks handling data coming in and out a UART stream.
@@ -82,6 +91,5 @@ private:
   void send();
   void recv();
 };
-#endif // UARTBRIDGEMODULE_struct_guard
 
 #endif // __UART_H

--- a/sim/midas/src/main/cc/bridges/autocounter.cc
+++ b/sim/midas/src/main/cc/bridges/autocounter.cc
@@ -1,4 +1,3 @@
-#ifdef AUTOCOUNTERBRIDGEMODULE_struct_guard
 
 #include "autocounter.h"
 
@@ -179,5 +178,3 @@ void autocounter_t::finish() {
   while (drain_sample())
     ;
 }
-
-#endif // AUTOCOUNTERBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/autocounter.h
+++ b/sim/midas/src/main/cc/bridges/autocounter.h
@@ -36,7 +36,20 @@ constexpr int autocounter_csv_format_version = 1;
       AUTOCOUNTERBRIDGEMODULE_##IDX##_clock_divisor,                           \
       IDX));
 
-#ifdef AUTOCOUNTERBRIDGEMODULE_struct_guard
+typedef struct AUTOCOUNTERBRIDGEMODULE_struct {
+  uint64_t cycles_low;
+  uint64_t cycles_high;
+  uint64_t readrate_low;
+  uint64_t readrate_high;
+  uint64_t init_done;
+  uint64_t countersready;
+  uint64_t readdone;
+} AUTOCOUNTERBRIDGEMODULE_struct;
+
+#ifdef AUTOCOUNTERBRIDGEMODULE_checks
+AUTOCOUNTERBRIDGEMODULE_checks;
+#endif // AUTOCOUNTERBRIDGEMODULE_checks
+
 class autocounter_t : public bridge_driver_t {
 public:
   autocounter_t(simif_t *sim,
@@ -89,6 +102,5 @@ private:
   // Writes event autocounter metadata to the first lines of the output csv.
   void emit_autocounter_header();
 };
-#endif // AUTOCOUNTERWIDGET_struct_guard
 
 #endif // __AUROCOUNTER_H

--- a/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
+++ b/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
@@ -17,6 +17,13 @@
 
 #include "fpga_model.h"
 
+typedef struct FASEDMEMORYTIMINGMODEL_struct {
+} FASEDMEMORYTIMINGMODEL_struct;
+
+#ifdef FASEDMEMORYTIMINGMODEL_checks
+FASEDMEMORYTIMINGMODEL_checks
+#endif
+
 // Bridge Driver Instantiation Template
 // Casts are required for now since the emitted type can change
 #define INSTANTIATE_FASED(FUNC, IDX)                                           \
@@ -33,8 +40,8 @@
       1L << FASEDMEMORYTIMINGMODEL_##IDX##_target_addr_bits,                   \
       "_" #IDX));
 
-// MICRO HACKS.
-constexpr int HISTOGRAM_SIZE = 1024;
+    // MICRO HACKS.
+    constexpr int HISTOGRAM_SIZE = 1024;
 constexpr int BIN_SIZE = 36;
 constexpr int RANGE_COUNT_SIZE = 48;
 constexpr uint32_t BIN_H_MASK = (1L << (BIN_SIZE - 32)) - 1;

--- a/sim/midas/src/main/cc/bridges/fpga_model.h
+++ b/sim/midas/src/main/cc/bridges/fpga_model.h
@@ -31,6 +31,8 @@ public:
   virtual void profile() = 0;
   virtual void finish() = 0;
 
+  const AddressMap &get_addr_map() const { return addr_map; }
+
 protected:
   AddressMap addr_map;
 

--- a/sim/midas/src/main/cc/bridges/plusargs.cc
+++ b/sim/midas/src/main/cc/bridges/plusargs.cc
@@ -1,5 +1,3 @@
-#ifdef PLUSARGSBRIDGEMODULE_struct_guard
-
 #include "plusargs.h"
 #include <iomanip>
 #include <iostream>
@@ -128,5 +126,3 @@ void plusargs_t::init() {
   // after all registers are handled, set this
   write(mmio_addrs.initDone, 1);
 }
-
-#endif

--- a/sim/midas/src/main/cc/bridges/plusargs.h
+++ b/sim/midas/src/main/cc/bridges/plusargs.h
@@ -3,12 +3,18 @@
 #define __PLUSARGS_H
 // See LICENSE for license details.
 
-#ifdef PLUSARGSBRIDGEMODULE_struct_guard
-
 #include "bridges/bridge_driver.h"
 #include <gmp.h>
 #include <string.h>
 #include <string_view>
+
+typedef struct PLUSARGSBRIDGEMODULE_struct {
+  uint64_t initDone;
+} PLUSARGSBRIDGEMODULE_struct;
+
+#ifdef PLUSARGSBRIDGEMODULE_checks
+PLUSARGSBRIDGEMODULE_checks;
+#endif // PLUSARGSBRIDGEMODULE_checks
 
 #define INSTANTIATE_PLUSARGS(FUNC, IDX)                                        \
   FUNC(new plusargs_t(simif,                                                   \
@@ -55,5 +61,5 @@ private:
   const uint32_t slice_count = 0;
   const std::vector<uint32_t> slice_addrs;
 };
-#endif // PLUSARGSBRIDGEMODULE_struct_guard
+
 #endif //__PLUSARGS_H

--- a/sim/midas/src/main/cc/bridges/reset_pulse.cc
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.cc
@@ -1,4 +1,3 @@
-#ifdef RESETPULSEBRIDGEMODULE_struct_guard
 
 #include "reset_pulse.h"
 
@@ -36,5 +35,3 @@ void reset_pulse_t::init() {
   write(mmio_addrs.pulseLength, this->pulse_length);
   write(mmio_addrs.doneInit, 1);
 }
-
-#endif // RESETPULSEBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/reset_pulse.h
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.h
@@ -1,7 +1,14 @@
 #ifndef __RESET_PULSE_H
 #define __RESET_PULSE_H
 
-#ifdef RESETPULSEBRIDGEMODULE_struct_guard
+typedef struct RESETPULSEBRIDGEMODULE_struct {
+  unsigned long pulseLength;
+  unsigned long doneInit;
+} RESETPULSEBRIDGEMODULE_struct;
+
+#ifdef RESETPULSEBRIDGEMODULE_checks
+RESETPULSEBRIDGEMODULE_checks;
+#endif // RESETPULSEBRIDGEMODULE_checks
 
 #include <vector>
 
@@ -39,7 +46,5 @@ private:
 
   unsigned int pulse_length = default_pulse_length;
 };
-
-#endif // RESETPULSEBRIDGEMODULE_struct_guard
 
 #endif //__RESET_PULSE_H

--- a/sim/midas/src/main/cc/bridges/synthesized_assertions.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_assertions.cc
@@ -1,5 +1,3 @@
-#ifdef ASSERTBRIDGEMODULE_struct_guard
-
 #include "synthesized_assertions.h"
 #include <fstream>
 #include <iostream>
@@ -41,5 +39,3 @@ void synthesized_assertions_t::resume() {
   assert_fired = false;
   write(mmio_addrs.resume, 1);
 }
-
-#endif // ASSERTBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/synthesized_assertions.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_assertions.h
@@ -1,9 +1,20 @@
 #ifndef __SYNTHESIZED_ASSERTIONS_H
 #define __SYNTHESIZED_ASSERTIONS_H
 
-#ifdef ASSERTBRIDGEMODULE_struct_guard
-
 #include "bridge_driver.h"
+
+typedef struct ASSERTBRIDGEMODULE_struct {
+  uint64_t id;
+  uint64_t fire;
+  uint64_t cycle_low;
+  uint64_t cycle_high;
+  uint64_t resume;
+  uint64_t enable;
+} ASSERTBRIDGEMODULE_struct;
+
+#ifdef ASSERTBRIDGEMODULE_checks
+ASSERTBRIDGEMODULE_checks;
+#endif // ASSERTBRIDGEMODULE_checks
 
 class synthesized_assertions_t : public bridge_driver_t {
 public:
@@ -28,7 +39,5 @@ private:
   const ASSERTBRIDGEMODULE_struct mmio_addrs;
   const char *const *msgs;
 };
-
-#endif // ASSERTBRIDGEMODULE_struct_guard
 
 #endif //__SYNTHESIZED_ASSERTIONS_H

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.cc
@@ -1,5 +1,3 @@
-#ifdef PRINTBRIDGEMODULE_struct_guard
-
 #include <iomanip>
 #include <iostream>
 
@@ -334,5 +332,3 @@ void synthesized_prints_t::flush() {
   }
   this->printstream->flush();
 }
-
-#endif // PRINTBRIDGEMODULE_struct_guard

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.h
@@ -1,8 +1,6 @@
 #ifndef __SYNTHESIZED_PRINTS_H
 #define __SYNTHESIZED_PRINTS_H
 
-#ifdef PRINTBRIDGEMODULE_struct_guard
-
 #include <fstream>
 #include <gmp.h>
 #include <iostream>
@@ -39,6 +37,19 @@ struct print_vars_t {
     }
   }
 };
+
+typedef struct PRINTBRIDGEMODULE_struct {
+  uint64_t startCycleL;
+  uint64_t startCycleH;
+  uint64_t endCycleL;
+  uint64_t endCycleH;
+  uint64_t doneInit;
+  uint64_t flushNarrowPacket;
+} PRINTBRIDGEMODULE_struct;
+
+#ifdef PRINTBRIDGEMODULE_checks
+PRINTBRIDGEMODULE_checks;
+#endif // PRINTBRIDGEMODULE_checks
 
 class synthesized_prints_t : public bridge_driver_t {
 
@@ -121,7 +132,5 @@ private:
   // same value
   int beats_avaliable_stable();
 };
-
-#endif // PRINTBRIDGEMODULE_struct_guard
 
 #endif //__SYNTHESIZED_PRINTS_H

--- a/sim/midas/src/main/cc/bridges/termination.cc
+++ b/sim/midas/src/main/cc/bridges/termination.cc
@@ -1,5 +1,3 @@
-#ifdef TERMINATIONBRIDGEMODULE_struct_guard
-
 #include "termination.h"
 #include <iostream>
 
@@ -52,5 +50,3 @@ int termination_t::cycle_count() {
   uint32_t cycle_h = read(mmio_addrs.out_counter_1);
   return (((uint64_t)cycle_h) << 32) | cycle_l;
 }
-
-#endif

--- a/sim/midas/src/main/cc/bridges/termination.h
+++ b/sim/midas/src/main/cc/bridges/termination.h
@@ -3,8 +3,6 @@
 #define __TERMINATION_H
 // See LICENSE for license details.
 
-#ifdef TERMINATIONBRIDGEMODULE_struct_guard
-
 #include "bridge_driver.h"
 
 // Bridge Driver Instantiation Template
@@ -15,6 +13,18 @@
                          TERMINATIONBRIDGEMODULE_##IDX##_message_count,        \
                          TERMINATIONBRIDGEMODULE_##IDX##_message_type,         \
                          TERMINATIONBRIDGEMODULE_##IDX##_message));
+
+typedef struct TERMINATIONBRIDGEMODULE_struct {
+  uint64_t out_counter_0;
+  uint64_t out_counter_1;
+  uint64_t out_counter_latch;
+  uint64_t out_status;
+  uint64_t out_terminationCode;
+} TERMINATIONBRIDGEMODULE_struct;
+
+#ifdef TERMINATIONBRIDGEMODULE_checks
+TERMINATIONBRIDGEMODULE_checks;
+#endif // TERMINATIONBRIDGEMODULE_checks
 
 class termination_t : public bridge_driver_t {
 public:
@@ -43,5 +53,5 @@ private:
   unsigned int *is_err;
   const char *const *msgs;
 };
-#endif // TerminationBridgeModule_struct_guard
+
 #endif //__TERMINATION_H

--- a/sim/midas/src/main/cc/constructor.h
+++ b/sim/midas/src/main/cc/constructor.h
@@ -130,7 +130,6 @@ INSTANTIATE_SERIAL(add_bridge_driver, 14)
 INSTANTIATE_SERIAL(add_bridge_driver, 15)
 #endif
 
-#ifdef BLOCKDEVBRIDGEMODULE_struct_guard
 #ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
 add_bridge_driver(new blockdev_t(simif,
                                  args,
@@ -195,9 +194,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  BLOCKDEVBRIDGEMODULE_7_substruct_create,
                                  7));
 #endif
-#endif
 
-#ifdef SIMPLENICBRIDGEMODULE_struct_guard
 #ifdef SIMPLENICBRIDGEMODULE_0_PRESENT
 INSTANTIATE_SIMPLENIC(add_bridge_driver, 0)
 #endif
@@ -222,9 +219,7 @@ INSTANTIATE_SIMPLENIC(add_bridge_driver, 6)
 #ifdef SIMPLENICBRIDGEMODULE_7_PRESENT
 INSTANTIATE_SIMPLENIC(add_bridge_driver, 7)
 #endif
-#endif
 
-#ifdef TRACERVBRIDGEMODULE_struct_guard
 #ifdef TRACERVBRIDGEMODULE_0_PRESENT
 INSTANTIATE_TRACERV(add_bridge_driver, 0)
 #endif
@@ -321,9 +316,7 @@ INSTANTIATE_TRACERV(add_bridge_driver, 30)
 #ifdef TRACERVBRIDGEMODULE_31_PRESENT
 INSTANTIATE_TRACERV(add_bridge_driver, 31)
 #endif
-#endif
 
-#ifdef DROMAJOBRIDGEMODULE_struct_guard
 #ifdef DROMAJOBRIDGEMODULE_0_PRESENT
     add_bridge_driver(new dromajo_t(
             simif, args,
@@ -338,9 +331,7 @@ INSTANTIATE_TRACERV(add_bridge_driver, 31)
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_count_address,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_full_address)
 #endif
-#endif
 
-#ifdef GROUNDTESTBRIDGEMODULE_struct_guard
 #ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
     add_bridge_driver(new groundtest_t(
             simif, args, GROUNDTESTBRIDGEMODULE_0_substruct_create));
@@ -372,7 +363,6 @@ INSTANTIATE_TRACERV(add_bridge_driver, 31)
 #ifdef GROUNDTESTBRIDGEMODULE_7_PRESENT
     add_bridge_driver(new groundtest_t(
             simif, args, GROUNDTESTBRIDGEMODULE_7_substruct_create));
-#endif
 #endif
 
 #ifdef AUTOCOUNTERBRIDGEMODULE_0_PRESENT

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -68,6 +68,37 @@ protected:
   const std::vector<std::string> args;
 };
 
+typedef struct SIMULATIONMASTER_struct {
+  uint64_t STEP;
+  uint64_t DONE;
+  uint64_t INIT_DONE;
+} SIMULATIONMASTER_struct;
+
+typedef struct LOADMEMWIDGET_struct {
+  uint64_t W_ADDRESS_H;
+  uint64_t W_ADDRESS_L;
+  uint64_t W_LENGTH;
+  uint64_t ZERO_OUT_DRAM;
+  uint64_t W_DATA;
+  uint64_t ZERO_FINISHED;
+  uint64_t R_ADDRESS_H;
+  uint64_t R_ADDRESS_L;
+  uint64_t R_DATA;
+} LOADMEMWIDGET_struct;
+
+typedef struct CLOCKBRIDGEMODULE_struct {
+  uint64_t hCycle_0;
+  uint64_t hCycle_1;
+  uint64_t hCycle_latch;
+  uint64_t tCycle_0;
+  uint64_t tCycle_1;
+  uint64_t tCycle_latch;
+} CLOCKBRIDGEMODULE_struct;
+
+SIMULATIONMASTER_checks;
+LOADMEMWIDGET_checks;
+CLOCKBRIDGEMODULE_checks;
+
 /** \class simif_t
  *
  *  @brief FireSim's main simulation class.

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -431,6 +431,8 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
     "FPGA_MANAGED_AXI4_ID_BITS"    -> fpga_managed_axi4.map(_.params.idBits)  .getOrElse(0).toLong,
     "FPGA_MANAGED_AXI4_ADDR_BITS"  -> fpga_managed_axi4.map(_.params.addrBits).getOrElse(0).toLong,
     "FPGA_MANAGED_AXI4_DATA_BITS"  -> fpga_managed_axi4.map(_.params.dataBits).getOrElse(0).toLong,
+    // Data chunk width of LoadMemWidget
+    "MEM_DATA_CHUNK" -> outer.loadMem.memDataChunk
   ) ++:
    cpu_managed_axi4.map { _ => "CPU_MANAGED_AXI4_PRESENT" -> 1.toLong } ++:
    fpga_managed_axi4.map { _ => "FPGA_MANAGED_AXI4_PRESENT" -> 1.toLong } ++:

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -550,8 +550,8 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
     // Generate the configuration registers and tie them to the ctrl bus
     attachIO(model.io.mmReg)
     attachIO(funcModelRegs)
-    attach(rrespError, "rrespError", ReadOnly)
-    attach(brespError, "brespError", ReadOnly)
+    attach(rrespError, "rrespError", ReadOnly, substruct = false)
+    attach(brespError, "brespError", ReadOnly, substruct = false)
 
     genCRFile()
 

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -31,6 +31,7 @@ private [midas] object PlatformShim {
 abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
   val top = LazyModule(new midas.core.FPGATop)
   def genHeader(sb: StringBuilder, target: String) {
+    sb.append("#include <stddef.h>\n")
     sb.append("#include <stdint.h>\n")
     sb.append("#include <stdbool.h>\n")
     sb.append(genStatic("TARGET_NAME", CStrLit(target)))

--- a/sim/midas/src/main/scala/midas/widgets/LoadMem.scala
+++ b/sim/midas/src/main/scala/midas/widgets/LoadMem.scala
@@ -175,12 +175,8 @@ class LoadMemWidget(val totalDRAMAllocated: BigInt)(implicit p: Parameters) exte
   rDataQ.io.in.bits := memNasti.r.bits.data
 
   genCRFile()
+  }
 
-  override def genHeader(base: BigInt, sb: StringBuilder) {
-    super.genHeader(base, sb)
-    import CppGenerationUtils._
-    sb.append(genMacro("MEM_DATA_CHUNK", UInt64(
-      ((hKey.dataBits - 1) / p(CtrlNastiKey).dataBits) + 1)))
-  }
-  }
+  def memDataChunk: Long =
+    ((module.hKey.dataBits - 1) / p(CtrlNastiKey).dataBits) + 1
 }

--- a/sim/midas/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -48,7 +48,7 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
     // before we reach the desired target cycle
     val cycleHorizon = RegInit(0.U(ctrlWidth.W))
     val tCycleName = "tCycle"
-    val tCycle = genWideRORegInit(0.U(64.W), tCycleName)
+    val tCycle = genWideRORegInit(0.U(64.W), tCycleName, false)
     val tCycleAdvancing = WireInit(false.B)
 
     // needs back pressure from reset queues
@@ -91,7 +91,7 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
       channel.bits := Cat(reg.reverse).asTypeOf(channel.bits)
       channel.valid := !cyclesAhead.full && cyclesAhead.value < cycleHorizon || advanceViaPoke
 
-      val regAddrs = reg.zipWithIndex.map({ case (chunk, idx) => attach(chunk,  s"${name}_${idx}", ReadWrite) })
+      val regAddrs = reg.zipWithIndex.map({ case (chunk, idx) => attach(chunk,  s"${name}_${idx}", ReadWrite, false) })
       channelDecouplingFlags += isAhead
       channelPokes += regAddrs -> poke
       regAddrs
@@ -119,7 +119,7 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
 
       channelDecouplingFlags += isAhead
       outputPrecisePeekableFlags += cyclesAhead.value === 1.U
-      reg.zipWithIndex.map({ case (chunk, idx) => attach(chunk,  s"${name}_${idx}", ReadOnly) })
+      reg.zipWithIndex.map({ case (chunk, idx) => attach(chunk,  s"${name}_${idx}", ReadOnly, false) })
     }
 
     val inputAddrs = hPort.ins.map(elm => bindInputs(elm._1, elm._2))

--- a/sim/midas/src/main/scala/midas/widgets/PlusArgsBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PlusArgsBridge.scala
@@ -167,7 +167,7 @@ class PlusArgsBridgeModule(params: PlusArgsBridgeParams)(implicit p: Parameters)
     // zip/map the widths to call genWOReg
     // reg names are out0, out1, ...
     val slices = slicesWidths.zipWithIndex.map { case (width, idx) =>
-      genWOReg(Wire(UInt(width.W)), s"out${idx}")
+      genWOReg(Wire(UInt(width.W)), s"out${idx}", false)
     }
 
     // glue the slices together to get a single wide register

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -1,13 +1,11 @@
 // See LICENSE for license details.
 
-#include <inttypes.h>
+// MIDAS-defined bridges
+#include <cinttypes>
 
 #include "bridges/fased_memory_timing_model.h"
 #include "bridges/reset_pulse.h"
-#include "bridges/synthesized_assertions.h"
-#include "bridges/synthesized_prints.h"
 #include "fasedtests_top.h"
-#include "simif.h"
 #include "test_harness_bridge.h"
 
 fasedtests_top_t::fasedtests_top_t(const std::vector<std::string> &args,

--- a/sim/src/main/cc/fasedtests/fasedtests_top.h
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.h
@@ -9,8 +9,6 @@
 #include "firesim/systematic_scheduler.h"
 #include "midasexamples/simif_peek_poke.h"
 
-#include "bridges/synthesized_prints.h"
-
 class fasedtests_top_t : public simif_peek_poke_t,
                          public systematic_scheduler_t,
                          public simulation_t {

--- a/sim/src/main/cc/midasexamples/TestHarness.h
+++ b/sim/src/main/cc/midasexamples/TestHarness.h
@@ -35,24 +35,12 @@ public:
     abort();                                                                   \
   }
 
-#ifdef AUTOCOUNTERBRIDGEMODULE_struct_guard
   BRIDGE_HANDLER(autocounter_t, "Auto Counter bridge");
-#endif
-#ifdef ASSERTBRIDGEMODULE_struct_guard
   BRIDGE_HANDLER(synthesized_assertions_t, "Synthesized Assert bridge");
-#endif
-#ifdef PRINTBRIDGEMODULE_struct_guard
   BRIDGE_HANDLER(synthesized_prints_t, "Synthesized Print bridge");
-#endif
-#ifdef RESETPULSEBRIDGEMODULE_struct_guard
   BRIDGE_HANDLER(reset_pulse_t, "Reset Pulse bridge");
-#endif
-#ifdef PLUSARGSBRIDGEMODULE_struct_guard
   BRIDGE_HANDLER(plusargs_t, "PlusArgs bridge");
-#endif
-#ifdef TERMINATIONBRIDGEMODULE_struct_guard
   BRIDGE_HANDLER(termination_t, "Termination bridge");
-#endif
 
   /// Test entry point to override.
   virtual void run_test() = 0;

--- a/sim/src/main/cc/midasexamples/simif_peek_poke.h
+++ b/sim/src/main/cc/midasexamples/simif_peek_poke.h
@@ -6,6 +6,13 @@
 #include "simif.h"
 #include <gmp.h>
 
+typedef struct PEEKPOKEBRIDGEMODULE_struct {
+  uint64_t PRECISE_PEEKABLE;
+  uint64_t READY;
+} PEEKPOKEBRIDGEMODULE_struct;
+
+PEEKPOKEBRIDGEMODULE_checks;
+
 // This derivation of simif_t is used to implement small integration
 // tests where the test writer wants fine grained control over individual
 // token channels. In these tests, the peek poke bridge drives all IO of the

--- a/sim/src/main/makefrag/midasexamples/Makefrag
+++ b/sim/src/main/makefrag/midasexamples/Makefrag
@@ -63,8 +63,7 @@ firesim_lib_dir = $(firesim_base_dir)/firesim-lib/src/main/cc/
 DRIVER_H = $(shell find $(driver_dir) -name "*.h")
 DRIVER_CC := \
 		$(driver_dir)/midasexamples/simif_peek_poke.cc \
-		$(driver_dir)/midasexamples/Test$(DESIGN).cc \
-		$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* )))
+		$(driver_dir)/midasexamples/Test$(DESIGN).cc
 
 TARGET_CXX_FLAGS := \
 		-I$(driver_dir) \


### PR DESCRIPTION
Structure types carrying MMIO port addresses are no longer generated in the monolithic header. Instead, the header contains a `*_check` macro definition which can be used to assert that the type defined alongside the bridge matches the one constructed by the header.

Modified register generation methods in `Widget.scala` to include an optional `substruct` argument. Setting `substruct` to false excludes a register from the structure constructed via `substruct`.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
