### PR TITLE
Provided tests with their own random number generator

### DIFF
--- a/sim/src/main/cc/midasexamples/ShiftRegisterTest.h
+++ b/sim/src/main/cc/midasexamples/ShiftRegisterTest.h
@@ -13,7 +13,7 @@ public:
     std::vector<uint32_t> reg(4);
     target_reset();
     for (int i = 0; i < 64; i++) {
-      uint32_t in = simif->rand_next(2);
+      uint32_t in = random() % 2;
       poke(io_in, in);
       step(1);
       for (int j = 3; j > 0; j--)

--- a/sim/src/main/cc/midasexamples/TestEnableShiftRegister.cc
+++ b/sim/src/main/cc/midasexamples/TestEnableShiftRegister.cc
@@ -10,8 +10,8 @@ public:
     target_reset();
     std::vector<uint32_t> reg(4, 0);
     for (int i = 0; i < 64; i++) {
-      uint32_t in = simif->rand_next(16);
-      uint32_t shift = simif->rand_next(2);
+      uint32_t in = random() % 16;
+      uint32_t shift = random() % 2;
       poke(io_in, in);
       poke(io_shift, shift);
       step(1);

--- a/sim/src/main/cc/midasexamples/TestHarness.h
+++ b/sim/src/main/cc/midasexamples/TestHarness.h
@@ -1,6 +1,8 @@
 #ifndef MIDAEXAMPLES_TESTHARNESS_H
 #define MIDAEXAMPLES_TESTHARNESS_H
 
+#include <random>
+
 #include "bridges/autocounter.h"
 #include "bridges/bridge_driver.h"
 #include "bridges/plusargs.h"
@@ -65,6 +67,10 @@ public:
     run_test();
     return teardown();
   }
+
+protected:
+  /// Random number generator for tests, using a fixed default seed.
+  std::mt19937_64 random;
 };
 
 #define TEST_MAIN(CLASS_NAME)                                                  \

--- a/sim/src/main/cc/midasexamples/TestParity.cc
+++ b/sim/src/main/cc/midasexamples/TestParity.cc
@@ -10,7 +10,7 @@ public:
     uint32_t is_odd = 0;
     target_reset();
     for (int i = 0; i < 64; i++) {
-      uint32_t bit = simif->rand_next(2);
+      uint32_t bit = random() % 2;
       poke(io_in, bit);
       step(1);
       is_odd = (is_odd + bit) % 2;

--- a/sim/src/main/cc/midasexamples/TestResetShiftRegister.cc
+++ b/sim/src/main/cc/midasexamples/TestResetShiftRegister.cc
@@ -11,8 +11,8 @@ public:
     int k = 0;
     target_reset();
     for (int i = 0; i < 64; i++) {
-      uint32_t in = simif->rand_next(16);
-      uint32_t shift = simif->rand_next(2);
+      uint32_t in = random() % 16;
+      uint32_t shift = random() % 2;
       if (shift == 1)
         ins[k % 5] = in;
       poke(io_in, in);

--- a/sim/src/main/cc/midasexamples/TestStack.cc
+++ b/sim/src/main/cc/midasexamples/TestStack.cc
@@ -13,10 +13,10 @@ public:
     uint32_t nextDataOut = 0;
     target_reset();
     for (int i = 0; i < 64; i++) {
-      uint32_t enable = simif->rand_next(2);
-      uint32_t push = simif->rand_next(2);
-      uint32_t pop = simif->rand_next(2);
-      uint32_t dataIn = simif->rand_next(256);
+      uint32_t enable = random() % 2;
+      uint32_t push = random() % 2;
+      uint32_t pop = random() % 2;
+      uint32_t dataIn = random() % 256;
       uint32_t dataOut = nextDataOut;
 
       if (enable) {

--- a/sim/src/main/cc/midasexamples/TestTerminationModule.cc
+++ b/sim/src/main/cc/midasexamples/TestTerminationModule.cc
@@ -26,9 +26,9 @@ public:
     int reset_length = 1;
     std::string failure_msg_list[3] = {"success 1", "success 2", "failure 3"};
     int failure_cond_list[3] = {0, 0, 1};
-    validinCycle = simif->rand_next(100);
-    msginCycle = simif->rand_next(100);
-    int termination_code = simif->rand_next(8);
+    validinCycle = random() % 100;
+    msginCycle = random() % 100;
+    int termination_code = random() % 8;
     lv_validinCycle = lv_validinCycle + validinCycle;
     lv_msginCycle = lv_msginCycle + msginCycle;
     poke(io_validInCycle, lv_validinCycle);

--- a/sim/src/main/cc/midasexamples/TestWireInterconnect.cc
+++ b/sim/src/main/cc/midasexamples/TestWireInterconnect.cc
@@ -18,11 +18,11 @@ public:
     for (int i = 0; i < 64; i++) {
 
       // Poke channel A
-      uint32_t in = simif->rand_next(16);
+      uint32_t in = random() % 16;
       poke(io_aIn, in);
 
-      uint32_t vbIn_foo = simif->rand_next(16);
-      uint32_t vbIn_bar_valid = simif->rand_next(2);
+      uint32_t vbIn_foo = random() % 16;
+      uint32_t vbIn_bar_valid = random() % 2;
       mpz_urandomb(vbIn_bar_bits, rstate, width);
 
       // These pokes also serve to provide some host delay for the poke above to


### PR DESCRIPTION
Tests now use their own default-seeded random number generator instead of piggy-backing on the one provided by the simulation. This further separates tests from the implementation and will allow the scope of `simif_t` to be limited.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
