### PR TITLE
Moved widget logic to individual classes

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/serial.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.cc
@@ -89,12 +89,14 @@ void serial_t::handle_loadmem_read(firesim_loadmem_t loadmem) {
   mpz_t buf;
   mpz_init(buf);
   while (loadmem.size > 0) {
-    sim->read_mem(loadmem.addr + mem_host_offset, buf);
+    auto &driver = sim->get_loadmem();
+    driver.read_mem(loadmem.addr + mem_host_offset, buf);
 
     // If the read word is 0; mpz_export seems to return an array with length 0
-    size_t beats_requested = (loadmem.size / sizeof(uint32_t) > MEM_DATA_CHUNK)
-                                 ? MEM_DATA_CHUNK
-                                 : loadmem.size / sizeof(uint32_t);
+    size_t beats_requested =
+        (loadmem.size / sizeof(uint32_t) > driver.get_mem_data_chunk())
+            ? driver.get_mem_data_chunk()
+            : loadmem.size / sizeof(uint32_t);
     // The number of beats exported from buf; may be less than beats requested.
     size_t non_zero_beats;
     uint32_t *data = (uint32_t *)mpz_export(
@@ -127,7 +129,8 @@ void serial_t::handle_loadmem_write(firesim_loadmem_t loadmem) {
              0,
              0,
              buf);
-  sim->write_mem_chunk(loadmem.addr + mem_host_offset, data, loadmem.size);
+  sim->get_loadmem().write_mem_chunk(
+      loadmem.addr + mem_host_offset, data, loadmem.size);
   mpz_clear(data);
 }
 

--- a/sim/midas/src/main/cc/bridges/clock.cc
+++ b/sim/midas/src/main/cc/bridges/clock.cc
@@ -1,0 +1,23 @@
+// See LICENSE for license details.
+
+#include "clock.h"
+
+#include "simif.h"
+
+clockmodule_t::clockmodule_t(simif_t *sim,
+                             const CLOCKBRIDGEMODULE_struct &mmio_addrs)
+    : sim(sim), mmio_addrs(mmio_addrs) {}
+
+uint64_t clockmodule_t::tcycle() {
+  sim->write(mmio_addrs.tCycle_latch, 1);
+  uint32_t cycle_l = sim->read(mmio_addrs.tCycle_0);
+  uint32_t cycle_h = sim->read(mmio_addrs.tCycle_1);
+  return (((uint64_t)cycle_h) << 32) | cycle_l;
+}
+
+uint64_t clockmodule_t::hcycle() {
+  sim->write(mmio_addrs.hCycle_latch, 1);
+  uint32_t cycle_l = sim->read(mmio_addrs.hCycle_0);
+  uint32_t cycle_h = sim->read(mmio_addrs.hCycle_1);
+  return (((uint64_t)cycle_h) << 32) | cycle_l;
+}

--- a/sim/midas/src/main/cc/bridges/clock.h
+++ b/sim/midas/src/main/cc/bridges/clock.h
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+#ifndef __CLOCK_H
+#define __CLOCK_H
+
+#include <cstdint>
+
+class simif_t;
+
+typedef struct CLOCKBRIDGEMODULE_struct {
+  uint64_t hCycle_0;
+  uint64_t hCycle_1;
+  uint64_t hCycle_latch;
+  uint64_t tCycle_0;
+  uint64_t tCycle_1;
+  uint64_t tCycle_latch;
+} CLOCKBRIDGEMODULE_struct;
+
+CLOCKBRIDGEMODULE_checks;
+
+class clockmodule_t final {
+public:
+  clockmodule_t(simif_t *sim, const CLOCKBRIDGEMODULE_struct &mmio_addrs);
+
+  /**
+   * Provides the current target cycle of the fastest clock.
+   *
+   * The target cycle is based on the number of clock tokens enqueued
+   * (will report a larger number).
+   */
+  uint64_t tcycle();
+
+  /**
+   * Returns the current host cycle as measured by a hardware counter
+   */
+  uint64_t hcycle();
+
+private:
+  simif_t *sim;
+  const CLOCKBRIDGEMODULE_struct mmio_addrs;
+};
+
+#endif // __CLOCK_H

--- a/sim/midas/src/main/cc/bridges/loadmem.cc
+++ b/sim/midas/src/main/cc/bridges/loadmem.cc
@@ -1,0 +1,86 @@
+// See LICENSE for license details.
+
+#include "loadmem.h"
+
+#include <fstream>
+
+#include "simif.h"
+
+loadmem_t::loadmem_t(simif_t *sim,
+                     const LOADMEMWIDGET_struct &mmio_addrs,
+                     unsigned mem_data_chunk)
+    : sim(sim), mmio_addrs(mmio_addrs), mem_data_chunk(mem_data_chunk) {}
+
+void loadmem_t::load_mem_from_file(const std::string &filename) {
+  fprintf(stdout, "[loadmem] start loading\n");
+  std::ifstream file(filename.c_str());
+  if (!file) {
+    fprintf(stderr, "Cannot open %s\n", filename.c_str());
+    exit(EXIT_FAILURE);
+  }
+  const size_t chunk = MEM_DATA_BITS / 4;
+  size_t addr = 0;
+  std::string line;
+  mpz_t data;
+  mpz_init(data);
+  while (std::getline(file, line)) {
+    assert(line.length() % chunk == 0);
+    for (int j = line.length() - chunk; j >= 0; j -= chunk) {
+      mpz_set_str(data, line.substr(j, chunk).c_str(), 16);
+      write_mem(addr, data);
+      addr += chunk / 2;
+    }
+  }
+  mpz_clear(data);
+  file.close();
+  fprintf(stdout, "[loadmem] done\n");
+}
+
+void loadmem_t::read_mem(size_t addr, mpz_t &value) {
+  // NB: mpz_t variables may not export <size> <uint32_t> beats, if initialized
+  // with an array of zeros.
+  sim->write(mmio_addrs.R_ADDRESS_H, addr >> 32);
+  sim->write(mmio_addrs.R_ADDRESS_L, addr & ((1ULL << 32) - 1));
+  const size_t size = MEM_DATA_CHUNK;
+  uint32_t data[size];
+  for (size_t i = 0; i < size; i++) {
+    data[i] = sim->read(mmio_addrs.R_DATA);
+  }
+  mpz_import(value, size, -1, sizeof(uint32_t), 0, 0, data);
+}
+
+void loadmem_t::write_mem(size_t addr, mpz_t &value) {
+  sim->write(mmio_addrs.W_ADDRESS_H, addr >> 32);
+  sim->write(mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
+  sim->write(mmio_addrs.W_LENGTH, 1);
+  size_t size;
+  uint32_t *data =
+      (uint32_t *)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
+  for (size_t i = 0; i < MEM_DATA_CHUNK; i++) {
+    sim->write(mmio_addrs.W_DATA, i < size ? data[i] : 0);
+  }
+}
+
+static size_t ceil_div(size_t a, size_t b) { return ((a)-1) / (b) + 1; }
+
+void loadmem_t::write_mem_chunk(size_t addr, mpz_t &value, size_t bytes) {
+  const unsigned mem_data_chunk_bytes = mem_data_chunk * sizeof(uint32_t);
+
+  sim->write(mmio_addrs.W_ADDRESS_H, addr >> 32);
+  sim->write(mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
+
+  size_t num_beats = ceil_div(bytes, mem_data_chunk_bytes);
+  sim->write(mmio_addrs.W_LENGTH, num_beats);
+  size_t size;
+  uint32_t *data =
+      (uint32_t *)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
+  for (size_t i = 0; i < num_beats * MEM_DATA_CHUNK; i++) {
+    sim->write(mmio_addrs.W_DATA, i < size ? data[i] : 0);
+  }
+}
+
+void loadmem_t::zero_out_dram() {
+  sim->write(mmio_addrs.ZERO_OUT_DRAM, 1);
+  while (!sim->read(mmio_addrs.ZERO_FINISHED))
+    ;
+}

--- a/sim/midas/src/main/cc/bridges/loadmem.h
+++ b/sim/midas/src/main/cc/bridges/loadmem.h
@@ -1,0 +1,50 @@
+// See LICENSE for license details.
+
+#ifndef __LOADMEM_H
+#define __LOADMEM_H
+
+#include <cstdint>
+
+#include <gmp.h>
+
+class simif_t;
+
+typedef struct LOADMEMWIDGET_struct {
+  uint64_t W_ADDRESS_H;
+  uint64_t W_ADDRESS_L;
+  uint64_t W_LENGTH;
+  uint64_t ZERO_OUT_DRAM;
+  uint64_t W_DATA;
+  uint64_t ZERO_FINISHED;
+  uint64_t R_ADDRESS_H;
+  uint64_t R_ADDRESS_L;
+  uint64_t R_DATA;
+} LOADMEMWIDGET_struct;
+
+LOADMEMWIDGET_checks;
+
+class loadmem_t final {
+public:
+  loadmem_t(simif_t *sim,
+            const LOADMEMWIDGET_struct &mmio_addrs,
+            unsigned mem_data_chunk);
+
+  void read_mem(size_t addr, mpz_t &value);
+  void write_mem(size_t addr, mpz_t &value);
+  void write_mem_chunk(size_t addr, mpz_t &value, size_t bytes);
+
+  // Helper to zero out all DRAM.
+  void zero_out_dram();
+
+  // Loads the contents of memory from a file.
+  void load_mem_from_file(const std::string &filename);
+
+  unsigned get_mem_data_chunk() const { return mem_data_chunk; }
+
+private:
+  simif_t *sim;
+  const LOADMEMWIDGET_struct mmio_addrs;
+  const unsigned mem_data_chunk;
+};
+
+#endif // __LOADMEM_H

--- a/sim/midas/src/main/cc/bridges/master.cc
+++ b/sim/midas/src/main/cc/bridges/master.cc
@@ -1,0 +1,19 @@
+// See LICENSE for license details.
+
+#include "simif.h"
+
+master_t::master_t(simif_t *sim, const SIMULATIONMASTER_struct &mmio_addrs)
+    : sim(sim), mmio_addrs(mmio_addrs) {}
+
+bool master_t::is_init_done() { return sim->read(mmio_addrs.INIT_DONE); }
+
+bool master_t::is_done() { return sim->read(mmio_addrs.DONE); }
+
+void master_t::step(size_t n, bool blocking) {
+  sim->write(mmio_addrs.STEP, n);
+
+  if (blocking) {
+    while (!is_done())
+      ;
+  }
+}

--- a/sim/midas/src/main/cc/bridges/master.h
+++ b/sim/midas/src/main/cc/bridges/master.h
@@ -1,0 +1,42 @@
+// See LICENSE for license details.
+
+#ifndef __MASTER_H
+#define __MASTER_H
+
+#include <cstdint>
+
+class simif_t;
+
+typedef struct SIMULATIONMASTER_struct {
+  uint64_t STEP;
+  uint64_t DONE;
+  uint64_t INIT_DONE;
+} SIMULATIONMASTER_struct;
+
+SIMULATIONMASTER_checks;
+
+class master_t final {
+public:
+  master_t(simif_t *sim, const SIMULATIONMASTER_struct &mmio_addrs);
+
+  /**
+   * Check whether the device is initialised.
+   */
+  bool is_init_done();
+
+  /**
+   * Check whether the simulation is complete.
+   */
+  bool is_done();
+
+  /**
+   * Request the simulation to advance a given number of steps.
+   */
+  void step(size_t n, bool blocking);
+
+private:
+  simif_t *sim;
+  const SIMULATIONMASTER_struct mmio_addrs;
+};
+
+#endif // __MASTER_H

--- a/sim/midas/src/main/cc/simif.cc
+++ b/sim/midas/src/main/cc/simif.cc
@@ -2,7 +2,6 @@
 
 #include "simif.h"
 #include <algorithm>
-#include <fstream>
 #include <inttypes.h>
 
 midas_time_t timestamp() {
@@ -19,16 +18,16 @@ extern std::unique_ptr<simulation_t>
 create_simulation(const std::vector<std::string> &args, simif_t *simif);
 
 simif_t::simif_t(const std::vector<std::string> &args)
-    : sim(create_simulation(args, this)),
-      master_mmio_addrs(SIMULATIONMASTER_0_substruct_create),
-      loadmem_mmio_addrs(LOADMEMWIDGET_0_substruct_create),
-      clock_bridge_mmio_addrs(CLOCKBRIDGEMODULE_0_substruct_create) {
+    : loadmem(this, LOADMEMWIDGET_0_substruct_create, MEM_DATA_CHUNK),
+      clock(this, CLOCKBRIDGEMODULE_0_substruct_create),
+      master(this, SIMULATIONMASTER_0_substruct_create),
+      sim(create_simulation(args, this)) {
   for (auto &arg : args) {
     if (arg.find("+fastloadmem") == 0) {
       fastloadmem = true;
     }
     if (arg.find("+loadmem=") == 0) {
-      loadmem = arg.c_str() + 9;
+      load_mem_path = arg.c_str() + 9;
     }
     if (arg.find("+seed=") == 0) {
       seed = strtoll(arg.c_str() + 6, NULL, 10);
@@ -48,10 +47,10 @@ simif_t::simif_t(const std::vector<std::string> &args)
 
 void simif_t::target_init() {
   // Do any post-constructor initialization required before requesting MMIO
-  while (!read(master_mmio_addrs.INIT_DONE))
+  while (!master.is_init_done())
     ;
-  if (!fastloadmem && !loadmem.empty()) {
-    load_mem(loadmem.c_str());
+  if (!fastloadmem && !load_mem_path.empty()) {
+    loadmem.load_mem_from_file(load_mem_path);
   }
 }
 
@@ -60,7 +59,7 @@ int simif_t::simulation_run() {
 
   if (do_zero_out_dram) {
     fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few seconds...\n");
-    zero_out_dram();
+    loadmem.zero_out_dram();
   }
 
   sim->simulation_init();
@@ -75,101 +74,15 @@ int simif_t::simulation_run() {
   return exitcode;
 }
 
-uint64_t simif_t::actual_tcycle() {
-  write(clock_bridge_mmio_addrs.tCycle_latch, 1);
-  uint32_t cycle_l = read(clock_bridge_mmio_addrs.tCycle_0);
-  uint32_t cycle_h = read(clock_bridge_mmio_addrs.tCycle_1);
-  return (((uint64_t)cycle_h) << 32) | cycle_l;
-}
-
-uint64_t simif_t::hcycle() {
-  write(clock_bridge_mmio_addrs.hCycle_latch, 1);
-  uint32_t cycle_l = read(clock_bridge_mmio_addrs.hCycle_0);
-  uint32_t cycle_h = read(clock_bridge_mmio_addrs.hCycle_1);
-  return (((uint64_t)cycle_h) << 32) | cycle_l;
-}
-
-void simif_t::load_mem(std::string filename) {
-  fprintf(stdout, "[loadmem] start loading\n");
-  std::ifstream file(filename.c_str());
-  if (!file) {
-    fprintf(stderr, "Cannot open %s\n", filename.c_str());
-    exit(EXIT_FAILURE);
-  }
-  const size_t chunk = MEM_DATA_BITS / 4;
-  size_t addr = 0;
-  std::string line;
-  mpz_t data;
-  mpz_init(data);
-  while (std::getline(file, line)) {
-    assert(line.length() % chunk == 0);
-    for (int j = line.length() - chunk; j >= 0; j -= chunk) {
-      mpz_set_str(data, line.substr(j, chunk).c_str(), 16);
-      write_mem(addr, data);
-      addr += chunk / 2;
-    }
-  }
-  mpz_clear(data);
-  file.close();
-  fprintf(stdout, "[loadmem] done\n");
-}
-
-// NB: mpz_t variables may not export <size> <uint32_t> beats, if initialized
-// with an array of zeros.
-void simif_t::read_mem(size_t addr, mpz_t &value) {
-  write(loadmem_mmio_addrs.R_ADDRESS_H, addr >> 32);
-  write(loadmem_mmio_addrs.R_ADDRESS_L, addr & ((1ULL << 32) - 1));
-  const size_t size = MEM_DATA_CHUNK;
-  uint32_t data[size];
-  for (size_t i = 0; i < size; i++) {
-    data[i] = read(loadmem_mmio_addrs.R_DATA);
-  }
-  mpz_import(value, size, -1, sizeof(uint32_t), 0, 0, data);
-}
-
-void simif_t::write_mem(size_t addr, mpz_t &value) {
-  write(loadmem_mmio_addrs.W_ADDRESS_H, addr >> 32);
-  write(loadmem_mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
-  write(loadmem_mmio_addrs.W_LENGTH, 1);
-  size_t size;
-  uint32_t *data =
-      (uint32_t *)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
-  for (size_t i = 0; i < MEM_DATA_CHUNK; i++) {
-    write(loadmem_mmio_addrs.W_DATA, i < size ? data[i] : 0);
-  }
-}
-
-#define MEM_DATA_CHUNK_BYTES (MEM_DATA_CHUNK * sizeof(uint32_t))
-#define ceil_div(a, b) (((a)-1) / (b) + 1)
-
-void simif_t::write_mem_chunk(size_t addr, mpz_t &value, size_t bytes) {
-  write(loadmem_mmio_addrs.W_ADDRESS_H, addr >> 32);
-  write(loadmem_mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
-  size_t num_beats = ceil_div(bytes, MEM_DATA_CHUNK_BYTES);
-  write(loadmem_mmio_addrs.W_LENGTH, num_beats);
-  size_t size;
-  uint32_t *data =
-      (uint32_t *)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
-  for (size_t i = 0; i < num_beats * MEM_DATA_CHUNK; i++) {
-    write(loadmem_mmio_addrs.W_DATA, i < size ? data[i] : 0);
-  }
-}
-
-void simif_t::zero_out_dram() {
-  write(loadmem_mmio_addrs.ZERO_OUT_DRAM, 1);
-  while (!read(loadmem_mmio_addrs.ZERO_FINISHED))
-    ;
-}
-
 void simif_t::record_start_times() {
-  this->start_hcycle = hcycle();
+  this->start_hcycle = clock.hcycle();
   this->start_time = timestamp();
 }
 
 void simif_t::record_end_times() {
   this->end_time = timestamp();
   this->end_tcycle = actual_tcycle();
-  this->end_hcycle = hcycle();
+  this->end_hcycle = clock.hcycle();
 }
 
 void simif_t::print_simulation_performance_summary() {

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -11,9 +11,6 @@ simif_emul_t::simif_emul_t(const std::vector<std::string> &args)
     if (arg.find("+waveform=") == 0) {
       waveform = arg.c_str() + 10;
     }
-    if (arg.find("+loadmem=") == 0) {
-      loadmem = arg.c_str() + 9;
-    }
     if (arg.find("+fastloadmem") == 0) {
       fastloadmem = true;
     }
@@ -77,9 +74,9 @@ simif_emul_t::simif_emul_t(const std::vector<std::string> &args)
 simif_emul_t::~simif_emul_t(){};
 
 int simif_emul_t::run() {
-  if (fastloadmem && !loadmem.empty()) {
-    fprintf(stdout, "[fast loadmem] %s\n", loadmem.c_str());
-    load_mems(loadmem.c_str());
+  if (fastloadmem && !load_mem_path.empty()) {
+    fprintf(stdout, "[fast loadmem] %s\n", load_mem_path.c_str());
+    load_mems(load_mem_path.c_str());
   }
 
   sim_init();


### PR DESCRIPTION
Introduced classes to represent `SimulationMaster`, `ClockBridge` and `LoadMemWidget`. This cleans up `simif` by wrapping the MMIO accesses into self-contained methods.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
