### PR TITLE
Introduced a uniform harness across all simulations

### DIFF
--- a/sim/src/main/cc/bridges/BridgeHarness.cc
+++ b/sim/src/main/cc/bridges/BridgeHarness.cc
@@ -8,7 +8,7 @@
 
 BridgeHarness::BridgeHarness(const std::vector<std::string> &args,
                              simif_t *simif)
-    : simulation_t(args), simif(simif) {}
+    : simulation_t(*simif, args), simif(simif) {}
 
 BridgeHarness::~BridgeHarness() {}
 

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -10,7 +10,7 @@
 
 fasedtests_top_t::fasedtests_top_t(const std::vector<std::string> &args,
                                    simif_t *simif)
-    : simulation_t(args), simif(simif) {
+    : simulation_t(*simif, args), simif(simif) {
   max_cycles = -1;
   profile_interval = max_cycles;
 
@@ -75,8 +75,6 @@ void fasedtests_top_t::simulation_init() {
 }
 
 int fasedtests_top_t::simulation_run() {
-  fprintf(stderr, "Commencing simulation.\n");
-
   while (!simulation_complete() && !finished_scheduled_tasks()) {
     run_scheduled_tasks();
     simif->take_steps(get_largest_stepsize(), false);
@@ -86,33 +84,7 @@ int fasedtests_top_t::simulation_run() {
     }
   }
 
-  fprintf(stderr, "\nSimulation complete.\n");
-
-  int exitcode = exit_code();
-
-  // If the simulator is idle and we've gotten here without any bridge
-  // indicating doneness, we've advanced to the +max_cycles limit in the fastest
-  // target clock domain.
-  bool max_cycles_timeout =
-      !simulation_complete() && simif->done() && finished_scheduled_tasks();
-
-  if (exitcode != 0) {
-    fprintf(stderr,
-            "*** FAILED *** (code = %d) after %" PRIu64 " cycles\n",
-            exitcode,
-            simif->actual_tcycle());
-  } else if (max_cycles_timeout) {
-    fprintf(stderr,
-            "*** FAILED *** +max_cycles specified timeout after %" PRIu64
-            " cycles\n",
-            simif->actual_tcycle());
-  } else {
-    fprintf(stderr,
-            "*** PASSED *** after %" PRIu64 " cycles\n",
-            simif->actual_tcycle());
-  }
-
-  return ((exitcode != 0) || max_cycles_timeout) ? EXIT_FAILURE : EXIT_SUCCESS;
+  return exit_code();
 }
 
 void fasedtests_top_t::simulation_finish() {

--- a/sim/src/main/cc/fasedtests/fasedtests_top.h
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.h
@@ -18,7 +18,12 @@ public:
   void simulation_finish();
   int simulation_run();
 
-protected:
+private:
+  bool simulation_timed_out() {
+    return !simulation_complete() && simif->done() &&
+           finished_scheduled_tasks();
+  }
+
   void add_bridge_driver(bridge_driver_t *bridge) {
     bridges.emplace_back(bridge);
   }

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -23,7 +23,7 @@
 
 firesim_top_t::firesim_top_t(const std::vector<std::string> &args,
                              simif_t *simif)
-    : simulation_t(args), simif(simif) {
+    : simulation_t(*simif, args), simif(simif) {
   max_cycles = -1;
   profile_interval = max_cycles;
 
@@ -89,7 +89,6 @@ void firesim_top_t::simulation_init() {
 }
 
 int firesim_top_t::simulation_run() {
-  fprintf(stderr, "Commencing simulation.\n");
 
   while (!simulation_complete() && !finished_scheduled_tasks()) {
     run_scheduled_tasks();
@@ -100,32 +99,7 @@ int firesim_top_t::simulation_run() {
     }
   }
 
-  fprintf(stderr, "\nSimulation complete.\n");
-
-  int exitcode = exit_code();
-  // If the simulator is idle and we've gotten here without any bridge
-  // indicating doneness, we've advanced to the +max_cycles limit in the
-  // fastest target clock domain.
-  bool max_cycles_timeout =
-      !simulation_complete() && simif->done() && finished_scheduled_tasks();
-
-  if (exitcode != 0) {
-    fprintf(stderr,
-            "*** FAILED *** (code = %d) after %" PRIu64 " cycles\n",
-            exitcode,
-            simif->actual_tcycle());
-  } else if (max_cycles_timeout) {
-    fprintf(stderr,
-            "*** FAILED *** +max_cycles specified timeout after %" PRIu64
-            " cycles\n",
-            simif->actual_tcycle());
-  } else {
-    fprintf(stderr,
-            "*** PASSED *** after %" PRIu64 " cycles\n",
-            simif->actual_tcycle());
-  }
-
-  return ((exitcode != 0) || max_cycles_timeout) ? EXIT_FAILURE : EXIT_SUCCESS;
+  return exit_code();
 }
 
 void firesim_top_t::simulation_finish() {

--- a/sim/src/main/cc/firesim/firesim_top.h
+++ b/sim/src/main/cc/firesim/firesim_top.h
@@ -20,7 +20,12 @@ public:
   void simulation_finish();
   int simulation_run();
 
-protected:
+private:
+  bool simulation_timed_out() {
+    return !simulation_complete() && simif->done() &&
+           finished_scheduled_tasks();
+  }
+
   void add_bridge_driver(bridge_driver_t *bridge) {
     bridges.emplace_back(bridge);
   }

--- a/sim/src/main/cc/midasexamples/TestHarness.cc
+++ b/sim/src/main/cc/midasexamples/TestHarness.cc
@@ -7,7 +7,7 @@ static const char *blocking_fail =
     "progress.";
 
 TestHarness::TestHarness(const std::vector<std::string> &args, simif_t *simif)
-    : simulation_t(args), simif(simif) {
+    : simulation_t(*simif, args), simif(simif) {
   for (auto arg : args) {
     if (arg.find("+seed=") == 0) {
       random_seed = strtoll(arg.c_str() + 6, NULL, 10);


### PR DESCRIPTION
Moved the post-simulation dumps of `fasedtests` and `firesim` to `simulation_t` to de-duplicate the logic and to print out the same information across all simulation, including `midasexamples`.

This is necessary to clean up `simif_t` by decoupling non-IO related logic.

`simulation_t` now exposes a callback to check whether the simulation timed out. In the future, such timeout logic should be introduced and respected across `midasexamples` as well.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

`midasexamples` and all simulations will print out the exit status and the cycle count.

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
