### PR TITLE
Replace AXI4 configuration with structures

### DIFF
--- a/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
+++ b/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
@@ -46,12 +46,14 @@ typedef struct StreamParameters {
 class CPUManagedDriver {
 public:
   CPUManagedDriver(StreamParameters params,
+                   const AXI4Config &config,
                    std::function<uint32_t(size_t)> mmio_read_func)
-      : params(params), mmio_read_func(mmio_read_func){};
+      : params(params), config(config), mmio_read_func(mmio_read_func){};
   virtual ~CPUManagedDriver(){};
 
 private:
   StreamParameters params;
+  const AXI4Config config;
   std::function<uint32_t(size_t)> mmio_read_func;
 
 public:
@@ -60,6 +62,7 @@ public:
   int fpga_buffer_size() { return params.fpga_buffer_size; };
   uint64_t dma_addr() { return params.dma_addr; };
   uint64_t count_addr() { return params.count_addr; };
+  uint64_t beat_bytes() const { return config.beat_bytes(); }
 };
 
 /**
@@ -74,9 +77,10 @@ class FPGAToCPUDriver final : public CPUManagedDriver,
                               public FPGAToCPUStreamDriver {
 public:
   FPGAToCPUDriver(StreamParameters params,
+                  const AXI4Config &config,
                   std::function<uint32_t(size_t)> mmio_read,
                   std::function<size_t(size_t, char *, size_t)> axi4_read)
-      : CPUManagedDriver(params, mmio_read), axi4_read(axi4_read){};
+      : CPUManagedDriver(params, config, mmio_read), axi4_read(axi4_read){};
 
   virtual size_t
   pull(void *dest, size_t num_bytes, size_t required_bytes) override;
@@ -100,9 +104,10 @@ class CPUToFPGADriver final : public CPUManagedDriver,
                               public CPUToFPGAStreamDriver {
 public:
   CPUToFPGADriver(StreamParameters params,
+                  const AXI4Config &config,
                   std::function<uint32_t(size_t)> mmio_read,
                   std::function<size_t(size_t, char *, size_t)> axi4_write)
-      : CPUManagedDriver(params, mmio_read), axi4_write(axi4_write){};
+      : CPUManagedDriver(params, config, mmio_read), axi4_write(axi4_write){};
 
   virtual size_t
   push(void *src, size_t num_bytes, size_t required_bytes) override;

--- a/sim/midas/src/main/cc/bridges/loadmem.h
+++ b/sim/midas/src/main/cc/bridges/loadmem.h
@@ -27,6 +27,7 @@ class loadmem_t final {
 public:
   loadmem_t(simif_t *sim,
             const LOADMEMWIDGET_struct &mmio_addrs,
+            const AXI4Config &mem_conf,
             unsigned mem_data_chunk);
 
   void read_mem(size_t addr, mpz_t &value);
@@ -44,6 +45,7 @@ public:
 private:
   simif_t *sim;
   const LOADMEMWIDGET_struct mmio_addrs;
+  const AXI4Config mem_conf;
   const unsigned mem_data_chunk;
 };
 

--- a/sim/midas/src/main/cc/config.h
+++ b/sim/midas/src/main/cc/config.h
@@ -1,0 +1,53 @@
+#ifndef __EMUL_AXI4
+#define __EMUL_AXI4
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+/**
+ * Structure carrying the configuration of an AXI4 channel.
+ */
+struct AXI4Config {
+  const uint64_t id_bits;
+  const uint64_t addr_bits;
+  const uint64_t data_bits;
+
+  /**
+   * Return the number of strobe bits.
+   */
+  uint64_t strb_bits() const { return data_bits / 8; }
+
+  /**
+   * Return the number of bytes in a beat.
+   */
+  uint64_t beat_bytes() const { return strb_bits(); }
+
+  /**
+   *  Return the AXI4-lite control interface size.
+   */
+  uint64_t get_size() const { return ceil(log2(strb_bits())); }
+
+  /**
+   * Returns the number of words carried by the channel.
+   */
+  uint64_t get_data_size() const { return beat_bytes() / sizeof(uint32_t); }
+};
+
+/**
+ * Structure carrying the configuration of a target.
+ */
+struct TargetConfig {
+  const AXI4Config ctrl;
+
+  const AXI4Config mem;
+  const unsigned mem_num_channels;
+
+  const std::optional<AXI4Config> cpu_managed;
+
+  const std::optional<AXI4Config> fpga_managed;
+
+  const char *target_name;
+};
+
+#endif // __EMUL_AXI4

--- a/sim/midas/src/main/cc/emul/mm.cc
+++ b/sim/midas/src/main/cc/emul/mm.cc
@@ -36,9 +36,9 @@ std::vector<char> mm_t::read(uint64_t addr) {
   return std::vector<char>(base, base + word_size);
 }
 
-void mm_t::init(size_t sz, int wsz, int lsz) {
-  assert(wsz > 0 && lsz > 0 && (lsz & (lsz - 1)) == 0 && lsz % wsz == 0);
-  word_size = wsz;
+void mm_t::init(size_t sz, int lsz) {
+  assert(word_size > 0 && lsz > 0);
+  assert((lsz & (lsz - 1)) == 0 && lsz % word_size == 0);
   line_size = lsz;
   data = (uint8_t *)mmap(NULL,
                          sz,
@@ -56,8 +56,8 @@ void mm_t::init(size_t sz, int wsz, int lsz) {
 
 mm_t::~mm_t() { munmap(data, this->size); }
 
-void mm_magic_t::init(size_t sz, int wsz, int lsz) {
-  mm_t::init(sz, wsz, lsz);
+void mm_magic_t::init(size_t sz, int lsz) {
+  mm_t::init(sz, lsz);
   dummy_data.resize(word_size);
 }
 

--- a/sim/midas/src/main/cc/emul/mm.h
+++ b/sim/midas/src/main/cc/emul/mm.h
@@ -9,9 +9,10 @@
 
 class mm_t {
 public:
-  mm_t() : data(0), size(0) {}
+  mm_t(const AXI4Config conf)
+      : conf(conf), word_size(conf.beat_bytes()), data(0), size(0) {}
 
-  virtual void init(size_t sz, int word_size, int line_size);
+  virtual void init(size_t sz, int line_size);
 
   virtual bool ar_ready() = 0;
   virtual bool aw_ready() = 0;
@@ -59,10 +60,14 @@ public:
 
   void load_mem(unsigned long start, const char *fname);
 
+  const AXI4Config &get_config() const { return conf; }
+
 protected:
+  const AXI4Config conf;
+
+  int word_size;
   uint8_t *data;
   size_t size;
-  int word_size;
   int line_size;
 };
 
@@ -85,9 +90,9 @@ struct mm_rresp_t {
 
 class mm_magic_t final : public mm_t {
 public:
-  mm_magic_t() : store_inflight(false){};
+  mm_magic_t(const AXI4Config &conf) : mm_t(conf), store_inflight(false){};
 
-  virtual void init(size_t sz, int word_size, int line_size);
+  virtual void init(size_t sz, int line_size);
 
   virtual bool ar_ready() { return true; }
   virtual bool aw_ready() { return !store_inflight; }

--- a/sim/midas/src/main/cc/emul/mmio.h
+++ b/sim/midas/src/main/cc/emul/mmio.h
@@ -48,8 +48,9 @@ struct mmio_resp_data_t {
  */
 class mmio_t final {
 public:
-  mmio_t(size_t size) : read_inflight(false), write_inflight(false) {
-    dummy_data.resize(size);
+  mmio_t(const AXI4Config &conf)
+      : conf(conf), read_inflight(false), write_inflight(false) {
+    dummy_data.resize(conf.beat_bytes());
   }
 
   ~mmio_t() {}
@@ -91,7 +92,11 @@ public:
   bool read_resp(void *data);
   bool write_resp();
 
+  const AXI4Config &get_config() const { return conf; }
+
 private:
+  const AXI4Config conf;
+
   std::queue<mmio_req_addr_t> ar;
   std::queue<mmio_req_addr_t> aw;
   std::queue<mmio_req_data_t> w;

--- a/sim/midas/src/main/cc/simif.cc
+++ b/sim/midas/src/main/cc/simif.cc
@@ -17,8 +17,12 @@ double diff_secs(midas_time_t end, midas_time_t start) {
 extern std::unique_ptr<simulation_t>
 create_simulation(const std::vector<std::string> &args, simif_t *simif);
 
-simif_t::simif_t(const std::vector<std::string> &args)
-    : loadmem(this, LOADMEMWIDGET_0_substruct_create, MEM_DATA_CHUNK),
+simif_t::simif_t(const TargetConfig &config,
+                 const std::vector<std::string> &args)
+    : config(config), loadmem(this,
+                              LOADMEMWIDGET_0_substruct_create,
+                              config.mem,
+                              LOADMEMWIDGET_0_mem_data_chunk),
       clock(this, CLOCKBRIDGEMODULE_0_substruct_create),
       master(this, SIMULATIONMASTER_0_substruct_create),
       sim(create_simulation(args, this)) {

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -95,7 +95,7 @@ protected:
  */
 class simif_t {
 public:
-  simif_t(const std::vector<std::string> &args);
+  simif_t(const TargetConfig &config, const std::vector<std::string> &args);
   virtual ~simif_t() {}
 
 public:
@@ -231,7 +231,7 @@ public:
   loadmem_t &get_loadmem() { return loadmem; }
 
   /// Return the name of the simulated target.
-  std::string_view get_target_name() const { return TARGET_NAME; }
+  std::string_view get_target_name() const { return config.target_name; }
 
 private:
   /**
@@ -253,6 +253,11 @@ protected:
   int simulation_run();
 
 protected:
+  /**
+   * Target configuration.
+   */
+  const TargetConfig config;
+
   /**
    * LoadMem widget driver.
    */

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -5,10 +5,11 @@
 #include "bridges/cpu_managed_stream.h"
 #include "bridges/fpga_managed_stream.h"
 
-simif_emul_t::simif_emul_t(const std::vector<std::string> &args)
-    : simif_t(args), master(std::make_unique<mmio_t>(CTRL_BEAT_BYTES)),
-      cpu_managed_axi4(std::make_unique<mmio_t>(CPU_MANAGED_AXI4_BEAT_BYTES)),
-      cpu_mem(std::make_unique<mm_magic_t>()) {
+simif_emul_t::simif_emul_t(const TargetConfig &config,
+                           const std::vector<std::string> &args)
+    : simif_t(config, args), master(std::make_unique<mmio_t>(config.ctrl)) {
+
+  memsize = 1L << config.mem.addr_bits;
 
   // Parse arguments.
   for (auto arg : args) {
@@ -27,79 +28,82 @@ simif_emul_t::simif_emul_t(const std::vector<std::string> &args)
   }
 
   // Initialise memories.
-  for (unsigned i = 0; i < MEM_NUM_CHANNELS; ++i) {
-    slave.emplace_back(std::make_unique<mm_magic_t>());
-    (*slave.rbegin())->init(memsize, MEM_BEAT_BYTES, 64);
+  for (unsigned i = 0; i < config.mem_num_channels; ++i) {
+    slave.emplace_back(std::make_unique<mm_magic_t>(config.mem));
+    (*slave.rbegin())->init(memsize, 64);
   }
-
-#ifdef FPGA_MANAGED_AXI4_PRESENT
-  // The final parameter, line size, is not used under mm_magic_t
-  cpu_mem->init((1ULL << FPGA_MANAGED_AXI4_ADDR_BITS),
-                FPGA_MANAGED_AXI4_DATA_BITS / 8,
-                512);
-#endif
 
   using namespace std::placeholders;
   auto mmio_read_func = std::bind(&simif_emul_t::read, this, _1);
   auto mmio_write_func = std::bind(&simif_emul_t::write, this, _1, _2);
 
+  if (auto conf = config.cpu_managed) {
+    cpu_managed_axi4.reset(new mmio_t(*conf));
 #ifdef CPUMANAGEDSTREAMENGINE_0_PRESENT
-  auto cpu_managed_axi4_read_func =
-      std::bind(&simif_emul_t::cpu_managed_axi4_read, this, _1, _2, _3);
-  auto cpu_managed_axi4_write_func =
-      std::bind(&simif_emul_t::cpu_managed_axi4_write, this, _1, _2, _3);
+    auto cpu_managed_axi4_read_func =
+        std::bind(&simif_emul_t::cpu_managed_axi4_read, this, _1, _2, _3);
+    auto cpu_managed_axi4_write_func =
+        std::bind(&simif_emul_t::cpu_managed_axi4_write, this, _1, _2, _3);
 
-  for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_from_cpu_stream_count; i++) {
-    auto params = CPUManagedStreams::StreamParameters(
-        std::string(CPUMANAGEDSTREAMENGINE_0_from_cpu_names[i]),
-        CPUMANAGEDSTREAMENGINE_0_from_cpu_dma_addrs[i],
-        CPUMANAGEDSTREAMENGINE_0_from_cpu_count_addrs[i],
-        CPUMANAGEDSTREAMENGINE_0_from_cpu_buffer_sizes[i]);
+    for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_from_cpu_stream_count;
+         i++) {
+      auto params = CPUManagedStreams::StreamParameters(
+          std::string(CPUMANAGEDSTREAMENGINE_0_from_cpu_names[i]),
+          CPUMANAGEDSTREAMENGINE_0_from_cpu_dma_addrs[i],
+          CPUMANAGEDSTREAMENGINE_0_from_cpu_count_addrs[i],
+          CPUMANAGEDSTREAMENGINE_0_from_cpu_buffer_sizes[i]);
 
-    cpu_to_fpga_streams.push_back(
-        std::make_unique<CPUManagedStreams::CPUToFPGADriver>(
-            params, mmio_read_func, cpu_managed_axi4_write_func));
-  }
+      cpu_to_fpga_streams.push_back(
+          std::make_unique<CPUManagedStreams::CPUToFPGADriver>(
+              params, *conf, mmio_read_func, cpu_managed_axi4_write_func));
+    }
 
-  for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
-    auto params = CPUManagedStreams::StreamParameters(
-        std::string(CPUMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
-        CPUMANAGEDSTREAMENGINE_0_to_cpu_dma_addrs[i],
-        CPUMANAGEDSTREAMENGINE_0_to_cpu_count_addrs[i],
-        CPUMANAGEDSTREAMENGINE_0_to_cpu_buffer_sizes[i]);
+    for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
+      auto params = CPUManagedStreams::StreamParameters(
+          std::string(CPUMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
+          CPUMANAGEDSTREAMENGINE_0_to_cpu_dma_addrs[i],
+          CPUMANAGEDSTREAMENGINE_0_to_cpu_count_addrs[i],
+          CPUMANAGEDSTREAMENGINE_0_to_cpu_buffer_sizes[i]);
 
-    fpga_to_cpu_streams.push_back(
-        std::make_unique<CPUManagedStreams::FPGAToCPUDriver>(
-            params, mmio_read_func, cpu_managed_axi4_read_func));
-  }
+      fpga_to_cpu_streams.push_back(
+          std::make_unique<CPUManagedStreams::FPGAToCPUDriver>(
+              params, *conf, mmio_read_func, cpu_managed_axi4_read_func));
+    }
 #endif // CPUMANAGEDSTREAMENGINE_0_PRESENT
-#ifdef FPGAMANAGEDSTREAMENGINE_0_PRESENT
-  auto fpga_address_memory_base = ((char *)cpu_mem->get_data());
-  auto offset = 0;
-
-  for (size_t i = 0; i < FPGAMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
-    auto params = FPGAManagedStreams::StreamParameters(
-        std::string(FPGAMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_fpgaBufferDepth[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrHighAddrs[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrLowAddrs[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesAvailableAddrs[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesConsumedAddrs[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamDoneInitAddrs[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushAddrs[i],
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushDoneAddrs[i]);
-
-    fpga_to_cpu_streams.push_back(
-        std::make_unique<FPGAManagedStreams::FPGAToCPUDriver>(
-            params,
-            (void *)(fpga_address_memory_base + offset),
-            offset,
-            mmio_read_func,
-            mmio_write_func));
-    offset += params.buffer_capacity;
   }
 
+  if (auto conf = config.fpga_managed) {
+    // The final parameter, line size, is not used under mm_magic_t
+    cpu_mem.reset(new mm_magic_t(*conf));
+    cpu_mem->init((1ULL << conf->addr_bits), 512);
+
+#ifdef FPGAMANAGEDSTREAMENGINE_0_PRESENT
+    auto fpga_address_memory_base = ((char *)cpu_mem->get_data());
+    auto offset = 0;
+
+    for (size_t i = 0; i < FPGAMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
+      auto params = FPGAManagedStreams::StreamParameters(
+          std::string(FPGAMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_fpgaBufferDepth[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrHighAddrs[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrLowAddrs[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesAvailableAddrs[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesConsumedAddrs[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamDoneInitAddrs[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushAddrs[i],
+          FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushDoneAddrs[i]);
+
+      fpga_to_cpu_streams.push_back(
+          std::make_unique<FPGAManagedStreams::FPGAToCPUDriver>(
+              params,
+              (void *)(fpga_address_memory_base + offset),
+              offset,
+              mmio_read_func,
+              mmio_write_func));
+      offset += params.buffer_capacity;
+    }
 #endif // FPGAMANAGEDSTREAMENGINE_0_PRESENT
+  }
 
   // Set up the simulation thread.
   finished = false;
@@ -135,16 +139,18 @@ void simif_emul_t::wait_read(mmio_t &mmio, void *data) {
 }
 
 void simif_emul_t::write(size_t addr, uint32_t data) {
-  size_t strb = (1 << CTRL_STRB_BITS) - 1;
-  static_assert(CTRL_AXI4_SIZE == 2,
-                "AXI4-lite control interface has unexpected size");
-  master->write_req(addr, CTRL_AXI4_SIZE, 0, &data, &strb);
+  uint64_t size = master->get_config().get_size();
+  assert(size == 2 && "AXI4-lite control interface has unexpected size");
+  uint64_t strb = (1 << master->get_config().strb_bits()) - 1;
+  master->write_req(addr, size, 0, &data, &strb);
   wait_write(*master);
 }
 
 uint32_t simif_emul_t::read(size_t addr) {
+  uint64_t size = master->get_config().get_size();
+  assert(size == 2 && "AXI4-lite control interface has unexpected size");
   uint32_t data;
-  master->read_req(addr, CTRL_AXI4_SIZE, 0);
+  master->read_req(addr, size, 0);
   wait_read(*master, &data);
   return data;
 }
@@ -181,52 +187,49 @@ void simif_emul_t::push_flush(unsigned stream_idx) {
 
 size_t
 simif_emul_t::cpu_managed_axi4_read(size_t addr, char *data, size_t size) {
-  ssize_t len = (size - 1) / CPU_MANAGED_AXI4_BEAT_BYTES;
+  const uint64_t beat_bytes = config.cpu_managed->beat_bytes();
+  ssize_t len = (size - 1) / beat_bytes;
 
   while (len >= 0) {
     size_t part_len = len % (MAX_LEN + 1);
 
-    cpu_managed_axi4->read_req(
-        addr, log2(CPU_MANAGED_AXI4_BEAT_BYTES), part_len);
+    cpu_managed_axi4->read_req(addr, log2(beat_bytes), part_len);
     wait_read(*cpu_managed_axi4, data);
 
     len -= (part_len + 1);
-    addr += (part_len + 1) * CPU_MANAGED_AXI4_BEAT_BYTES;
-    data += (part_len + 1) * CPU_MANAGED_AXI4_BEAT_BYTES;
+    addr += (part_len + 1) * beat_bytes;
+    data += (part_len + 1) * beat_bytes;
   }
   return size;
 }
 
 size_t
 simif_emul_t::cpu_managed_axi4_write(size_t addr, char *data, size_t size) {
-  ssize_t len = (size - 1) / CPU_MANAGED_AXI4_BEAT_BYTES;
-  size_t remaining = size - len * CPU_MANAGED_AXI4_BEAT_BYTES;
+  const uint64_t beat_bytes = config.cpu_managed->beat_bytes();
+  ssize_t len = (size - 1) / beat_bytes;
+  const size_t remaining = size - len * beat_bytes;
   size_t strb[len + 1];
   size_t *strb_ptr = &strb[0];
 
   for (int i = 0; i < len; i++) {
-#if CPU_MANAGED_AXI4_BEAT_BYTES == 64
-    strb[i] = -1;
-#else
-    strb[i] = (1LL << CPU_MANAGED_AXI4_BEAT_BYTES) - 1;
-#endif
+    strb[i] = beat_bytes > 63 ? -1 : ((1LL << beat_bytes) - 1);
   }
 
-  if (remaining == CPU_MANAGED_AXI4_BEAT_BYTES)
+  if (remaining == beat_bytes)
     strb[len] = strb[0];
   else
     strb[len] = (1LL << remaining) - 1;
 
   while (len >= 0) {
-    size_t part_len = len % (MAX_LEN + 1);
+    const size_t part_len = len % (MAX_LEN + 1);
 
     cpu_managed_axi4->write_req(
-        addr, log2(CPU_MANAGED_AXI4_BEAT_BYTES), part_len, data, strb_ptr);
+        addr, log2(beat_bytes), part_len, data, strb_ptr);
     wait_write(*cpu_managed_axi4);
 
     len -= (part_len + 1);
-    addr += (part_len + 1) * CPU_MANAGED_AXI4_BEAT_BYTES;
-    data += (part_len + 1) * CPU_MANAGED_AXI4_BEAT_BYTES;
+    addr += (part_len + 1) * beat_bytes;
+    data += (part_len + 1) * beat_bytes;
     strb_ptr += (part_len + 1);
   }
 

--- a/sim/midas/src/main/cc/simif_emul.h
+++ b/sim/midas/src/main/cc/simif_emul.h
@@ -20,7 +20,8 @@
  */
 class simif_emul_t : public simif_t {
 public:
-  simif_emul_t(const std::vector<std::string> &args);
+  simif_emul_t(const TargetConfig &config,
+               const std::vector<std::string> &args);
 
   virtual ~simif_emul_t();
 
@@ -117,7 +118,7 @@ protected:
 
   std::string waveform = "dump.vcd";
 
-  uint64_t memsize = 1L << MEM_ADDR_BITS;
+  uint64_t memsize;
 
   /**
    * Advances the simulation by a random number of ticks.

--- a/sim/midas/src/main/cc/simif_emul_vcs.cc
+++ b/sim/midas/src/main/cc/simif_emul_vcs.cc
@@ -3,8 +3,9 @@
 
 #include "simif_emul_vcs.h"
 
-simif_emul_vcs_t::simif_emul_vcs_t(const std::vector<std::string> &args)
-    : simif_emul_t(args) {}
+simif_emul_vcs_t::simif_emul_vcs_t(const TargetConfig &config,
+                                   const std::vector<std::string> &args)
+    : simif_emul_t(config, args) {}
 
 simif_emul_vcs_t::~simif_emul_vcs_t() {}
 
@@ -20,6 +21,6 @@ int vcs_main(int argc, char **argv);
  */
 int main(int argc, char **argv) {
   std::vector<std::string> args{argv + 1, argv + argc};
-  simulator = new simif_emul_vcs_t(args);
+  simulator = new simif_emul_vcs_t(conf_target, args);
   return vcs_main(argc, argv);
 }

--- a/sim/midas/src/main/cc/simif_emul_vcs.h
+++ b/sim/midas/src/main/cc/simif_emul_vcs.h
@@ -17,7 +17,8 @@ void emul_signal_handler(int sig);
  */
 class simif_emul_vcs_t final : public simif_emul_t {
 public:
-  simif_emul_vcs_t(const std::vector<std::string> &args);
+  simif_emul_vcs_t(const TargetConfig &config,
+                   const std::vector<std::string> &args);
   ~simif_emul_vcs_t();
 };
 

--- a/sim/midas/src/main/cc/simif_emul_verilator.cc
+++ b/sim/midas/src/main/cc/simif_emul_verilator.cc
@@ -13,8 +13,8 @@ simif_emul_verilator_t *simulator = nullptr;
 double sc_time_stamp() { return simulator->get_time(); }
 
 simif_emul_verilator_t::simif_emul_verilator_t(
-    const std::vector<std::string> &args)
-    : simif_emul_t(args), top(std::make_unique<Vemul>()) {
+    const TargetConfig &config, const std::vector<std::string> &args)
+    : simif_emul_t(config, args), top(std::make_unique<Vemul>()) {
   simulator = this;
 
 #if VM_TRACE
@@ -72,5 +72,5 @@ void simif_emul_verilator_t::tick() {
 int main(int argc, char **argv) {
   Verilated::commandArgs(argc, argv);
   std::vector<std::string> args(argv + 1, argv + argc);
-  return simif_emul_verilator_t(args).run();
+  return simif_emul_verilator_t(conf_target, args).run();
 }

--- a/sim/midas/src/main/cc/simif_emul_verilator.h
+++ b/sim/midas/src/main/cc/simif_emul_verilator.h
@@ -15,7 +15,8 @@
  */
 class simif_emul_verilator_t final : public simif_emul_t {
 public:
-  simif_emul_verilator_t(const std::vector<std::string> &args);
+  simif_emul_verilator_t(const TargetConfig &config,
+                         const std::vector<std::string> &args);
 
   ~simif_emul_verilator_t();
 

--- a/sim/midas/src/main/cc/simif_f1.h
+++ b/sim/midas/src/main/cc/simif_f1.h
@@ -11,7 +11,7 @@
 
 class simif_f1_t final : public simif_t {
 public:
-  simif_f1_t(const std::vector<std::string> &args);
+  simif_f1_t(const TargetConfig &config, const std::vector<std::string> &args);
   ~simif_f1_t();
 
   // Unused since no F1-specific MMIO is required to setup the simulation.
@@ -39,9 +39,6 @@ public:
   void fpga_setup(int slot_id);
 
 private:
-  char in_buf[CTRL_BEAT_BYTES];
-  char out_buf[CTRL_BEAT_BYTES];
-
   std::vector<CPUManagedStreams::FPGAToCPUDriver> to_host_streams;
   std::vector<CPUManagedStreams::CPUToFPGADriver> from_host_streams;
 

--- a/sim/midas/src/main/cc/simif_vitis.cc
+++ b/sim/midas/src/main/cc/simif_vitis.cc
@@ -16,8 +16,9 @@ constexpr size_t u250_dram_channel_size_bytes = 16ULL * 1024 * 1024 * 1024;
  */
 constexpr uint64_t u250_dram_expected_offset = 0x4000000000L;
 
-simif_vitis_t::simif_vitis_t(const std::vector<std::string> &args)
-    : simif_t(args) {
+simif_vitis_t::simif_vitis_t(const TargetConfig &config,
+                             const std::vector<std::string> &args)
+    : simif_t(config, args) {
   slotid = -1;
   binary_file = "";
 
@@ -115,5 +116,5 @@ uint32_t simif_vitis_t::is_write_ready() {
 
 int main(int argc, char **argv) {
   std::vector<std::string> args(argv + 1, argv + argc);
-  return simif_vitis_t(args).run();
+  return simif_vitis_t(conf_target, args).run();
 }

--- a/sim/midas/src/main/cc/simif_vitis.h
+++ b/sim/midas/src/main/cc/simif_vitis.h
@@ -9,7 +9,8 @@
 
 class simif_vitis_t final : public simif_t {
 public:
-  simif_vitis_t(const std::vector<std::string> &args);
+  simif_vitis_t(const TargetConfig &config,
+                const std::vector<std::string> &args);
   ~simif_vitis_t() {}
 
   // Will be used once FPGA-managed AXI4 is fully plumbed through the shim
@@ -29,6 +30,9 @@ public:
               size_t num_bytes,
               size_t threshold_bytes) override;
   uint32_t is_write_ready();
+
+  void pull_flush(unsigned int stream_no) override {}
+  void push_flush(unsigned int stream_no) override {}
 
 private:
   int slotid;

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -30,21 +30,20 @@ private [midas] object PlatformShim {
 
 abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
   val top = LazyModule(new midas.core.FPGATop)
+
   def genHeader(sb: StringBuilder, target: String) {
-    sb.append("#include <stddef.h>\n")
-    sb.append("#include <stdint.h>\n")
-    sb.append("#include <stdbool.h>\n")
-    sb.append(genStatic("TARGET_NAME", CStrLit(target)))
-    top.module.genHeader(sb)
-    sb.append("\n// Simulation Constants\n")
-    top.module.headerConsts map { case (name, value) =>
-      genMacro(name, UInt32(value)) } addString sb
+    sb.append("#include <cstddef>\n")
+    sb.append("#include <cstdint>\n")
+    sb.append("#include <cstdbool>\n")
+    sb.append("#include <vector>\n")
+    sb.append("#include <optional>\n")
+    sb.append("#include \"config.h\"\n")
+
+    top.module.genHeader(sb, target)
   }
 
   def genVHeader(sb: StringBuilder, target: String): Unit = {
-    def vMacro(arg: (String, Long)): String = s"`define ${arg._1} ${arg._2}\n"
-
-    top.module.headerConsts map vMacro foreach sb.append
+    top.module.genVHeader(sb)
   }
 
   // Emit a `XDCPathToCircuitAnnotation` with the pre- and post-link circuit

--- a/sim/midas/src/main/scala/midas/widgets/LoadMem.scala
+++ b/sim/midas/src/main/scala/midas/widgets/LoadMem.scala
@@ -175,8 +175,14 @@ class LoadMemWidget(val totalDRAMAllocated: BigInt)(implicit p: Parameters) exte
   rDataQ.io.in.bits := memNasti.r.bits.data
 
   genCRFile()
-  }
 
   def memDataChunk: Long =
-    ((module.hKey.dataBits - 1) / p(CtrlNastiKey).dataBits) + 1
+    ((hKey.dataBits - 1) / p(CtrlNastiKey).dataBits) + 1
+
+  override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    super.genHeader(base, sb)
+    import CppGenerationUtils._
+    sb.append(genConstStatic(s"${getWName.toUpperCase}_mem_data_chunk", UInt32(memDataChunk)))
+  }
+  }
 }

--- a/sim/midas/src/main/verilog/top.sv
+++ b/sim/midas/src/main/verilog/top.sv
@@ -1,42 +1,54 @@
 /* verilator lint_off LITENDIAN */
 
-`define AXI4_FWD_STRUCT(name, defname) \
-  typedef struct packed {                                               \
-    bit                              ar_ready;                          \
-    bit                              aw_ready;                          \
-    bit                              w_ready;                           \
-    bit                              r_valid;                           \
-    bit [1:0]                        r_resp;                            \
-    bit [```defname``_ID_BITS-1:0]   r_id;                              \
-    bit [```defname``_DATA_BITS-1:0] r_data;                            \
-    bit                              r_last;                            \
-    bit                              b_valid;                           \
-    bit [1:0]                        b_resp;                            \
-    bit [```defname``_ID_BITS-1:0]   b_id;                              \
-  } name``_fwd_t;                                                       \
-  typedef struct packed {                                               \
-    bit                              ar_valid;                          \
-    bit [```defname``_ADDR_BITS-1:0] ar_addr;                           \
-    bit [```defname``_ID_BITS-1:0]   ar_id;                             \
-    bit [2:0]                        ar_size;                           \
-    bit [7:0]                        ar_len;                            \
-    bit                              aw_valid;                          \
-    bit [```defname``_ADDR_BITS-1:0] aw_addr;                           \
-    bit [```defname``_ID_BITS-1:0]   aw_id;                             \
-    bit [2:0]                        aw_size;                           \
-    bit [7:0]                        aw_len;                            \
-    bit                              w_valid;                           \
-    bit [```defname``_STRB_BITS-1:0] w_strb;                            \
-    bit [```defname``_DATA_BITS-1:0] w_data;                            \
-    bit                              w_last;                            \
-    bit                              r_ready;                           \
-    bit                              b_ready;                           \
+`ifndef CPU_MANAGED_AXI4_ADDR_BITS
+`define CPU_MANAGED_AXI4_ADDR_BITS 0
+`define CPU_MANAGED_AXI4_DATA_BITS 0
+`define CPU_MANAGED_AXI4_ID_BITS 0
+`endif
+
+`ifndef FPGA_MANAGED_AXI4_ADDR_BITS
+`define FPGA_MANAGED_AXI4_ADDR_BITS 0
+`define FPGA_MANAGED_AXI4_DATA_BITS 0
+`define FPGA_MANAGED_AXI4_ID_BITS 0
+`endif
+
+`define AXI4_STRUCT(name, defname) \
+  typedef struct packed {                                                 \
+    bit                                ar_ready;                          \
+    bit                                aw_ready;                          \
+    bit                                w_ready;                           \
+    bit                                r_valid;                           \
+    bit [1:0]                          r_resp;                            \
+    bit [```defname``_ID_BITS-1:0]     r_id;                              \
+    bit [```defname``_DATA_BITS-1:0]   r_data;                            \
+    bit                                r_last;                            \
+    bit                                b_valid;                           \
+    bit [1:0]                          b_resp;                            \
+    bit [```defname``_ID_BITS-1:0]     b_id;                              \
+  } name``_fwd_t;                                                         \
+  typedef struct packed {                                                 \
+    bit                                ar_valid;                          \
+    bit [```defname``_ADDR_BITS-1:0]   ar_addr;                           \
+    bit [```defname``_ID_BITS-1:0]     ar_id;                             \
+    bit [2:0]                          ar_size;                           \
+    bit [7:0]                          ar_len;                            \
+    bit                                aw_valid;                          \
+    bit [```defname``_ADDR_BITS-1:0]   aw_addr;                           \
+    bit [```defname``_ID_BITS-1:0]     aw_id;                             \
+    bit [2:0]                          aw_size;                           \
+    bit [7:0]                          aw_len;                            \
+    bit                                w_valid;                           \
+    bit [```defname``_DATA_BITS/8-1:0] w_strb;                            \
+    bit [```defname``_DATA_BITS-1:0]   w_data;                            \
+    bit                                w_last;                            \
+    bit                                r_ready;                           \
+    bit                                b_ready;                           \
   } name``_rev_t;
 
-`AXI4_FWD_STRUCT(ctrl, CTRL)
-`AXI4_FWD_STRUCT(cpu_managed_axi4, CPU_MANAGED_AXI4)
-`AXI4_FWD_STRUCT(fpga_managed_axi4, FPGA_MANAGED_AXI4)
-`AXI4_FWD_STRUCT(mem, MEM)
+`AXI4_STRUCT(ctrl, CTRL)
+`AXI4_STRUCT(mem, MEM)
+`AXI4_STRUCT(cpu_managed_axi4, CPU_MANAGED_AXI4)
+`AXI4_STRUCT(fpga_managed_axi4, FPGA_MANAGED_AXI4)
 
 `define BIND_AXI_FWD(name, obj)                    \
     .name``_ar_ready(obj.ar_ready),                \
@@ -168,14 +180,16 @@ module emul(
 
   /* verilator lint_off PINMISSING */
   FPGATop FPGATop(
+    `BIND_CHANNEL(ctrl)
 `ifdef CPU_MANAGED_AXI4_PRESENT
     `BIND_CHANNEL(cpu_managed_axi4)
 `endif
 `ifdef FPGA_MANAGED_AXI4_PRESENT
     `BIND_CHANNEL(fpga_managed_axi4)
 `endif
-    `BIND_CHANNEL(ctrl)
+`ifdef MEM_HAS_CHANNEL0
     `BIND_CHANNEL(mem_0)
+`endif
 `ifdef MEM_HAS_CHANNEL1
     `BIND_CHANNEL(mem_1)
 `endif


### PR DESCRIPTION
Instead of passing around multiple macros from the header to the design, options belonging to the same channel are now packed into a structure on the C++ side. The verilator harness still relies on macros. The whole system configuration is grouped under a `AXI4System`. The name might not be the best now, but later the struct should be moved next to `simif_t` since it effectively specifies the configuration of that interface.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

This change should not be externally visible.

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
