### PR TITLE
Eliminate random number generation from simif

### DIFF
--- a/sim/midas/src/main/cc/simif.cc
+++ b/sim/midas/src/main/cc/simif.cc
@@ -111,20 +111,10 @@ simif_t::simif_t(const TargetConfig &config,
     if (arg.find("+loadmem=") == 0) {
       load_mem_path = arg.c_str() + 9;
     }
-    if (arg.find("+seed=") == 0) {
-      seed = strtoll(arg.c_str() + 6, NULL, 10);
-      fprintf(stderr, "Using custom SEED: %ld\n", seed);
-    }
     if (arg.find("+zero-out-dram") == 0) {
       do_zero_out_dram = true;
     }
   }
-
-  gen.seed(seed);
-  fprintf(stderr,
-          "random min: 0x%" PRIx64 ", random max: 0x%" PRIx64 "\n",
-          gen.min(),
-          gen.max());
 }
 
 void simif_t::target_init() {

--- a/sim/midas/src/main/cc/simif.h
+++ b/sim/midas/src/main/cc/simif.h
@@ -249,16 +249,6 @@ public:
   // End host-platform interface.
 
   /**
-   * Returns the seed of the random-number generator.
-   */
-  uint64_t get_seed() const { return seed; };
-
-  /**
-   * Returns the next available random number, modulo limit.
-   */
-  uint64_t rand_next(uint64_t limit) { return gen() % limit; }
-
-  /**
    * Provides the current target cycle of the fastest clock.
    *
    * The target cycle is based on the number of clock tokens enqueued
@@ -329,9 +319,10 @@ protected:
   bool do_zero_out_dram = false;
 
 private:
-  // random numbers
-  uint64_t seed = 0;
-  std::mt19937_64 gen;
+  midas_time_t start_time, end_time;
+  uint64_t start_hcycle = -1;
+  uint64_t end_hcycle = 0;
+  uint64_t end_tcycle = 0;
 };
 
 #endif // __SIMIF_H

--- a/sim/midas/src/main/cc/simif_emul.cc
+++ b/sim/midas/src/main/cc/simif_emul.cc
@@ -25,7 +25,12 @@ simif_emul_t::simif_emul_t(const TargetConfig &config,
     if (arg.find("+fuzz-host-timing=") == 0) {
       maximum_host_delay = atoi(arg.c_str() + 18);
     }
+    if (arg.find("+fuzz-seed=") == 0) {
+      fuzz_seed = strtoll(arg.c_str() + 11, NULL, 10);
+      fprintf(stderr, "Using custom fuzzer seed: %ld\n", fuzz_seed);
+    }
   }
+  fuzz_gen.seed(fuzz_seed);
 
   // Initialise memories.
   for (unsigned i = 0; i < config.mem_num_channels; ++i) {

--- a/sim/midas/src/main/cc/simif_emul.h
+++ b/sim/midas/src/main/cc/simif_emul.h
@@ -116,6 +116,10 @@ protected:
   // bridge streams.
   int maximum_host_delay = 1;
 
+  // random numbers
+  uint64_t fuzz_seed = 0;
+  std::mt19937_64 fuzz_gen;
+
   std::string waveform = "dump.vcd";
 
   uint64_t memsize;
@@ -126,7 +130,7 @@ protected:
    * The number of ticks is bounded by `maximum_host_delay`.
    */
   inline void advance_target() {
-    unsigned nticks = rand_next(maximum_host_delay) + 1;
+    unsigned nticks = fuzz_gen() % maximum_host_delay + 1;
     for (unsigned i = 0; i < nticks; ++i)
       do_tick();
   }

--- a/sim/src/main/cc/midasexamples/TestWireInterconnect.cc
+++ b/sim/src/main/cc/midasexamples/TestWireInterconnect.cc
@@ -9,7 +9,7 @@ public:
   void run_test() {
     gmp_randstate_t rstate;
     gmp_randinit_default(rstate);
-    gmp_randseed_ui(rstate, simif->get_seed());
+    gmp_randseed_ui(rstate, 0u);
     mpz_t vbIn_bar_bits, vbOut_bar_bits;
     mpz_inits(vbIn_bar_bits, NULL);
     int width = 128;

--- a/sim/src/test/scala/midasexamples/ChiselExampleDesigns.scala
+++ b/sim/src/test/scala/midasexamples/ChiselExampleDesigns.scala
@@ -38,7 +38,7 @@ class CustomConstraintsF1Test extends TutorialSuite("CustomConstraints") {
 
 class TerminationF1Test extends TutorialSuite("TerminationModule") {
   (1 to 10).foreach { x =>
-    runTest(backendSimulator, args = Seq("+termination-bridge-tick-rate=10", s"+seed=${x}"), shouldPass = true)
+    runTest(backendSimulator, args = Seq("+termination-bridge-tick-rate=10", s"+fuzz-seed=${x}"), shouldPass = true)
   }
 }
 


### PR DESCRIPTION
This patch moves random number generation logic to `simif_emul_t` out of `simif_t` to further narrow the scope of `simif_t`. The generation of fuzzer randoms should be decoupled from the generation of simulation-specific random numbers.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
