### PR TITLE
[library] Introduced a unique main to the simulation.

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/serial.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.cc
@@ -61,7 +61,6 @@ serial_t::serial_t(simif_t &simif,
   printf("\n");
 
   tsi_argc = argc_count + 1;
-  fesvr = new firesim_tsi_t(tsi_argc, tsi_argv, has_mem);
 }
 
 serial_t::~serial_t() {
@@ -75,6 +74,11 @@ serial_t::~serial_t() {
 }
 
 void serial_t::init() {
+  // `ucontext` used by tsi cannot be created in one thread and resumed in
+  // another. To ensure that the tsi process is on the correct thread, it is
+  // built here, as the bridge constructor may be invoked from a thread other
+  // than the one it will run on later in meta-simulations.
+  fesvr = new firesim_tsi_t(tsi_argc, tsi_argv, has_mem);
   write(mmio_addrs.step_size, step_size);
   go();
 }

--- a/sim/make/cpp-lint.mk
+++ b/sim/make/cpp-lint.mk
@@ -11,16 +11,14 @@ clang_tidy_files := $(shell \
 	find $(firesim_base_dir) -name '*.cc' -or -name '*.h' \
 		| grep -v generic_vharness.cc \
 		| grep -v TestPointerChaser.cc \
-		| grep -v simif.cc \
 		| grep -v simif_ \
 		| grep -v tracerv \
 		| grep -v dromajo \
 		| grep -v serial \
 		| grep -v fesvr \
-		| grep -v firesim_top \
 		| grep -v generated-src \
 		| grep -v output \
-		| grep -v constructor.h \
+		| grep -v -F 'main.cc' \
 )
 
 clang_tidy_flags :=\

--- a/sim/midas/src/main/cc/bridges/peek_poke.h
+++ b/sim/midas/src/main/cc/bridges/peek_poke.h
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include "core/simif.h"
+#include "core/timing.h"
 
 struct PEEKPOKEBRIDGEMODULE_struct {
   uint64_t STEP;

--- a/sim/midas/src/main/cc/core/constructor.h
+++ b/sim/midas/src/main/cc/core/constructor.h
@@ -76,7 +76,7 @@ UARTBRIDGEMODULE_checks;
 #ifdef LOADMEMWIDGET_0_PRESENT
 registry.add_widget(new loadmem_t(simif,
                                   LOADMEMWIDGET_0_substruct_create,
-                                  config.mem,
+                                  conf_target.mem,
                                   LOADMEMWIDGET_0_mem_data_chunk));
 #endif // LOADMEMWIDGET_0_PRESENT
 

--- a/sim/midas/src/main/cc/core/main.cc
+++ b/sim/midas/src/main/cc/core/main.cc
@@ -1,0 +1,82 @@
+// See LICENSE for license details.
+
+#include <memory>
+
+#include "core/config.h"
+#include "core/simif.h"
+#include "core/simulation.h"
+
+#include "bridges/autocounter.h"
+#include "bridges/clock.h"
+#include "bridges/cpu_managed_stream.h"
+#include "bridges/fased_memory_timing_model.h"
+#include "bridges/fpga_managed_stream.h"
+#include "bridges/fpga_model.h"
+#include "bridges/loadmem.h"
+#include "bridges/master.h"
+#include "bridges/plusargs.h"
+#include "bridges/reset_pulse.h"
+#include "bridges/synthesized_assertions.h"
+#include "bridges/synthesized_prints.h"
+#include "bridges/termination.h"
+
+#ifdef PEEKPOKEBRIDGEMODULE_0_PRESENT
+#include "bridges/peek_poke.h"
+#endif
+#ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
+#include "bridges/blockdev.h"
+#endif
+#ifdef DROMAJOBRIDGEMODULE_0_PRESENT
+#include "bridges/dromajo.h"
+#endif
+#ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
+#include "bridges/groundtest.h"
+#endif
+#ifdef SERIALBRIDGEMODULE_0_PRESENT
+#include "bridges/serial.h"
+#endif
+#ifdef SIMPLENICBRIDGEMODULE_0_PRESENT
+#include "bridges/simplenic.h"
+#endif
+#ifdef TRACERVBRIDGEMODULE_0_PRESENT
+#include "bridges/tracerv.h"
+#endif
+#ifdef UARTBRIDGEMODULE_0_PRESENT
+#include "bridges/uart.h"
+#endif
+
+// The user-defined part of the driver implements this method to return
+// a simulation instance implementing all simulation-specific logic.
+extern std::unique_ptr<simulation_t>
+create_simulation(const std::vector<std::string> &args, simif_t &simif);
+
+// The platform-specific component of the driver implements this method
+// to return a handle to the simulation.
+extern std::unique_ptr<simif_t>
+create_simif(const TargetConfig &config, int argc, char **argv);
+
+// clang-format off
+
+// Entry point of the driver.
+int main(int argc, char **argv) {
+  std::vector<std::string> args(argv + 1, argv + argc);
+  auto simif_ptr = create_simif(conf_target, argc, argv);
+
+  {
+    auto &simif = *simif_ptr;
+    auto &registry = simif_ptr->get_registry();
+
+    // DOC include start: Bridge Driver Registration
+    // Here we instantiate our driver once for each bridge in the target
+    // Golden Gate emits a <BridgeModuleClassName>_<id>_PRESENT macro for each
+    // instance which you may use to conditionally instantiate your driver.
+    // This file can be included in the setup method of any top-level to pass
+    // an instance of each driver to the `add_bridge_driver` method. Drivers can
+    // be distinguished by overloading the method with the appropriate type.
+    #include "constructor.h"
+    // DOC include end: Bridge Driver Registration
+  }
+
+  auto sim = create_simulation(args, *simif_ptr);
+  return simif_ptr->run(*sim);
+}

--- a/sim/midas/src/main/cc/core/simif.h
+++ b/sim/midas/src/main/cc/core/simif.h
@@ -23,6 +23,7 @@ class StreamEngine;
 class simulation_t;
 class CPUManagedStreamIO;
 class FPGAManagedStreamIO;
+class TargetConfig;
 
 /** \class simif_t
  *
@@ -95,45 +96,45 @@ public:
    * (will report a larger number).
    */
   uint64_t actual_tcycle() {
-    return registry->get_widget<clockmodule_t>().tcycle();
+    return registry.get_widget<clockmodule_t>().tcycle();
   }
 
   /**
    * Provides the current host cycle.
    */
   uint64_t actual_hcycle() {
-    return registry->get_widget<clockmodule_t>().hcycle();
+    return registry.get_widget<clockmodule_t>().hcycle();
   }
 
   /**
    * Return the name of the simulated target.
    */
-  std::string_view get_target_name() const { return config.target_name; }
+  std::string_view get_target_name() const;
 
   /**
    * Return a reference to the registry which owns all widgets.
    */
-  widget_registry_t &get_registry() { return *registry; }
+  widget_registry_t &get_registry() { return registry; }
 
-private:
   /**
-   * Waits for the target to be initialised.
+   * Runs the simulation in the context of the driver.
+   *
+   * The default implementation initialises the target and hands control to
+   * the driver routines, suitable for actual FPGA implementations.
    */
-  void target_init();
-
-  void load_mem(std::string filename);
+  virtual int run(simulation_t &sim);
 
 protected:
   /**
-   * Simulation main loop.
+   * Sets up the target and blocks until it is initialized.
    */
-  int simulation_run();
+  void target_init();
 
 protected:
   /**
    * Target configuration.
    */
-  const TargetConfig config;
+  const TargetConfig &config;
 
   /**
    * Saved command-line arguments.
@@ -143,12 +144,7 @@ protected:
   /**
    * Helper holding references to all bridges.
    */
-  std::unique_ptr<widget_registry_t> registry;
-
-  /**
-   * Reference to the user-defined bits of the simulation.
-   */
-  std::unique_ptr<simulation_t> sim;
+  widget_registry_t registry;
 
   /**
    * Path to load DRAM contents from.

--- a/sim/midas/src/main/cc/core/widget_registry.cc
+++ b/sim/midas/src/main/cc/core/widget_registry.cc
@@ -2,55 +2,11 @@
 
 #include "widget_registry.h"
 
-#include "core/bridge_driver.h"
-
-#include "bridges/autocounter.h"
-#include "bridges/clock.h"
-#include "bridges/cpu_managed_stream.h"
 #include "bridges/fased_memory_timing_model.h"
-#include "bridges/fpga_managed_stream.h"
-#include "bridges/fpga_model.h"
-#include "bridges/loadmem.h"
-#include "bridges/master.h"
-#include "bridges/plusargs.h"
-#include "bridges/reset_pulse.h"
-#include "bridges/synthesized_assertions.h"
-#include "bridges/synthesized_prints.h"
-#include "bridges/termination.h"
+#include "core/bridge_driver.h"
+#include "core/stream_engine.h"
 
-#ifdef PEEKPOKEBRIDGEMODULE_0_PRESENT
-#include "bridges/peek_poke.h"
-#endif
-#ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
-#include "bridges/blockdev.h"
-#endif
-#ifdef DROMAJOBRIDGEMODULE_0_PRESENT
-#include "bridges/dromajo.h"
-#endif
-#ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
-#include "bridges/groundtest.h"
-#endif
-#ifdef SERIALBRIDGEMODULE_0_PRESENT
-#include "bridges/serial.h"
-#endif
-#ifdef SIMPLENICBRIDGEMODULE_0_PRESENT
-#include "bridges/simplenic.h"
-#endif
-#ifdef TRACERVBRIDGEMODULE_0_PRESENT
-#include "bridges/tracerv.h"
-#endif
-#ifdef UARTBRIDGEMODULE_0_PRESENT
-#include "bridges/uart.h"
-#endif
-
-widget_registry_t::widget_registry_t(const TargetConfig &config,
-                                     simif_t &simif,
-                                     const std::vector<std::string> &args)
-    : config(config) {
-
-  widget_registry_t &registry = *this;
-#include "constructor.h"
-}
+widget_registry_t::widget_registry_t() = default;
 
 widget_registry_t::~widget_registry_t() = default;
 

--- a/sim/midas/src/main/cc/core/widget_registry.h
+++ b/sim/midas/src/main/cc/core/widget_registry.h
@@ -26,10 +26,7 @@ class StreamEngine;
  */
 class widget_registry_t final {
 public:
-  widget_registry_t(const TargetConfig &config,
-                    simif_t &simif,
-                    const std::vector<std::string> &args);
-
+  widget_registry_t();
   ~widget_registry_t();
 
   /**
@@ -94,9 +91,6 @@ public:
   void add_widget(StreamEngine *widget);
 
 private:
-  // Target-specific configuration.
-  const TargetConfig config;
-
   // Mapping from bridge kinds to the list of bridges of that kind.
   using widget_list_t = std::vector<std::unique_ptr<widget_t>>;
   std::unordered_map<const void *, widget_list_t> widgets;

--- a/sim/midas/src/main/cc/emul/simif_emul.h
+++ b/sim/midas/src/main/cc/emul/simif_emul.h
@@ -39,7 +39,7 @@ public:
   int end();
 
   /**
-   * Simulation thread implementation.
+   * Start the driver thread.
    *
    * This thread is synchronized by the main thread driven by Verilator/VCS
    * which simulates the RTL and invokes the tick function through DPI. At
@@ -53,7 +53,7 @@ public:
    * runs for one cycle, handling the AXI transactions, before switching control
    * back to the target thread that reads outputs into the RTL.
    */
-  void thread_main();
+  void start_driver(simulation_t &sim);
 
   /**
    * Transfers control to the simulator on a tick.

--- a/sim/midas/src/main/cc/simif_emul_verilator.cc
+++ b/sim/midas/src/main/cc/simif_emul_verilator.cc
@@ -21,7 +21,7 @@ public:
 
   ~simif_emul_verilator_t();
 
-  int run();
+  int run(simulation_t &sim);
 
   uint64_t get_time() const { return main_time; }
 
@@ -62,7 +62,9 @@ simif_emul_verilator_t::~simif_emul_verilator_t() {
 #endif
 }
 
-int simif_emul_verilator_t::run() {
+int simif_emul_verilator_t::run(simulation_t &sim) {
+  start_driver(sim);
+
   top->clock = 0;
 
   top->reset = 1;
@@ -98,8 +100,9 @@ void simif_emul_verilator_t::tick() {
   top->eval();
 }
 
-int main(int argc, char **argv) {
+std::unique_ptr<simif_t>
+create_simif(const TargetConfig &config, int argc, char **argv) {
   Verilated::commandArgs(argc, argv);
   std::vector<std::string> args(argv + 1, argv + argc);
-  return simif_emul_verilator_t(conf_target, args).run();
+  return std::make_unique<simif_emul_verilator_t>(config, args);
 }

--- a/sim/midas/src/main/cc/simif_f1.cc
+++ b/sim/midas/src/main/cc/simif_f1.cc
@@ -16,8 +16,6 @@ public:
   simif_f1_t(const TargetConfig &config, const std::vector<std::string> &args);
   ~simif_f1_t();
 
-  int run() { return simulation_run(); }
-
   void write(size_t addr, uint32_t data) override;
   uint32_t read(size_t addr) override;
 
@@ -204,7 +202,8 @@ uint32_t simif_f1_t::is_write_ready() {
   return value & 0xFFFFFFFF;
 }
 
-int main(int argc, char **argv) {
+std::unique_ptr<simif_t>
+create_simif(const TargetConfig &config, int argc, char **argv) {
   std::vector<std::string> args(argv + 1, argv + argc);
-  return simif_f1_t(conf_target, args).run();
+  return std::make_unique<simif_f1_t>(config, args);
 }

--- a/sim/midas/src/main/cc/simif_f1_xsim.cc
+++ b/sim/midas/src/main/cc/simif_f1_xsim.cc
@@ -14,8 +14,6 @@ public:
                   const std::vector<std::string> &args);
   ~simif_f1_xsim_t();
 
-  int run() { return simulation_run(); }
-
   void write(size_t addr, uint32_t data) override;
   uint32_t read(size_t addr) override;
 
@@ -107,7 +105,8 @@ uint32_t simif_f1_xsim_t::is_write_ready() {
   return *((uint64_t *)buf);
 }
 
-int main(int argc, char **argv) {
+std::unique_ptr<simif_t>
+create_simif(const TargetConfig &config, int argc, char **argv) {
   std::vector<std::string> args(argv + 1, argv + argc);
-  return simif_f1_xsim_t(conf_target, args).run();
+  return std::make_unique<simif_f1_xsim_t>(config, args);
 }

--- a/sim/midas/src/main/cc/simif_vitis.cc
+++ b/sim/midas/src/main/cc/simif_vitis.cc
@@ -19,8 +19,6 @@ public:
                 const std::vector<std::string> &args);
   ~simif_vitis_t() {}
 
-  int run() { return simulation_run(); }
-
   void write(size_t addr, uint32_t data) override;
   uint32_t read(size_t addr) override;
 
@@ -138,7 +136,8 @@ char *simif_vitis_t::get_memory_base() {
   abort();
 }
 
-int main(int argc, char **argv) {
+std::unique_ptr<simif_t>
+create_simif(const TargetConfig &config, int argc, char **argv) {
   std::vector<std::string> args(argv + 1, argv + argc);
-  return simif_vitis_t(conf_target, args).run();
+  return std::make_unique<simif_vitis_t>(config, args);
 }

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -11,11 +11,11 @@
 class firesim_top_t : public systematic_scheduler_t, public simulation_t {
 public:
   firesim_top_t(const std::vector<std::string> &args, simif_t &sim);
-  ~firesim_top_t() {}
+  ~firesim_top_t() override = default;
 
-  void simulation_init();
-  void simulation_finish();
-  int simulation_run();
+  void simulation_init() override;
+  void simulation_finish() override;
+  int simulation_run() override;
 
 private:
   // profile interval: # of cycles to advance before profiling instrumentation


### PR DESCRIPTION
The main method centralizes more of the lifecycle of a simulation. This file will become the only one reliant on the automatically generated header. This PR also moves the simulation to its own file as it is now separate from simif.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
