### PR TITLE
Added a bridge registry to own all bridge instances

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,7 @@ Checks: >
         bugprone-copy-constructor-init,
         bugprone-dangling-handle,
         bugprone-dynamic-static-initializers,
-        #bugprone-macro-parentheses,
+        bugprone-macro-parentheses,
         bugprone-macro-repeated-side-effects,
         bugprone-misplaced-widening-cast,
         bugprone-move-forwarding-reference,

--- a/docs/Golden-Gate/Bridge-Walkthrough.rst
+++ b/docs/Golden-Gate/Bridge-Walkthrough.rst
@@ -132,11 +132,11 @@ Registering the Driver
 ++++++++++++++++++++++
 
 With the Bridge Driver implemented, we now have to register it in the main simulator
-simulator class defined in ``sim/src/main/cc/firesim/firesim_top.cc``. Here, we
+simulator class defined in ``sim/midas/src/main/cc/core/constructor.h``. Here, we
 rely on the C preprocessor macros to instantiate the bridge driver only when
 the corresponding BridgeModule is present:
 
-.. literalinclude:: ../../sim/src/main/cc/firesim/firesim_top.cc
+.. literalinclude:: ../../sim/midas/src/main/cc/core/constructor.h
     :language: c++
     :start-after: DOC include start: Bridge Driver Registration
     :end-before: DOC include end: Bridge Driver Registration

--- a/sim/make/cpp-lint.mk
+++ b/sim/make/cpp-lint.mk
@@ -20,6 +20,7 @@ clang_tidy_files := $(shell \
 		| grep -v firesim_top \
 		| grep -v generated-src \
 		| grep -v output \
+		| grep -v constructor.h \
 )
 
 clang_tidy_flags :=\

--- a/sim/midas/src/main/cc/bridges/cpu_managed_stream.cc
+++ b/sim/midas/src/main/cc/bridges/cpu_managed_stream.cc
@@ -1,6 +1,7 @@
 #include "cpu_managed_stream.h"
+#include "core/simif.h"
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 /**
@@ -87,28 +88,19 @@ size_t CPUManagedStreams::FPGAToCPUDriver::pull(void *dest,
   return bytes_read;
 }
 
-CPUManagedStreamWidget::CPUManagedStreamWidget(CPUManagedStreamIO &io) {
-#ifdef CPUMANAGEDSTREAMENGINE_0_PRESENT
-  for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_from_cpu_stream_count; i++) {
+CPUManagedStreamWidget::CPUManagedStreamWidget(
+    CPUManagedStreamIO &io,
+    std::vector<CPUManagedStreams::StreamParameters> &&from_cpu,
+    std::vector<CPUManagedStreams::StreamParameters> &&to_cpu) {
+  for (auto &&params : from_cpu) {
     cpu_to_fpga_streams.push_back(
-        std::make_unique<CPUManagedStreams::CPUToFPGADriver>(
-            CPUManagedStreams::StreamParameters(
-                std::string(CPUMANAGEDSTREAMENGINE_0_from_cpu_names[i]),
-                CPUMANAGEDSTREAMENGINE_0_from_cpu_dma_addrs[i],
-                CPUMANAGEDSTREAMENGINE_0_from_cpu_count_addrs[i],
-                CPUMANAGEDSTREAMENGINE_0_from_cpu_buffer_sizes[i]),
-            io));
+        std::make_unique<CPUManagedStreams::CPUToFPGADriver>(std::move(params),
+                                                             io));
   }
 
-  for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
+  for (auto &&params : to_cpu) {
     fpga_to_cpu_streams.push_back(
-        std::make_unique<CPUManagedStreams::FPGAToCPUDriver>(
-            CPUManagedStreams::StreamParameters(
-                std::string(CPUMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
-                CPUMANAGEDSTREAMENGINE_0_to_cpu_dma_addrs[i],
-                CPUMANAGEDSTREAMENGINE_0_to_cpu_count_addrs[i],
-                CPUMANAGEDSTREAMENGINE_0_to_cpu_buffer_sizes[i]),
-            io));
+        std::make_unique<CPUManagedStreams::FPGAToCPUDriver>(std::move(params),
+                                                             io));
   }
-#endif // CPUMANAGEDSTREAMENGINE_0_PRESENT
 }

--- a/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
+++ b/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
@@ -159,7 +159,10 @@ public:
    *
    * @param io Reference to a functor implementing low-level IO.
    */
-  CPUManagedStreamWidget(CPUManagedStreamIO &io);
+  CPUManagedStreamWidget(
+      CPUManagedStreamIO &io,
+      std::vector<CPUManagedStreams::StreamParameters> &&from_cpu,
+      std::vector<CPUManagedStreams::StreamParameters> &&to_cpu);
 };
 
 #endif // __BRIDGES_CPU_MANAGED_STREAM_H

--- a/sim/midas/src/main/cc/bridges/fpga_managed_stream.cc
+++ b/sim/midas/src/main/cc/bridges/fpga_managed_stream.cc
@@ -56,30 +56,20 @@ void FPGAManagedStreams::FPGAToCPUDriver::flush() {
   }
 }
 
-FPGAManagedStreamWidget::FPGAManagedStreamWidget(FPGAManagedStreamIO &io) {
-#ifdef FPGAMANAGEDSTREAMENGINE_0_PRESENT
-  char *fpga_address_memory_base = io.get_memory_base();
-  auto offset = 0;
+FPGAManagedStreamWidget::FPGAManagedStreamWidget(
+    FPGAManagedStreamIO &io,
+    std::vector<FPGAManagedStreams::StreamParameters> &&to_cpu) {
 
-  for (size_t i = 0; i < FPGAMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
-    uint32_t buffer_capacity =
-        FPGAMANAGEDSTREAMENGINE_0_to_cpu_fpgaBufferDepth[i];
+  char *fpga_address_memory_base = io.get_memory_base();
+  uint64_t offset = 0;
+  for (auto &&params : to_cpu) {
+    uint32_t capacity = params.buffer_capacity;
     fpga_to_cpu_streams.push_back(
         std::make_unique<FPGAManagedStreams::FPGAToCPUDriver>(
-            FPGAManagedStreams::StreamParameters(
-                std::string(FPGAMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
-                buffer_capacity,
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrHighAddrs[i],
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrLowAddrs[i],
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesAvailableAddrs[i],
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesConsumedAddrs[i],
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamDoneInitAddrs[i],
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushAddrs[i],
-                FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushDoneAddrs[i]),
+            std::move(params),
             (void *)(fpga_address_memory_base + offset),
             offset,
             io));
-    offset += buffer_capacity;
+    offset += capacity;
   }
-#endif // FPGAMANAGEDSTREAMENGINE_0_PRESENT
 }

--- a/sim/midas/src/main/cc/bridges/fpga_managed_stream.h
+++ b/sim/midas/src/main/cc/bridges/fpga_managed_stream.h
@@ -116,7 +116,9 @@ public:
    *
    * @param io Reference to a functor implementing the low-level IO.
    */
-  FPGAManagedStreamWidget(FPGAManagedStreamIO &io);
+  FPGAManagedStreamWidget(
+      FPGAManagedStreamIO &io,
+      std::vector<FPGAManagedStreams::StreamParameters> &&to_cpu);
 };
 
 #endif // __BRIDGES_FPGA_MANAGED_STREAM_H

--- a/sim/midas/src/main/cc/core/constructor.h
+++ b/sim/midas/src/main/cc/core/constructor.h
@@ -1,33 +1,15 @@
+// DOC include start: Bridge Driver Registration
+
 // Helper file to be included in a method to instantiate all bridges available.
-// Each bridge is constructed and passed to the `add_bridge_driver` method.
+// Each bridge is constructed and passed to the `registry.add_widget` method.
 // Top-levels can filter the bridges they want to add by creating overloads
-// of the `add_bridge_driver` method with appropriate types.
+// of the `registry.add_widget` method with appropriate types.
 
-#ifdef PEEKPOKEBRIDGEMODULE_0_PRESENT
-add_bridge_driver(new peek_poke_t(*simif,
-                                  PEEKPOKEBRIDGEMODULE_0_substruct_create,
-                                  POKE_SIZE,
-                                  (const uint32_t *)INPUT_ADDRS,
-                                  (const char *const *)INPUT_NAMES,
-                                  (const uint32_t *)INPUT_CHUNKS,
-                                  PEEK_SIZE,
-                                  (const uint32_t *)OUTPUT_ADDRS,
-                                  (const char *const *)OUTPUT_NAMES,
-                                  (const uint32_t *)OUTPUT_CHUNKS));
-#endif
-
-#ifdef RESETPULSEBRIDGEMODULE_checks
-RESETPULSEBRIDGEMODULE_checks;
-#endif // RESETPULSEBRIDGEMODULE_checks
-
-// Bridge Driver Instantiation Template
-#define INSTANTIATE_RESET_PULSE(FUNC, IDX)                                     \
-  FUNC(new reset_pulse_t(*simif,                                               \
-                         args,                                                 \
-                         RESETPULSEBRIDGEMODULE_##IDX##_substruct_create,      \
-                         RESETPULSEBRIDGEMODULE_##IDX##_max_pulse_length,      \
-                         RESETPULSEBRIDGEMODULE_##IDX##_default_pulse_length,  \
-                         IDX));
+// Here we instantiate our driver once for each bridge in the target
+// Golden Gate emits a <BridgeModuleClassName>_<id>_PRESENT macro for each
+// instance which you may use to conditionally instantiate your driver.
+// This file can be included in the setup method of any top-level to pass
+// an instance of each driver to the `add_bridge_driver` method.
 
 #ifdef CLOCKBRIDGEMODULE_checks
 CLOCKBRIDGEMODULE_checks;
@@ -39,54 +21,181 @@ LOADMEMWIDGET_checks;
 SIMULATIONMASTER_checks;
 #endif // SIMULATIONMASTER_checks
 
-#ifdef RESETPULSEBRIDGEMODULE_0_PRESENT
-INSTANTIATE_RESET_PULSE(add_bridge_driver, 0)
-#endif
+#ifdef ASSERTBRIDGEMODULE_checks
+ASSERTBRIDGEMODULE_checks;
+#endif // ASSERTBRIDGEMODULE_checks
 
-#ifdef UARTBRIDGEMODULE_checks
-UARTBRIDGEMODULE_checks;
-#endif // UARTBRIDGEMODULE_checks
+#ifdef TERMINATIONBRIDGEMODULE_checks
+TERMINATIONBRIDGEMODULE_checks;
+#endif // TERMINATIONBRIDGEMODULE_checks
 
-#ifdef UARTBRIDGEMODULE_0_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_0_substruct_create, 0));
-#endif
-#ifdef UARTBRIDGEMODULE_1_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_1_substruct_create, 1));
-#endif
-#ifdef UARTBRIDGEMODULE_2_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_2_substruct_create, 2));
-#endif
-#ifdef UARTBRIDGEMODULE_3_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_3_substruct_create, 3));
-#endif
-#ifdef UARTBRIDGEMODULE_4_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_4_substruct_create, 4));
-#endif
-#ifdef UARTBRIDGEMODULE_5_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_5_substruct_create, 5));
-#endif
-#ifdef UARTBRIDGEMODULE_6_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_6_substruct_create, 6));
-#endif
-#ifdef UARTBRIDGEMODULE_7_PRESENT
-add_bridge_driver(
-    new uart_t(*simif, args, UARTBRIDGEMODULE_7_substruct_create, 7));
-#endif
+#ifdef RESETPULSEBRIDGEMODULE_checks
+RESETPULSEBRIDGEMODULE_checks;
+#endif // RESETPULSEBRIDGEMODULE_checks
 
 #ifdef FASEDMEMORYTIMINGMODEL_checks
 FASEDMEMORYTIMINGMODEL_checks;
 #endif
 
-#define INSTANTIATE_FASED(FUNC, IDX)                                           \
-  FUNC(new FASEDMemoryTimingModel(                                             \
-      *simif,                                                                  \
+#ifdef AUTOCOUNTERBRIDGEMODULE_checks
+AUTOCOUNTERBRIDGEMODULE_checks;
+#endif // AUTOCOUNTERBRIDGEMODULE_checks
+
+#ifdef PRINTBRIDGEMODULE_checks
+PRINTBRIDGEMODULE_checks;
+#endif // PRINTBRIDGEMODULE_checks
+
+#ifdef PLUSARGSBRIDGEMODULE_checks
+PLUSARGSBRIDGEMODULE_checks;
+#endif // PLUSARGSBRIDGEMODULE_checks
+
+#ifdef BLOCKDEVBRIDGEMODULE_checks
+BLOCKDEVBRIDGEMODULE_checks;
+#endif // BLOCKDEVBRIDGEMODULE_checks
+
+#ifdef SERIALBRIDGEMODULE_checks
+SERIALBRIDGEMODULE_checks;
+#endif // SERIALBRIDGEMODULE_checks
+
+#ifdef TRACERVBRIDGEMODULE_checks
+TRACERVBRIDGEMODULE_checks;
+#endif // TRACERVBRIDGEMODULE_checks
+
+#ifdef SIMPLENICBRIDGEMODULE_checks
+SIMPLENICBRIDGEMODULE_checks;
+#endif // SIMPLENICBRIDGEMODULE_checks
+
+#ifdef PEEKPOKEBRIDGEMODULE_checks
+PEEKPOKEBRIDGEMODULE_checks;
+#endif // PEEKPOKEBRIDGEMODULE_checks
+
+#ifdef UARTBRIDGEMODULE_checks
+UARTBRIDGEMODULE_checks;
+#endif // UARTBRIDGEMODULE_checks
+
+#ifdef LOADMEMWIDGET_0_PRESENT
+registry.add_widget(new loadmem_t(simif,
+                                  LOADMEMWIDGET_0_substruct_create,
+                                  config.mem,
+                                  LOADMEMWIDGET_0_mem_data_chunk));
+#endif // LOADMEMWIDGET_0_PRESENT
+
+#ifdef CLOCKBRIDGEMODULE_0_PRESENT
+registry.add_widget(new clockmodule_t(simif,
+                                      CLOCKBRIDGEMODULE_0_substruct_create));
+#endif // CLOCKBRIDGEMODULE_0_PRESENT
+
+#ifdef SIMULATIONMASTER_0_PRESENT
+registry.add_widget(new master_t(simif, SIMULATIONMASTER_0_substruct_create));
+#endif // SIMULATIONMASTER_0_PRESENT
+
+#ifdef CPUMANAGEDSTREAMENGINE_0_PRESENT
+{
+  std::vector<CPUManagedStreams::StreamParameters> from_cpu;
+  for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_from_cpu_stream_count; i++) {
+    from_cpu.emplace_back(
+        std::string(CPUMANAGEDSTREAMENGINE_0_from_cpu_names[i]),
+        CPUMANAGEDSTREAMENGINE_0_from_cpu_dma_addrs[i],
+        CPUMANAGEDSTREAMENGINE_0_from_cpu_count_addrs[i],
+        CPUMANAGEDSTREAMENGINE_0_from_cpu_buffer_sizes[i]);
+  }
+
+  std::vector<CPUManagedStreams::StreamParameters> to_cpu;
+  for (size_t i = 0; i < CPUMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
+    to_cpu.emplace_back(std::string(CPUMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
+                        CPUMANAGEDSTREAMENGINE_0_to_cpu_dma_addrs[i],
+                        CPUMANAGEDSTREAMENGINE_0_to_cpu_count_addrs[i],
+                        CPUMANAGEDSTREAMENGINE_0_to_cpu_buffer_sizes[i]);
+  }
+  registry.add_widget(
+      new CPUManagedStreamWidget(simif.get_cpu_managed_stream_io(),
+                                 std::move(from_cpu),
+                                 std::move(to_cpu)));
+}
+#endif // CPUMANAGEDSTREAMENGINE_0_PRESENT
+
+#ifdef FPGAMANAGEDSTREAMENGINE_0_PRESENT
+{
+  std::vector<FPGAManagedStreams::StreamParameters> to_cpu;
+  for (size_t i = 0; i < FPGAMANAGEDSTREAMENGINE_0_to_cpu_stream_count; i++) {
+    to_cpu.emplace_back(FPGAManagedStreams::StreamParameters(
+        std::string(FPGAMANAGEDSTREAMENGINE_0_to_cpu_names[i]),
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_fpgaBufferDepth[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrHighAddrs[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostPhysAddrLowAddrs[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesAvailableAddrs[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_bytesConsumedAddrs[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamDoneInitAddrs[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushAddrs[i],
+        FPGAMANAGEDSTREAMENGINE_0_to_cpu_toHostStreamFlushDoneAddrs[i]));
+  }
+  registry.add_widget(new FPGAManagedStreamWidget(
+      simif.get_fpga_managed_stream_io(), std::move(to_cpu)));
+}
+#endif // FPGAMANAGEDSTREAMENGINE_0_PRESENT
+
+#define INSTANTIATE_RESET_PULSE(FUNC, IDX)                                     \
+  registry.add_widget(                                                         \
+      new reset_pulse_t(simif,                                                 \
+                        args,                                                  \
+                        RESETPULSEBRIDGEMODULE_##IDX##_substruct_create,       \
+                        RESETPULSEBRIDGEMODULE_##IDX##_max_pulse_length,       \
+                        RESETPULSEBRIDGEMODULE_##IDX##_default_pulse_length,   \
+                        IDX));
+
+#ifdef RESETPULSEBRIDGEMODULE_0_PRESENT
+INSTANTIATE_RESET_PULSE(registry.add_widget, 0)
+#endif
+
+#ifdef PEEKPOKEBRIDGEMODULE_0_PRESENT
+registry.add_widget(new peek_poke_t(simif,
+                                    PEEKPOKEBRIDGEMODULE_0_substruct_create,
+                                    POKE_SIZE,
+                                    (const uint32_t *)INPUT_ADDRS,
+                                    (const char *const *)INPUT_NAMES,
+                                    (const uint32_t *)INPUT_CHUNKS,
+                                    PEEK_SIZE,
+                                    (const uint32_t *)OUTPUT_ADDRS,
+                                    (const char *const *)OUTPUT_NAMES,
+                                    (const uint32_t *)OUTPUT_CHUNKS));
+#endif
+
+#ifdef UARTBRIDGEMODULE_0_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_0_substruct_create, 0));
+#endif
+#ifdef UARTBRIDGEMODULE_1_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_1_substruct_create, 1));
+#endif
+#ifdef UARTBRIDGEMODULE_2_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_2_substruct_create, 2));
+#endif
+#ifdef UARTBRIDGEMODULE_3_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_3_substruct_create, 3));
+#endif
+#ifdef UARTBRIDGEMODULE_4_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_4_substruct_create, 4));
+#endif
+#ifdef UARTBRIDGEMODULE_5_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_5_substruct_create, 5));
+#endif
+#ifdef UARTBRIDGEMODULE_6_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_6_substruct_create, 6));
+#endif
+#ifdef UARTBRIDGEMODULE_7_PRESENT
+registry.add_widget(
+    new uart_t(simif, args, UARTBRIDGEMODULE_7_substruct_create, 7));
+#endif
+
+#define INSTANTIATE_FASED(IDX)                                                 \
+  registry.add_widget(new FASEDMemoryTimingModel(                              \
+      simif,                                                                   \
       AddressMap(FASEDMEMORYTIMINGMODEL_##IDX##_R_num_registers,               \
                  (const unsigned int *)FASEDMEMORYTIMINGMODEL_##IDX##_R_addrs, \
                  (const char *const *)FASEDMEMORYTIMINGMODEL_##IDX##_R_names,  \
@@ -99,192 +208,180 @@ FASEDMEMORYTIMINGMODEL_checks;
       "_" #IDX));
 
 #ifdef FASEDMEMORYTIMINGMODEL_0
-INSTANTIATE_FASED(add_bridge_driver, 0)
+INSTANTIATE_FASED(0)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_1
-INSTANTIATE_FASED(add_bridge_driver, 1)
+INSTANTIATE_FASED(1)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_2
-INSTANTIATE_FASED(add_bridge_driver, 2)
+INSTANTIATE_FASED(2)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_3
-INSTANTIATE_FASED(add_bridge_driver, 3)
+INSTANTIATE_FASED(3)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_4
-INSTANTIATE_FASED(add_bridge_driver, 4)
+INSTANTIATE_FASED(4)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_5
-INSTANTIATE_FASED(add_bridge_driver, 5)
+INSTANTIATE_FASED(5)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_6
-INSTANTIATE_FASED(add_bridge_driver, 6)
+INSTANTIATE_FASED(6)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_7
-INSTANTIATE_FASED(add_bridge_driver, 7)
+INSTANTIATE_FASED(7)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_8
-INSTANTIATE_FASED(add_bridge_driver, 8)
+INSTANTIATE_FASED(8)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_9
-INSTANTIATE_FASED(add_bridge_driver, 9)
+INSTANTIATE_FASED(9)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_10
-INSTANTIATE_FASED(add_bridge_driver, 10)
+INSTANTIATE_FASED(registry.add_widget, 10)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_11
-INSTANTIATE_FASED(add_bridge_driver, 11)
+INSTANTIATE_FASED(registry.add_widget, 11)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_12
-INSTANTIATE_FASED(add_bridge_driver, 12)
+INSTANTIATE_FASED(registry.add_widget, 12)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_13
-INSTANTIATE_FASED(add_bridge_driver, 13)
+INSTANTIATE_FASED(registry.add_widget, 13)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_14
-INSTANTIATE_FASED(add_bridge_driver, 14)
+INSTANTIATE_FASED(registry.add_widget, 14)
 #endif
 #ifdef FASEDMEMORYTIMINGMODEL_15
-INSTANTIATE_FASED(add_bridge_driver, 15)
+INSTANTIATE_FASED(registry.add_widget, 15)
 #endif
 
-#ifdef SERIALBRIDGEMODULE_checks
-SERIALBRIDGEMODULE_checks;
-#endif // SERIALBRIDGEMODULE_checks
-
 #define INSTANTIATE_SERIAL(FUNC, IDX)                                          \
-  FUNC(new serial_t(*simif,                                                    \
+  FUNC(new serial_t(simif,                                                     \
                     args,                                                      \
                     SERIALBRIDGEMODULE_##IDX##_substruct_create,               \
-                    simif->get_loadmem(),                                      \
+                    registry.get_widget<loadmem_t>(),                          \
                     SERIALBRIDGEMODULE_##IDX##_has_memory,                     \
                     SERIALBRIDGEMODULE_##IDX##_memory_offset,                  \
                     IDX));
 
 #ifdef SERIALBRIDGEMODULE_0_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 0)
+INSTANTIATE_SERIAL(registry.add_widget, 0)
 #endif
 #ifdef SERIALBRIDGEMODULE_1_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 1)
+INSTANTIATE_SERIAL(registry.add_widget, 1)
 #endif
 #ifdef SERIALBRIDGEMODULE_2_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 2)
+INSTANTIATE_SERIAL(registry.add_widget, 2)
 #endif
 #ifdef SERIALBRIDGEMODULE_3_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 3)
+INSTANTIATE_SERIAL(registry.add_widget, 3)
 #endif
 #ifdef SERIALBRIDGEMODULE_4_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 4)
+INSTANTIATE_SERIAL(registry.add_widget, 4)
 #endif
 #ifdef SERIALBRIDGEMODULE_5_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 5)
+INSTANTIATE_SERIAL(registry.add_widget, 5)
 #endif
 #ifdef SERIALBRIDGEMODULE_6_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 6)
+INSTANTIATE_SERIAL(registry.add_widget, 6)
 #endif
 #ifdef SERIALBRIDGEMODULE_7_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 7)
+INSTANTIATE_SERIAL(registry.add_widget, 7)
 #endif
 #ifdef SERIALBRIDGEMODULE_8_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 8)
+INSTANTIATE_SERIAL(registry.add_widget, 8)
 #endif
 #ifdef SERIALBRIDGEMODULE_9_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 9)
+INSTANTIATE_SERIAL(registry.add_widget, 9)
 #endif
 #ifdef SERIALBRIDGEMODULE_10_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 10)
+INSTANTIATE_SERIAL(registry.add_widget, 10)
 #endif
 #ifdef SERIALBRIDGEMODULE_11_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 11)
+INSTANTIATE_SERIAL(registry.add_widget, 11)
 #endif
 #ifdef SERIALBRIDGEMODULE_12_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 12)
+INSTANTIATE_SERIAL(registry.add_widget, 12)
 #endif
 #ifdef SERIALBRIDGEMODULE_13_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 13)
+INSTANTIATE_SERIAL(registry.add_widget, 13)
 #endif
 #ifdef SERIALBRIDGEMODULE_14_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 14)
+INSTANTIATE_SERIAL(registry.add_widget, 14)
 #endif
 #ifdef SERIALBRIDGEMODULE_15_PRESENT
-INSTANTIATE_SERIAL(add_bridge_driver, 15)
+INSTANTIATE_SERIAL(registry.add_widget, 15)
 #endif
-
-#ifdef BLOCKDEVBRIDGEMODULE_checks
-BLOCKDEVBRIDGEMODULE_checks;
-#endif // BLOCKDEVBRIDGEMODULE_checks
 
 #ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_0_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_0_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_0_substruct_create,
-                                 0));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_0_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_0_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_0_substruct_create,
+                                   0));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_1_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_1_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_1_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_1_substruct_create,
-                                 1));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_1_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_1_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_1_substruct_create,
+                                   1));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_2_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_2_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_2_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_2_substruct_create,
-                                 2));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_2_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_2_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_2_substruct_create,
+                                   2));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_3_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_3_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_3_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_3_substruct_create,
-                                 3));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_3_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_3_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_3_substruct_create,
+                                   3));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_4_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_4_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_4_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_4_substruct_create,
-                                 4));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_4_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_4_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_4_substruct_create,
+                                   4));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_5_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_5_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_5_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_5_substruct_create,
-                                 5));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_5_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_5_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_5_substruct_create,
+                                   5));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_6_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_6_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_6_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_6_substruct_create,
-                                 6));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_6_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_6_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_6_substruct_create,
+                                   6));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_7_PRESENT
-add_bridge_driver(new blockdev_t(*simif,
-                                 args,
-                                 BLOCKDEVBRIDGEMODULE_7_num_trackers,
-                                 BLOCKDEVBRIDGEMODULE_7_latency_bits,
-                                 BLOCKDEVBRIDGEMODULE_7_substruct_create,
-                                 7));
+registry.add_widget(new blockdev_t(simif,
+                                   args,
+                                   BLOCKDEVBRIDGEMODULE_7_num_trackers,
+                                   BLOCKDEVBRIDGEMODULE_7_latency_bits,
+                                   BLOCKDEVBRIDGEMODULE_7_substruct_create,
+                                   7));
 #endif
 
-#ifdef SIMPLENICBRIDGEMODULE_checks
-SIMPLENICBRIDGEMODULE_checks;
-#endif // SIMPLENICBRIDGEMODULE_checks
-
 #define INSTANTIATE_SIMPLENIC(FUNC, IDX)                                       \
-  FUNC(new simplenic_t(*simif,                                                 \
-                       simif->get_managed_stream(),                            \
+  FUNC(new simplenic_t(simif,                                                  \
+                       *registry.get_stream_engine(),                          \
                        args,                                                   \
                        SIMPLENICBRIDGEMODULE_##IDX##_substruct_create,         \
                        IDX,                                                    \
@@ -294,38 +391,33 @@ SIMPLENICBRIDGEMODULE_checks;
                        SIMPLENICBRIDGEMODULE_##IDX##_from_cpu_stream_depth));
 
 #ifdef SIMPLENICBRIDGEMODULE_0_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 0)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 0)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_1_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 1)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 1)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_2_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 2)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 2)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_3_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 3)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 3)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_4_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 4)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 4)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_5_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 5)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 5)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_6_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 6)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 6)
 #endif
 #ifdef SIMPLENICBRIDGEMODULE_7_PRESENT
-INSTANTIATE_SIMPLENIC(add_bridge_driver, 7)
+INSTANTIATE_SIMPLENIC(registry.add_widget, 7)
 #endif
 
-#ifdef TRACERVBRIDGEMODULE_checks
-TRACERVBRIDGEMODULE_checks;
-#endif // TRACERVBRIDGEMODULE_checks
-
-// Bridge Driver Instantiation Template
 #define INSTANTIATE_TRACERV(FUNC, IDX)                                         \
-  FUNC(new tracerv_t(*simif,                                                   \
-                     simif->get_managed_stream(),                              \
+  FUNC(new tracerv_t(simif,                                                    \
+                     *registry.get_stream_engine(),                            \
                      args,                                                     \
                      TRACERVBRIDGEMODULE_##IDX##_substruct_create,             \
                      TRACERVBRIDGEMODULE_##IDX##_to_cpu_stream_idx,            \
@@ -337,100 +429,100 @@ TRACERVBRIDGEMODULE_checks;
                      IDX));
 
 #ifdef TRACERVBRIDGEMODULE_0_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 0)
+INSTANTIATE_TRACERV(registry.add_widget, 0)
 #endif
 #ifdef TRACERVBRIDGEMODULE_1_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 1)
+INSTANTIATE_TRACERV(registry.add_widget, 1)
 #endif
 #ifdef TRACERVBRIDGEMODULE_2_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 2)
+INSTANTIATE_TRACERV(registry.add_widget, 2)
 #endif
 #ifdef TRACERVBRIDGEMODULE_3_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 3)
+INSTANTIATE_TRACERV(registry.add_widget, 3)
 #endif
 #ifdef TRACERVBRIDGEMODULE_4_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 4)
+INSTANTIATE_TRACERV(registry.add_widget, 4)
 #endif
 #ifdef TRACERVBRIDGEMODULE_5_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 5)
+INSTANTIATE_TRACERV(registry.add_widget, 5)
 #endif
 #ifdef TRACERVBRIDGEMODULE_6_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 6)
+INSTANTIATE_TRACERV(registry.add_widget, 6)
 #endif
 #ifdef TRACERVBRIDGEMODULE_7_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 7)
+INSTANTIATE_TRACERV(registry.add_widget, 7)
 #endif
 #ifdef TRACERVBRIDGEMODULE_8_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 8)
+INSTANTIATE_TRACERV(registry.add_widget, 8)
 #endif
 #ifdef TRACERVBRIDGEMODULE_9_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 9)
+INSTANTIATE_TRACERV(registry.add_widget, 9)
 #endif
 #ifdef TRACERVBRIDGEMODULE_10_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 10)
+INSTANTIATE_TRACERV(registry.add_widget, 10)
 #endif
 #ifdef TRACERVBRIDGEMODULE_11_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 11)
+INSTANTIATE_TRACERV(registry.add_widget, 11)
 #endif
 #ifdef TRACERVBRIDGEMODULE_12_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 12)
+INSTANTIATE_TRACERV(registry.add_widget, 12)
 #endif
 #ifdef TRACERVBRIDGEMODULE_13_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 13)
+INSTANTIATE_TRACERV(registry.add_widget, 13)
 #endif
 #ifdef TRACERVBRIDGEMODULE_14_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 14)
+INSTANTIATE_TRACERV(registry.add_widget, 14)
 #endif
 #ifdef TRACERVBRIDGEMODULE_15_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 15)
+INSTANTIATE_TRACERV(registry.add_widget, 15)
 #endif
 #ifdef TRACERVBRIDGEMODULE_16_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 16)
+INSTANTIATE_TRACERV(registry.add_widget, 16)
 #endif
 #ifdef TRACERVBRIDGEMODULE_17_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 17)
+INSTANTIATE_TRACERV(registry.add_widget, 17)
 #endif
 #ifdef TRACERVBRIDGEMODULE_18_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 18)
+INSTANTIATE_TRACERV(registry.add_widget, 18)
 #endif
 #ifdef TRACERVBRIDGEMODULE_19_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 19)
+INSTANTIATE_TRACERV(registry.add_widget, 19)
 #endif
 #ifdef TRACERVBRIDGEMODULE_20_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 20)
+INSTANTIATE_TRACERV(registry.add_widget, 20)
 #endif
 #ifdef TRACERVBRIDGEMODULE_21_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 21)
+INSTANTIATE_TRACERV(registry.add_widget, 21)
 #endif
 #ifdef TRACERVBRIDGEMODULE_22_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 22)
+INSTANTIATE_TRACERV(registry.add_widget, 22)
 #endif
 #ifdef TRACERVBRIDGEMODULE_23_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 23)
+INSTANTIATE_TRACERV(registry.add_widget, 23)
 #endif
 #ifdef TRACERVBRIDGEMODULE_24_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 24)
+INSTANTIATE_TRACERV(registry.add_widget, 24)
 #endif
 #ifdef TRACERVBRIDGEMODULE_25_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 25)
+INSTANTIATE_TRACERV(registry.add_widget, 25)
 #endif
 #ifdef TRACERVBRIDGEMODULE_26_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 26)
+INSTANTIATE_TRACERV(registry.add_widget, 26)
 #endif
 #ifdef TRACERVBRIDGEMODULE_27_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 27)
+INSTANTIATE_TRACERV(registry.add_widget, 27)
 #endif
 #ifdef TRACERVBRIDGEMODULE_28_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 28)
+INSTANTIATE_TRACERV(registry.add_widget, 28)
 #endif
 #ifdef TRACERVBRIDGEMODULE_29_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 29)
+INSTANTIATE_TRACERV(registry.add_widget, 29)
 #endif
 #ifdef TRACERVBRIDGEMODULE_30_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 30)
+INSTANTIATE_TRACERV(registry.add_widget, 30)
 #endif
 #ifdef TRACERVBRIDGEMODULE_31_PRESENT
-INSTANTIATE_TRACERV(add_bridge_driver, 31)
+INSTANTIATE_TRACERV(registry.add_widget, 31)
 #endif
 
 #ifdef DROMAJOBRIDGEMODULE_0_PRESENT
@@ -458,50 +550,42 @@ INSTANTIATE_TRACERV(add_bridge_driver, 31)
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_full_address)
 #endif
 
-#ifdef GROUNDTESTBRIDGEMODULE_checks
-GROUNDTESTBRIDGEMODULE_checks;
-#endif // GROUNDTESTBRIDGEMODULE_checks
-
 #ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_0_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_0_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_1_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_1_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_1_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_2_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_2_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_2_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_3_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_3_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_3_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_4_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_4_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_4_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_5_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_5_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_5_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_6_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_6_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_6_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_7_PRESENT
-    add_bridge_driver(new groundtest_t(
-            *simif, args, GROUNDTESTBRIDGEMODULE_7_substruct_create));
+    registry.add_widget(new groundtest_t(
+            simif, args, GROUNDTESTBRIDGEMODULE_7_substruct_create));
 #endif
-
-#ifdef AUTOCOUNTERBRIDGEMODULE_checks
-AUTOCOUNTERBRIDGEMODULE_checks;
-#endif // AUTOCOUNTERBRIDGEMODULE_checks
 
 #define INSTANTIATE_AUTOCOUNTER(FUNC, IDX)                                     \
   FUNC(new autocounter_t(                                                      \
-      *simif,                                                                  \
+      simif,                                                                   \
       args,                                                                    \
       AUTOCOUNTERBRIDGEMODULE_##IDX##_substruct_create,                        \
       AddressMap(                                                              \
@@ -525,82 +609,74 @@ AUTOCOUNTERBRIDGEMODULE_checks;
       IDX));
 
 #ifdef AUTOCOUNTERBRIDGEMODULE_0_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 0)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 0)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_1_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 1)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 1)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_2_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 2)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 2)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_3_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 3)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 3)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_4_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 4)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 4)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_5_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 5)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 5)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_6_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 6)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 6)
 #endif
 #ifdef AUTOCOUNTERBRIDGEMODULE_7_PRESENT
-    INSTANTIATE_AUTOCOUNTER(add_bridge_driver, 7)
+    INSTANTIATE_AUTOCOUNTER(registry.add_widget, 7)
 #endif
 
-#ifdef ASSERTBRIDGEMODULE_checks
-ASSERTBRIDGEMODULE_checks;
-#endif // ASSERTBRIDGEMODULE_checks
-
 #ifdef ASSERTBRIDGEMODULE_0_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_0_substruct_create,
                                                    ASSERTBRIDGEMODULE_0_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_1_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_1_substruct_create,
                                                    ASSERTBRIDGEMODULE_1_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_2_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_2_substruct_create,
                                                    ASSERTBRIDGEMODULE_2_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_3_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_3_substruct_create,
                                                    ASSERTBRIDGEMODULE_3_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_4_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_4_substruct_create,
                                                    ASSERTBRIDGEMODULE_4_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_5_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_5_substruct_create,
                                                    ASSERTBRIDGEMODULE_5_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_6_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_6_substruct_create,
                                                    ASSERTBRIDGEMODULE_6_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_7_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(*simif, args,
+    registry.add_widget(new synthesized_assertions_t(simif, args,
                                                    ASSERTBRIDGEMODULE_7_substruct_create,
                                                    ASSERTBRIDGEMODULE_7_assert_messages));
 #endif
 
-#ifdef PRINTBRIDGEMODULE_checks
-PRINTBRIDGEMODULE_checks;
-#endif // PRINTBRIDGEMODULE_checks
-
 #define INSTANTIATE_PRINTF(FUNC, IDX)                                          \
-  FUNC(new synthesized_prints_t(*simif,                                        \
-                                simif->get_managed_stream(),                   \
+  FUNC(new synthesized_prints_t(simif,                                         \
+                                *registry.get_stream_engine(),                 \
                                 args,                                          \
                                 PRINTBRIDGEMODULE_##IDX##_substruct_create,    \
                                 PRINTBRIDGEMODULE_##IDX##_print_count,         \
@@ -618,36 +694,32 @@ PRINTBRIDGEMODULE_checks;
                                 IDX));
 
 #ifdef PRINTBRIDGEMODULE_0_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,0)
+    INSTANTIATE_PRINTF(registry.add_widget,0)
 #endif
 #ifdef PRINTBRIDGEMODULE_1_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,1)
+    INSTANTIATE_PRINTF(registry.add_widget,1)
 #endif
 #ifdef PRINTBRIDGEMODULE_2_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,2)
+    INSTANTIATE_PRINTF(registry.add_widget,2)
 #endif
 #ifdef PRINTBRIDGEMODULE_3_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,3)
+    INSTANTIATE_PRINTF(registry.add_widget,3)
 #endif
 #ifdef PRINTBRIDGEMODULE_4_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,4)
+    INSTANTIATE_PRINTF(registry.add_widget,4)
 #endif
 #ifdef PRINTBRIDGEMODULE_5_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,5)
+    INSTANTIATE_PRINTF(registry.add_widget,5)
 #endif
 #ifdef PRINTBRIDGEMODULE_6_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,6)
+    INSTANTIATE_PRINTF(registry.add_widget,6)
 #endif
 #ifdef PRINTBRIDGEMODULE_7_PRESENT
-    INSTANTIATE_PRINTF(add_bridge_driver,7)
+    INSTANTIATE_PRINTF(registry.add_widget,7)
 #endif
 
-#ifdef PLUSARGSBRIDGEMODULE_checks
-PLUSARGSBRIDGEMODULE_checks;
-#endif // PLUSARGSBRIDGEMODULE_checks
-
 #define INSTANTIATE_PLUSARGS(FUNC, IDX)                                        \
-  FUNC(new plusargs_t(*simif,                                                  \
+  FUNC(new plusargs_t(simif,                                                   \
                       args,                                                    \
                       PLUSARGSBRIDGEMODULE_##IDX##_substruct_create,           \
                       PLUSARGSBRIDGEMODULE_##IDX##_name,                       \
@@ -657,36 +729,32 @@ PLUSARGSBRIDGEMODULE_checks;
                       PLUSARGSBRIDGEMODULE_##IDX##_slice_addrs));
 
 #ifdef PLUSARGSBRIDGEMODULE_0_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 0)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 0)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_1_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 1)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 1)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_2_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 2)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 2)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_3_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 3)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 3)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_4_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 4)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 4)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_5_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 5)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 5)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_6_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 6)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 6)
 #endif
 #ifdef PLUSARGSBRIDGEMODULE_7_PRESENT
-    INSTANTIATE_PLUSARGS(add_bridge_driver, 7)
+    INSTANTIATE_PLUSARGS(registry.add_widget, 7)
 #endif
 
-#ifdef TERMINATIONBRIDGEMODULE_checks
-TERMINATIONBRIDGEMODULE_checks;
-#endif // TERMINATIONBRIDGEMODULE_checks
-
 #define INSTANTIATE_TERMINATION(FUNC, IDX)                                     \
-  FUNC(new termination_t(*simif,                                               \
+  FUNC(new termination_t(simif,                                                \
                          args,                                                 \
                          TERMINATIONBRIDGEMODULE_##IDX##_substruct_create,     \
                          TERMINATIONBRIDGEMODULE_##IDX##_message_count,        \
@@ -694,50 +762,51 @@ TERMINATIONBRIDGEMODULE_checks;
                          TERMINATIONBRIDGEMODULE_##IDX##_message));
 
 #ifdef TERMINATIONBRIDGEMODULE_0_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 0)
+  INSTANTIATE_TERMINATION(registry.add_widget, 0)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_1_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 1)
+  INSTANTIATE_TERMINATION(registry.add_widget, 1)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_2_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 2)
+  INSTANTIATE_TERMINATION(registry.add_widget, 2)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_3_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 3)
+  INSTANTIATE_TERMINATION(registry.add_widget, 3)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_4_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 4)
+  INSTANTIATE_TERMINATION(registry.add_widget, 4)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_5_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 5)
+  INSTANTIATE_TERMINATION(registry.add_widget, 5)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_6_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 6)
+  INSTANTIATE_TERMINATION(registry.add_widget, 6)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_7_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 7)
+  INSTANTIATE_TERMINATION(registry.add_widget, 7)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_8_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 8)
+  INSTANTIATE_TERMINATION(registry.add_widget, 8)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_9_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 9)
+  INSTANTIATE_TERMINATION(registry.add_widget, 9)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_10_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 10)
+  INSTANTIATE_TERMINATION(registry.add_widget, 10)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_11_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 11)
+  INSTANTIATE_TERMINATION(registry.add_widget, 11)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_12_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 12)
+  INSTANTIATE_TERMINATION(registry.add_widget, 12)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_13_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 13)
+  INSTANTIATE_TERMINATION(registry.add_widget, 13)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_14_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 14)
+  INSTANTIATE_TERMINATION(registry.add_widget, 14)
 #endif
 #ifdef TERMINATIONBRIDGEMODULE_15_PRESENT
-  INSTANTIATE_TERMINATION(add_bridge_driver, 15)
+  INSTANTIATE_TERMINATION(registry.add_widget, 15)
 #endif
+// DOC include end: Bridge Driver Registration

--- a/sim/midas/src/main/cc/core/simif.cc
+++ b/sim/midas/src/main/cc/core/simif.cc
@@ -4,18 +4,11 @@
 #include "core/simulation.h"
 #include "core/stream_engine.h"
 
-extern std::unique_ptr<simulation_t>
-create_simulation(const std::vector<std::string> &args, simif_t *simif);
+#include <iostream>
 
 simif_t::simif_t(const TargetConfig &config,
                  const std::vector<std::string> &args)
-    : config(config), loadmem(*this,
-                              LOADMEMWIDGET_0_substruct_create,
-                              config.mem,
-                              LOADMEMWIDGET_0_mem_data_chunk),
-      clock(*this, CLOCKBRIDGEMODULE_0_substruct_create),
-      master(*this, SIMULATIONMASTER_0_substruct_create),
-      sim(create_simulation(args, this)) {
+    : config(config), args(args) {
   for (auto &arg : args) {
     if (arg.find("+fastloadmem") == 0) {
       fastloadmem = true;
@@ -31,27 +24,44 @@ simif_t::simif_t(const TargetConfig &config,
 
 simif_t::~simif_t() {}
 
+CPUManagedStreamIO &simif_t::get_cpu_managed_stream_io() {
+  std::cerr << "CPU-managed streams are not supported" << std::endl;
+  abort();
+}
+
+FPGAManagedStreamIO &simif_t::get_fpga_managed_stream_io() {
+  std::cerr << "FPGA-managed streams are not supported" << std::endl;
+  abort();
+}
+
 void simif_t::target_init() {
+  auto &master = registry->get_widget<master_t>();
+  auto &loadmem = registry->get_widget<loadmem_t>();
+
   // Do any post-constructor initialization required before requesting MMIO
   while (!master.is_init_done())
     ;
 
-  if (!fastloadmem && !load_mem_path.empty()) {
-    loadmem.load_mem_from_file(load_mem_path);
+  if (auto *stream = registry->get_stream_engine()) {
+    stream->init();
   }
-
-  if (managed_stream) {
-    managed_stream->init();
-  }
-}
-
-int simif_t::simulation_run() {
-  target_init();
 
   if (do_zero_out_dram) {
     fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few seconds...\n");
     loadmem.zero_out_dram();
   }
 
+  if (!fastloadmem && !load_mem_path.empty()) {
+    loadmem.load_mem_from_file(load_mem_path);
+  }
+}
+
+extern std::unique_ptr<simulation_t>
+create_simulation(const std::vector<std::string> &args, simif_t &simif);
+
+int simif_t::simulation_run() {
+  registry.reset(new widget_registry_t(config, *this, args));
+  sim = create_simulation(args, *this);
+  target_init();
   return sim->execute_simulation_flow();
 }

--- a/sim/midas/src/main/cc/core/widget_registry.cc
+++ b/sim/midas/src/main/cc/core/widget_registry.cc
@@ -1,0 +1,73 @@
+// See LICENSE for license details.
+
+#include "widget_registry.h"
+
+#include "core/bridge_driver.h"
+
+#include "bridges/autocounter.h"
+#include "bridges/clock.h"
+#include "bridges/cpu_managed_stream.h"
+#include "bridges/fased_memory_timing_model.h"
+#include "bridges/fpga_managed_stream.h"
+#include "bridges/fpga_model.h"
+#include "bridges/loadmem.h"
+#include "bridges/master.h"
+#include "bridges/plusargs.h"
+#include "bridges/reset_pulse.h"
+#include "bridges/synthesized_assertions.h"
+#include "bridges/synthesized_prints.h"
+#include "bridges/termination.h"
+
+#ifdef PEEKPOKEBRIDGEMODULE_0_PRESENT
+#include "bridges/peek_poke.h"
+#endif
+#ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
+#include "bridges/blockdev.h"
+#endif
+#ifdef DROMAJOBRIDGEMODULE_0_PRESENT
+#include "bridges/dromajo.h"
+#endif
+#ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
+#include "bridges/groundtest.h"
+#endif
+#ifdef SERIALBRIDGEMODULE_0_PRESENT
+#include "bridges/serial.h"
+#endif
+#ifdef SIMPLENICBRIDGEMODULE_0_PRESENT
+#include "bridges/simplenic.h"
+#endif
+#ifdef TRACERVBRIDGEMODULE_0_PRESENT
+#include "bridges/tracerv.h"
+#endif
+#ifdef UARTBRIDGEMODULE_0_PRESENT
+#include "bridges/uart.h"
+#endif
+
+widget_registry_t::widget_registry_t(const TargetConfig &config,
+                                     simif_t &simif,
+                                     const std::vector<std::string> &args)
+    : config(config) {
+
+  widget_registry_t &registry = *this;
+#include "constructor.h"
+}
+
+widget_registry_t::~widget_registry_t() = default;
+
+void widget_registry_t::add_widget(widget_t *widget) {
+  widgets[widget->kind].emplace_back(widget);
+}
+
+void widget_registry_t::add_widget(bridge_driver_t *widget) {
+  widgets[widget->kind].emplace_back(widget);
+  all_bridges.push_back(widget);
+}
+
+void widget_registry_t::add_widget(FASEDMemoryTimingModel *widget) {
+  widgets[widget->kind].emplace_back(widget);
+  all_models.push_back(widget);
+}
+
+void widget_registry_t::add_widget(StreamEngine *widget) {
+  stream_engine.reset(widget);
+}

--- a/sim/midas/src/main/cc/core/widget_registry.h
+++ b/sim/midas/src/main/cc/core/widget_registry.h
@@ -1,0 +1,120 @@
+// See LICENSE for license details.
+
+#ifndef __BRIDGE_REGISTRY_H
+#define __BRIDGE_REGISTRY_H
+
+#include "core/config.h"
+#include "core/widget.h"
+
+#include <cassert>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+class FASEDMemoryTimingModel;
+class bridge_driver_t;
+class widget_t;
+class StreamEngine;
+
+/**
+ * Unique class responsible for the creating and ownership of all bridges.
+ *
+ * The bridges of a design are registered with the registry through the
+ * `add_widget` methods for them to be retrieved later through the appropriate
+ * getters.
+ */
+class widget_registry_t final {
+public:
+  widget_registry_t(const TargetConfig &config,
+                    simif_t &simif,
+                    const std::vector<std::string> &args);
+
+  ~widget_registry_t();
+
+  /**
+   * Return a list of pointers to all bridges of a type.
+   *
+   * @tparam T Type of bridge to fetch.
+   * @return List of non-owning pointers to bridges.
+   */
+  template <typename T>
+  std::vector<T *> get_bridges() {
+    std::vector<T *> bridge_list;
+    for (auto &bridge : widgets[&T::KIND]) {
+      bridge_list.push_back(static_cast<T *>(bridge.get()));
+    }
+    return bridge_list;
+  }
+
+  /**
+   * Return a widget of a particular kind which has a single instance.
+   *
+   * This function should only be used with widgets that have a unique instance.
+   * If multiple widgets of the same kind were registered or the widget does
+   * not exist, the function fails.
+   *
+   * @tparam T Type of the widget to fetch
+   * @return Reference to the widget.
+   */
+  template <typename T>
+  T &get_widget() {
+    auto it = widgets.find(&T::KIND);
+    assert(it != widgets.end() && "no bridges registered");
+    assert(it->second.size() == 1 && "multiple bridges registered");
+    return *static_cast<T *>(it->second[0].get());
+  }
+
+  /**
+   * Returns all bridges in the deterministic order of their construction.
+   *
+   * Hash map traversals are not deterministic, especially if keys are pointers.
+   * To be able to iterate over bridges in a stable order across different runs,
+   * the bridges are also stored in a list in the order they are built.
+   */
+  const std::vector<bridge_driver_t *> &get_all_bridges() {
+    return all_bridges;
+  }
+
+  /**
+   * Returns all models in the deterministic order of their construction.
+   */
+  const std::vector<FASEDMemoryTimingModel *> &get_all_models() {
+    return all_models;
+  }
+
+  /**
+   * Returns a pointer to the stream engine widget, if one exists.
+   */
+  StreamEngine *get_stream_engine() { return stream_engine.get(); }
+
+  void add_widget(widget_t *widget);
+  void add_widget(bridge_driver_t *widget);
+  void add_widget(FASEDMemoryTimingModel *widget);
+  void add_widget(StreamEngine *widget);
+
+private:
+  // Target-specific configuration.
+  const TargetConfig config;
+
+  // Mapping from bridge kinds to the list of bridges of that kind.
+  using widget_list_t = std::vector<std::unique_ptr<widget_t>>;
+  std::unordered_map<const void *, widget_list_t> widgets;
+
+  /**
+   * Widget implementing CPU-managed streams.
+   */
+  std::unique_ptr<StreamEngine> stream_engine;
+
+  /**
+   * List of all bridges, maintained in a deterministic order.
+   */
+  std::vector<bridge_driver_t *> all_bridges;
+
+  /**
+   * List of all models, maintained in a deterministic order.
+   */
+  std::vector<FASEDMemoryTimingModel *> all_models;
+};
+
+#endif // __BRIDGE_REGISTRY_H

--- a/sim/midas/src/main/cc/emul/simif_emul.cc
+++ b/sim/midas/src/main/cc/emul/simif_emul.cc
@@ -43,13 +43,11 @@ simif_emul_t::simif_emul_t(const TargetConfig &config,
   if (std::optional<AXI4Config> conf = config.cpu_managed) {
     assert(!config.fpga_managed && "stream should be CPU or FPGA managed");
     cpu_managed_stream_io.reset(new CPUManagedStreamIOImpl(*this, *conf));
-    managed_stream.reset(new CPUManagedStreamWidget(*cpu_managed_stream_io));
   }
 
   if (std::optional<AXI4Config> conf = config.fpga_managed) {
     assert(!config.cpu_managed && "stream should be CPU or FPGA managed");
     fpga_managed_stream_io.reset(new FPGAManagedStreamIOImpl(*this, *conf));
-    managed_stream.reset(new FPGAManagedStreamWidget(*fpga_managed_stream_io));
   }
 
   // Set up the simulation thread.

--- a/sim/midas/src/main/cc/emul/simif_emul.h
+++ b/sim/midas/src/main/cc/emul/simif_emul.h
@@ -113,6 +113,20 @@ public:
    */
   std::vector<std::unique_ptr<mm_t>> slave;
 
+  /**
+   * Return the wrapper around the CPU-managed stream AXI interface.
+   */
+  CPUManagedStreamIO &get_cpu_managed_stream_io() override {
+    return *cpu_managed_stream_io;
+  }
+
+  /**
+   * Return the wrapper around the FPGA-managed stream AXI interface.
+   */
+  FPGAManagedStreamIO &get_fpga_managed_stream_io() override {
+    return *fpga_managed_stream_io;
+  }
+
 protected:
   // The maximum number of cycles the RTL simulator can advance before
   // switching back to the driver process. +fuzz-host-timings sets this to a

--- a/sim/midas/src/main/cc/simif_f1.cc
+++ b/sim/midas/src/main/cc/simif_f1.cc
@@ -56,8 +56,6 @@ simif_f1_t::simif_f1_t(const TargetConfig &config,
     slot_id = 0;
   }
   fpga_setup(slot_id);
-
-  managed_stream.reset(new CPUManagedStreamWidget(*this));
 }
 
 void simif_f1_t::check_rc(int rc, char *infostr) {

--- a/sim/midas/src/main/cc/simif_f1_xsim.cc
+++ b/sim/midas/src/main/cc/simif_f1_xsim.cc
@@ -46,8 +46,6 @@ simif_f1_xsim_t::simif_f1_xsim_t(const TargetConfig &config,
   driver_to_xsim_fd = open(driver_to_xsim, O_WRONLY);
   fprintf(stderr, "opening xsim to driver\n");
   xsim_to_driver_fd = open(xsim_to_driver, O_RDONLY);
-
-  managed_stream.reset(new CPUManagedStreamWidget(*this));
 }
 
 void simif_f1_xsim_t::check_rc(int rc, char *infostr) {}

--- a/sim/midas/src/main/cc/simif_vitis.cc
+++ b/sim/midas/src/main/cc/simif_vitis.cc
@@ -124,6 +124,13 @@ uint32_t simif_vitis_t::read(size_t addr) {
   return value & 0xFFFFFFFF;
 }
 
+AXIStreamIO &simif_vitis_t::get_cpu_managed_stream_io() override {
+  std::cerr << "FPGA-to-CPU Bridge streams are not yet supported on "
+               "vitis-based FPGA deployments."
+            << std::endl;
+  exit(1);
+}
+
 uint32_t simif_vitis_t::is_write_ready() {
   uint64_t addr = 0x4;
   uint32_t value;

--- a/sim/src/main/cc/bridges/BridgeHarness.h
+++ b/sim/src/main/cc/bridges/BridgeHarness.h
@@ -17,12 +17,9 @@ class bridge_driver_t;
  */
 class BridgeHarness : public simulation_t {
 public:
-  BridgeHarness(const std::vector<std::string> &args, simif_t *simif);
+  BridgeHarness(const std::vector<std::string> &args, simif_t &sim);
 
   ~BridgeHarness() override;
-
-  void add_bridge_driver(bridge_driver_t *bridge);
-  void add_bridge_driver(peek_poke_t *bridge);
 
   void simulation_init() override;
   int simulation_run() override;
@@ -33,14 +30,12 @@ protected:
   virtual unsigned get_tick_limit() const = 0;
 
 private:
-  simif_t *simif;
-  std::vector<std::unique_ptr<bridge_driver_t>> bridges;
-  std::unique_ptr<peek_poke_t> peek_poke;
+  peek_poke_t &peek_poke;
 };
 
 #define TEST_MAIN(CLASS_NAME)                                                  \
   std::unique_ptr<simulation_t> create_simulation(                             \
-      const std::vector<std::string> &args, simif_t *simif) {                  \
-    return std::make_unique<CLASS_NAME>(args, simif);                          \
+      const std::vector<std::string> &args, simif_t &sim) {                    \
+    return std::make_unique<CLASS_NAME>(args, sim);                            \
   }
 #endif // MIDAEXAMPLES_BRIDGEHARNESS_H

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -1,21 +1,7 @@
 // See LICENSE for license details
 
-#include "bridges/autocounter.h"
-#include "bridges/blockdev.h"
-#include "bridges/dromajo.h"
 #include "bridges/fased_memory_timing_model.h"
-#include "bridges/fpga_model.h"
-#include "bridges/groundtest.h"
 #include "bridges/heartbeat.h"
-#include "bridges/peek_poke.h"
-#include "bridges/plusargs.h"
-#include "bridges/reset_pulse.h"
-#include "bridges/serial.h"
-#include "bridges/simplenic.h"
-#include "bridges/synthesized_assertions.h"
-#include "bridges/synthesized_prints.h"
-#include "bridges/tracerv.h"
-#include "bridges/uart.h"
 #include "core/bridge_driver.h"
 #include "core/simif.h"
 #include "core/simulation.h"
@@ -23,32 +9,14 @@
 
 class firesim_top_t : public systematic_scheduler_t, public simulation_t {
 public:
-  firesim_top_t(const std::vector<std::string> &args, simif_t *simif);
+  firesim_top_t(const std::vector<std::string> &args, simif_t &sim);
   ~firesim_top_t() {}
 
   void simulation_init();
   void simulation_finish();
   int simulation_run();
 
-protected:
-  void add_bridge_driver(peek_poke_t *peek_poke) { delete peek_poke; }
-  void add_bridge_driver(bridge_driver_t *bridge) {
-    bridges.emplace_back(bridge);
-  }
-  void add_bridge_driver(FpgaModel *bridge) {
-    fpga_models.emplace_back(bridge);
-  }
-
 private:
-  // Simulator interface.
-  simif_t *simif;
-
-  // A registry of all bridge drivers in the simulator
-  std::vector<std::unique_ptr<bridge_driver_t>> bridges;
-  // FPGA-hosted models with programmable registers & instrumentation
-  // (i.e., bridges_drivers whose tick() is a nop)
-  std::vector<std::unique_ptr<FpgaModel>> fpga_models;
-
   // profile interval: # of cycles to advance before profiling instrumentation
   // registers in models
   uint64_t profile_interval = -1;
@@ -60,9 +28,9 @@ private:
   int exit_code();
 };
 
-firesim_top_t::firesim_top_t(const std::vector<std::string> &args,
-                             simif_t *simif)
-    : simulation_t(*simif, args), simif(simif) {
+firesim_top_t::firesim_top_t(const std::vector<std::string> &args, simif_t &sim)
+    : simulation_t(sim, args) {
+
   max_cycles = -1;
   profile_interval = max_cycles;
 
@@ -74,25 +42,27 @@ firesim_top_t::firesim_top_t(const std::vector<std::string> &args,
       profile_interval = atoi(arg.c_str() + 18);
     }
   }
+
+  sim.get_registry().add_widget(new heartbeat_t(sim, args));
 }
 
 bool firesim_top_t::simulation_complete() {
   bool is_complete = false;
-  for (auto &e : bridges) {
+  for (auto &e : sim.get_registry().get_all_bridges()) {
     is_complete |= e->terminate();
   }
   return is_complete;
 }
 
 uint64_t firesim_top_t::profile_models() {
-  for (auto &mod : fpga_models) {
+  for (auto &mod : sim.get_registry().get_all_models()) {
     mod->profile();
   }
   return profile_interval;
 }
 
 int firesim_top_t::exit_code() {
-  for (auto &e : bridges) {
+  for (auto &e : sim.get_registry().get_all_bridges()) {
     if (e->exit_code())
       return e->exit_code();
   }
@@ -100,39 +70,25 @@ int firesim_top_t::exit_code() {
 }
 
 void firesim_top_t::simulation_init() {
-  add_bridge_driver(new heartbeat_t(*simif, args));
-
-  // DOC include start: Bridge Driver Registration
-  // Here we instantiate our driver once for each bridge in the target
-  // Golden Gate emits a <BridgeModuleClassName>_<id>_PRESENT macro for each
-  // instance which you may use to conditionally instantiate your driver.
-  // This file can be included in the setup method of any top-level to pass
-  // an instance of each driver to the `add_bridge_driver` method. Drivers can
-  // be distinguished by overloading the method with the appropriate type.
-#include "core/constructor.h"
-  // DOC include end: Bridge Driver Registration
-
   // Add functions you'd like to periodically invoke on a paused simulator here.
   if (profile_interval != -1) {
     register_task([this]() { return this->profile_models(); }, 0);
   }
 
-  for (auto &e : fpga_models) {
-    e->init();
+  for (auto *bridge : sim.get_registry().get_all_bridges()) {
+    bridge->init();
   }
-
-  for (auto &e : bridges) {
-    e->init();
+  for (auto *model : sim.get_registry().get_all_models()) {
+    model->init();
   }
 }
 
 int firesim_top_t::simulation_run() {
-
   while (!simulation_complete() && !finished_scheduled_tasks()) {
     run_scheduled_tasks();
-    simif->take_steps(get_largest_stepsize(), false);
-    while (!simif->done() && !simulation_complete()) {
-      for (auto &e : bridges)
+    sim.take_steps(get_largest_stepsize(), false);
+    while (!sim.done() && !simulation_complete()) {
+      for (auto &e : sim.get_registry().get_all_bridges())
         e->tick();
     }
   }
@@ -141,16 +97,15 @@ int firesim_top_t::simulation_run() {
 }
 
 void firesim_top_t::simulation_finish() {
-  for (auto &e : fpga_models) {
-    e->finish();
+  for (auto *bridge : sim.get_registry().get_all_bridges()) {
+    bridge->finish();
   }
-
-  for (auto &e : bridges) {
-    e->finish();
+  for (auto *model : sim.get_registry().get_all_models()) {
+    model->finish();
   }
 }
 
 std::unique_ptr<simulation_t>
-create_simulation(const std::vector<std::string> &args, simif_t *simif) {
-  return std::make_unique<firesim_top_t>(args, simif);
+create_simulation(const std::vector<std::string> &args, simif_t &sim) {
+  return std::make_unique<firesim_top_t>(args, sim);
 }

--- a/sim/src/main/cc/midasexamples/AssertTest.h
+++ b/sim/src/main/cc/midasexamples/AssertTest.h
@@ -12,14 +12,12 @@ public:
 
   ~AssertTest() override = default;
 
-  std::vector<std::unique_ptr<synthesized_assertions_t>> assert_endpoints;
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {
-    assert_endpoints.emplace_back(bridge);
-  }
+  std::vector<synthesized_assertions_t *> assert_endpoints =
+      get_bridges<synthesized_assertions_t>();
 
   void simulation_init() override {
     TestHarness::simulation_init();
-    for (auto &assert_endpoint : assert_endpoints) {
+    for (auto *assert_endpoint : assert_endpoints) {
       assert_endpoint->init();
     }
   }

--- a/sim/src/main/cc/midasexamples/AutoCounterTest.h
+++ b/sim/src/main/cc/midasexamples/AutoCounterTest.h
@@ -4,6 +4,7 @@
 #define MIDASEXAMPLES_AUTOCOUNTERMODULE_H
 
 #include "TestHarness.h"
+#include "bridges/autocounter.h"
 
 class AutoCounterTest : public TestHarness {
 public:
@@ -11,14 +12,19 @@ public:
 
   ~AutoCounterTest() override = default;
 
-  std::vector<std::unique_ptr<autocounter_t>> autocounter_endpoints;
-  void add_bridge_driver(autocounter_t *bridge) override {
-    autocounter_endpoints.emplace_back(bridge);
+  const std::vector<autocounter_t *> autocounter_endpoints =
+      get_bridges<autocounter_t>();
+
+  void simulation_init() override {
+    assert(!autocounter_endpoints.empty() && "missing counters");
+    for (auto &autocounter_endpoint : autocounter_endpoints) {
+      autocounter_endpoint->init();
+    }
   }
 
   void run_and_collect(int cycles) {
     step(cycles, false);
-    while (!simif->done()) {
+    while (!sim.done()) {
       for (auto &autocounter_endpoint : autocounter_endpoints) {
         autocounter_endpoint->tick();
       }

--- a/sim/src/main/cc/midasexamples/PassthroughModelTest.h
+++ b/sim/src/main/cc/midasexamples/PassthroughModelTest.h
@@ -11,8 +11,6 @@ class PassthroughModelDriver : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {}
-
   int latency = 1;
   int length = 1 << 16;
 

--- a/sim/src/main/cc/midasexamples/PrintfTest.h
+++ b/sim/src/main/cc/midasexamples/PrintfTest.h
@@ -1,24 +1,29 @@
 // See LICENSE for license details.
 
-#ifndef MIDASEXAMPLES_PRINTFMODULE_H
-#define MIDASEXAMPLES_PRINTFMODULE_H
-
-#include <memory>
+#ifndef MIDASEXAMPLES_PRINTTEST_H
+#define MIDASEXAMPLES_PRINTTEST_H
 
 #include "TestHarness.h"
+#include "bridges/synthesized_prints.h"
 
 class PrintTest : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  std::vector<std::unique_ptr<synthesized_prints_t>> print_endpoints;
-  void add_bridge_driver(synthesized_prints_t *bridge) override {
-    print_endpoints.emplace_back(bridge);
+  ~PrintTest() override = default;
+
+  const std::vector<synthesized_prints_t *> print_endpoints =
+      get_bridges<synthesized_prints_t>();
+
+  void simulation_init() override {
+    for (auto &print_endpoint : print_endpoints) {
+      print_endpoint->init();
+    }
   }
 
   void run_and_collect_prints(int cycles) {
     step(cycles, false);
-    while (!simif->done()) {
+    while (!sim.done()) {
       for (auto &print_endpoint : print_endpoints) {
         print_endpoint->tick();
       }
@@ -29,4 +34,4 @@ public:
   }
 };
 
-#endif // MIDASEXAMPLES_PRINTFMODULE_H
+#endif // MIDASEXAMPLES_PRINTTEST_H

--- a/sim/src/main/cc/midasexamples/TestAssertGlobalResetCondition.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertGlobalResetCondition.cc
@@ -1,22 +1,15 @@
 // See LICENSE for license details.
 
-#include "TestHarness.h"
+#include "AssertTest.h"
 
-class TestAssertGlobalResetCondition final : public TestHarness {
+class TestAssertGlobalResetCondition final : public AssertTest {
 public:
-  using TestHarness::TestHarness;
-
-  std::vector<std::unique_ptr<synthesized_assertions_t>> assert_endpoints;
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {
-    assert_endpoints.emplace_back(bridge);
-  }
+  using AssertTest::AssertTest;
 
   void run_test() override {
-    for (auto &ep : assert_endpoints)
-      ep->init();
     target_reset(2);
     step(40000, false);
-    while (!simif->done()) {
+    while (!sim.done()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
         if (ep->terminate()) {

--- a/sim/src/main/cc/midasexamples/TestAssertModule.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertModule.cc
@@ -8,6 +8,9 @@ public:
   using AssertTest::AssertTest;
 
   void run_test() override {
+    assert(assert_endpoints.size() == 1 && "expected one assert");
+    auto *assert_endpoint = assert_endpoints[0];
+
     int assertions_thrown = 0;
     poke("reset", 1);
     poke("io_a", 0);
@@ -40,8 +43,9 @@ public:
                                  std::to_string(test_case));
         break;
       }
+
       auto &assert_endpoint = *assert_endpoints[0];
-      while (!simif->done()) {
+      while (!sim.done()) {
         assert_endpoint.tick();
         if (assert_endpoint.terminate()) {
           assert_endpoint.resume();

--- a/sim/src/main/cc/midasexamples/TestAssertTorture.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertTorture.cc
@@ -1,23 +1,15 @@
 // See LICENSE for license details.
 
-#include "TestHarness.h"
+#include "AssertTest.h"
 
-class TestAssertTorture final : public TestHarness {
+class TestAssertTorture final : public AssertTest {
 public:
-  using TestHarness::TestHarness;
-
-  std::vector<std::unique_ptr<synthesized_assertions_t>> assert_endpoints;
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {
-    assert_endpoints.emplace_back(bridge);
-  }
+  using AssertTest::AssertTest;
 
   void run_test() override {
-    for (auto &ep : assert_endpoints)
-      ep->init();
-
     target_reset(2);
     step(40000, false);
-    while (!simif->done()) {
+    while (!sim.done()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
         if (ep->terminate()) {

--- a/sim/src/main/cc/midasexamples/TestAutoCounter32bRollover.cc
+++ b/sim/src/main/cc/midasexamples/TestAutoCounter32bRollover.cc
@@ -7,9 +7,6 @@ public:
   using AutoCounterTest::AutoCounterTest;
 
   void run_test() override {
-    for (auto &autocounter_endpoint : autocounter_endpoints) {
-      autocounter_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_a", 0);
     step(1);

--- a/sim/src/main/cc/midasexamples/TestAutoCounterCoverModule.cc
+++ b/sim/src/main/cc/midasexamples/TestAutoCounterCoverModule.cc
@@ -7,9 +7,6 @@ public:
   using AutoCounterTest::AutoCounterTest;
 
   void run_test() override {
-    for (auto &autocounter_endpoint : autocounter_endpoints) {
-      autocounter_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_a", 0);
     step(1);

--- a/sim/src/main/cc/midasexamples/TestAutoCounterGlobalResetCondition.cc
+++ b/sim/src/main/cc/midasexamples/TestAutoCounterGlobalResetCondition.cc
@@ -7,9 +7,6 @@ public:
   using AutoCounterTest::AutoCounterTest;
 
   void run_test() override {
-    for (auto &autocounter_endpoint : autocounter_endpoints) {
-      autocounter_endpoint->init();
-    }
     poke("reset", 1);
     step(4);
     poke("reset", 0);

--- a/sim/src/main/cc/midasexamples/TestAutoCounterModule.cc
+++ b/sim/src/main/cc/midasexamples/TestAutoCounterModule.cc
@@ -7,9 +7,6 @@ public:
   using AutoCounterTest::AutoCounterTest;
 
   void run_test() override {
-    for (auto &autocounter_endpoint : autocounter_endpoints) {
-      autocounter_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_a", 0);
     step(1);

--- a/sim/src/main/cc/midasexamples/TestAutoCounterPrintfModule.cc
+++ b/sim/src/main/cc/midasexamples/TestAutoCounterPrintfModule.cc
@@ -7,9 +7,6 @@ public:
   using PrintTest::PrintTest;
 
   void run_test() override {
-    for (auto &print_endpoint : print_endpoints) {
-      print_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_a", 0);
     step(1);

--- a/sim/src/main/cc/midasexamples/TestGCD.cc
+++ b/sim/src/main/cc/midasexamples/TestGCD.cc
@@ -6,8 +6,6 @@ class TestGCD final : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {}
-
   void run_test() override {
     uint32_t a = 64, b = 48, z = 16; // test vectors
     target_reset();

--- a/sim/src/main/cc/midasexamples/TestHarness.h
+++ b/sim/src/main/cc/midasexamples/TestHarness.h
@@ -5,11 +5,6 @@
 
 #include "bridges/autocounter.h"
 #include "bridges/peek_poke.h"
-#include "bridges/plusargs.h"
-#include "bridges/reset_pulse.h"
-#include "bridges/synthesized_assertions.h"
-#include "bridges/synthesized_prints.h"
-#include "bridges/termination.h"
 #include "core/bridge_driver.h"
 #include "core/simif.h"
 #include "core/simulation.h"
@@ -25,34 +20,14 @@
  */
 class TestHarness : public simulation_t {
 public:
-  TestHarness(const std::vector<std::string> &args, simif_t *simif);
+  TestHarness(const std::vector<std::string> &args, simif_t &sim);
 
   ~TestHarness() override;
-
-  // Bridge creation callbacks.
-#define BRIDGE_HANDLER(ty, name)                                               \
-  virtual void add_bridge_driver(ty *bridge) {                                 \
-    fprintf(stderr, "Cannot handle " name "\n");                               \
-    abort();                                                                   \
-  }
-
-  BRIDGE_HANDLER(autocounter_t, "Auto Counter bridge");
-  BRIDGE_HANDLER(synthesized_assertions_t, "Synthesized Assert bridge");
-  BRIDGE_HANDLER(synthesized_prints_t, "Synthesized Print bridge");
-  BRIDGE_HANDLER(reset_pulse_t, "Reset Pulse bridge");
-  BRIDGE_HANDLER(plusargs_t, "PlusArgs bridge");
-  BRIDGE_HANDLER(termination_t, "Termination bridge");
-
-  void add_bridge_driver(peek_poke_t *bridge) { peek_poke.reset(bridge); }
 
   /**
    * Test entry point to override.
    */
   virtual void run_test() = 0;
-
-  void simulation_init() override {
-#include "core/constructor.h"
-  }
 
   int simulation_run() override {
     run_test();
@@ -68,7 +43,7 @@ public:
   uint32_t peek(std::string_view id, bool blocking = true);
   void peek(std::string_view id, mpz_t &value);
   uint32_t sample_value(std::string_view id) {
-    return peek_poke->sample_value(id);
+    return peek_poke.sample_value(id);
   }
 
   /**
@@ -83,15 +58,28 @@ public:
 
   int teardown();
 
+  /**
+   * Convenience method to get all bridges from the registry.
+   */
+  template <typename T>
+  std::vector<T *> get_bridges() {
+    return sim.get_registry().get_bridges<T>();
+  }
+
+  /**
+   * Convenience method to get a single bridge from the registry.
+   */
+  template <typename T>
+  T &get_bridge() {
+    return sim.get_registry().get_widget<T>();
+  }
+
 protected:
-  simif_t *simif;
+  peek_poke_t &peek_poke;
 
   /// Random number generator for tests, using a fixed default seed.
   uint64_t random_seed = 0;
   std::mt19937_64 random;
-
-private:
-  std::unique_ptr<peek_poke_t> peek_poke;
 
   bool pass = true;
   bool log = true;
@@ -102,7 +90,7 @@ private:
 
 #define TEST_MAIN(CLASS_NAME)                                                  \
   std::unique_ptr<simulation_t> create_simulation(                             \
-      const std::vector<std::string> &args, simif_t *simif) {                  \
-    return std::make_unique<CLASS_NAME>(args, simif);                          \
+      const std::vector<std::string> &args, simif_t &sim) {                    \
+    return std::make_unique<CLASS_NAME>(args, sim);                            \
   }
 #endif // MIDAEXAMPLES_TESTHARNESS_H

--- a/sim/src/main/cc/midasexamples/TestMultiSRAM.cc
+++ b/sim/src/main/cc/midasexamples/TestMultiSRAM.cc
@@ -2,7 +2,7 @@
 
 class TestMultiSRAM final : public MultiRegfileTest {
 public:
-  TestMultiSRAM(const std::vector<std::string> &args, simif_t *simif)
+  TestMultiSRAM(const std::vector<std::string> &args, simif_t &simif)
       : MultiRegfileTest(args, simif) {
     write_first = false;
   }

--- a/sim/src/main/cc/midasexamples/TestMulticlockAssertModule.cc
+++ b/sim/src/main/cc/midasexamples/TestMulticlockAssertModule.cc
@@ -8,13 +8,10 @@ class TestMulticlockAssertModule final : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  std::vector<std::unique_ptr<synthesized_assertions_t>> assert_endpoints;
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {
-    assert_endpoints.emplace_back(bridge);
-  }
-
   void run_test() override {
     int assertions_thrown = 0;
+
+    const auto &assert_endpoints = get_bridges<synthesized_assertions_t>();
 
     for (auto &ep : assert_endpoints)
       ep->init();
@@ -24,8 +21,9 @@ public:
     poke("fullrate_cycle", 186);
     poke("halfrate_pulseLength", 2);
     poke("halfrate_cycle", 129);
+
     step(256, false);
-    while (!simif->done()) {
+    while (!sim.done()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
         if (ep->terminate()) {

--- a/sim/src/main/cc/midasexamples/TestNarrowPrintfModule.cc
+++ b/sim/src/main/cc/midasexamples/TestNarrowPrintfModule.cc
@@ -7,9 +7,6 @@ public:
   using PrintTest::PrintTest;
 
   void run_test() override {
-    for (auto &print_endpoint : print_endpoints) {
-      print_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_enable", 0);
     step(1);
@@ -21,7 +18,7 @@ public:
     step(256);
     poke("io_enable", 1);
     run_and_collect_prints(256);
-  };
+  }
 };
 
 TEST_MAIN(TestNarrowPrintfModule)

--- a/sim/src/main/cc/midasexamples/TestPlusArgsModule.cc
+++ b/sim/src/main/cc/midasexamples/TestPlusArgsModule.cc
@@ -1,10 +1,11 @@
 // See LICENSE for license details.
 
-#include "TestHarness.h"
-
 #include <iomanip>
 #include <iostream>
 #include <string_view>
+
+#include "TestHarness.h"
+#include "bridges/plusargs.h"
 
 /**
  * @brief PlusArgs Bridge Driver Test
@@ -35,19 +36,15 @@ private:
   }
 
 public:
-  std::unique_ptr<plusargs_t> plusargsinator;
-  void add_bridge_driver(plusargs_t *bridge) override {
-    assert(!plusargsinator && "multiple bridges registered");
-    plusargsinator.reset(bridge);
-  }
+  plusargs_t &plusargsinator;
 
   /**
    * Constructor.
    *
    * @param [in] args The argument list from main
    */
-  TestPlusArgsModule(const std::vector<std::string> &args, simif_t *simif)
-      : TestHarness(args, simif) {
+  TestPlusArgsModule(const std::vector<std::string> &args, simif_t &simif)
+      : TestHarness(args, simif), plusargsinator(get_bridge<plusargs_t>()) {
     parse_key(args);
   }
 
@@ -113,7 +110,7 @@ public:
       std::cout << "No test key found, will not assert\n";
     }
 
-    plusargsinator->init();
+    plusargsinator.init();
     target_reset();
 
     for (int i = 0; i < 8; i++) {

--- a/sim/src/main/cc/midasexamples/TestPrintfCycleBounds.cc
+++ b/sim/src/main/cc/midasexamples/TestPrintfCycleBounds.cc
@@ -7,9 +7,6 @@ public:
   using PrintTest::PrintTest;
 
   void run_test() override {
-    for (auto &print_endpoint : print_endpoints) {
-      print_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_a", 0);
     poke("io_b", 0);

--- a/sim/src/main/cc/midasexamples/TestPrintfModule.cc
+++ b/sim/src/main/cc/midasexamples/TestPrintfModule.cc
@@ -7,9 +7,6 @@ public:
   using PrintTest::PrintTest;
 
   void run_test() override {
-    for (auto &print_endpoint : print_endpoints) {
-      print_endpoint->init();
-    }
     poke("reset", 1);
     poke("io_a", 0);
     poke("io_b", 0);

--- a/sim/src/main/cc/midasexamples/TestResetPulseBridgeTest.cc
+++ b/sim/src/main/cc/midasexamples/TestResetPulseBridgeTest.cc
@@ -1,24 +1,21 @@
 // See LICENSE for license details.
 
-#include <vector>
-
 #include "TestHarness.h"
+#include "bridges/reset_pulse.h"
+
+#include <vector>
 
 class TestResetPulseBridge final : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  std::unique_ptr<reset_pulse_t> rb;
-  void add_bridge_driver(reset_pulse_t *bridge) override {
-    assert(!rb && "multiple bridges registered");
-    rb.reset(bridge);
-  }
+  reset_pulse_t &rb = get_bridge<reset_pulse_t>();
 
   // Since we rely on an assertion firing to catch a failure, just run a
   // similation that is at least the length of the expected pulse.
   void run_test() override {
-    rb->init();
-    step(2 * rb->get_max_pulse_length());
+    rb.init();
+    step(2 * rb.get_max_pulse_length());
   }
 };
 

--- a/sim/src/main/cc/midasexamples/TestTerminationModule.cc
+++ b/sim/src/main/cc/midasexamples/TestTerminationModule.cc
@@ -1,19 +1,16 @@
 // See LICENSE for license details.
 
 #include "TestHarness.h"
+#include "bridges/termination.h"
 
+#include <cstring>
 #include <iostream>
-#include <string.h>
 
 class TestTerminationModule final : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  std::unique_ptr<termination_t> terminator;
-  void add_bridge_driver(termination_t *bridge) override {
-    assert(!terminator && "multiple bridges registered");
-    terminator.reset(bridge);
-  }
+  termination_t &terminator = get_bridge<termination_t>();
 
   void run_test() override {
     poke("reset", 1);
@@ -43,13 +40,13 @@ public:
       msgid = 2;
     }
     step(lv_validinCycle + 2, false);
-    while (!terminator->terminate()) {
-      terminator->tick();
+    while (!terminator.terminate()) {
+      terminator.tick();
     }
-    int str_match = terminator->exit_message() == failure_msg_list[msgid];
-    expect(terminator->cycle_count() == (lv_validinCycle + reset_length),
+    int str_match = terminator.exit_message() == failure_msg_list[msgid];
+    expect(terminator.cycle_count() == (lv_validinCycle + reset_length),
            "Code Exits at precise time");
-    expect(terminator->exit_code() == failure_cond_list[msgid],
+    expect(terminator.exit_code() == failure_cond_list[msgid],
            "Error Code Verified");
     expect(str_match, "Error Message Verified");
   };

--- a/sim/src/main/cc/midasexamples/TestTerminationModuleAssert.cc
+++ b/sim/src/main/cc/midasexamples/TestTerminationModuleAssert.cc
@@ -1,16 +1,13 @@
 // See LICENSE for license details.
 
 #include "TestHarness.h"
+#include "bridges/termination.h"
 
 class TestTerminationModuleAssert final : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  std::unique_ptr<termination_t> terminator;
-  void add_bridge_driver(termination_t *bridge) override {
-    assert(!terminator && "multiple bridges registered");
-    terminator.reset(bridge);
-  }
+  termination_t &terminator = get_bridge<termination_t>();
 
   int expected_cycle_at_bridge = 0;
 
@@ -18,9 +15,9 @@ public:
   void step_assume_continue(int count) {
     step(count, false);
     expected_cycle_at_bridge += count;
-    while (!simif->done()) {
-      terminator->tick();
-      assert(!terminator->terminate() && "Unexpected termination signaled.");
+    while (!sim.done()) {
+      terminator.tick();
+      assert(!terminator.terminate() && "Unexpected termination signaled.");
     }
   }
 
@@ -30,9 +27,9 @@ public:
     // Call this repeated to give the sim time to have a poke propagate to the
     // bridge
     for (int i = 0; i < tick_attempts; i++) {
-      terminator->tick();
+      terminator.tick();
     }
-    expect(terminator->terminate(),
+    expect(terminator.terminate(),
            "Termination bridge correctly calls for termination.");
   }
 
@@ -58,9 +55,9 @@ public:
     poke("io_shouldBeTrue", 0);
     step_once_and_wait_on_terminate();
 
-    expect(terminator->cycle_count() == expected_cycle_at_bridge,
+    expect(terminator.cycle_count() == expected_cycle_at_bridge,
            "Termination bridge provides correct exit cycle");
-    expect(terminator->exit_code() == 1,
+    expect(terminator.exit_code() == 1,
            "Termination bridge returns non-zero when used in assert mode");
   };
 };

--- a/sim/src/main/cc/midasexamples/TestTriggerPredicatedPrintf.cc
+++ b/sim/src/main/cc/midasexamples/TestTriggerPredicatedPrintf.cc
@@ -6,12 +6,7 @@ class TestTriggerPredicatedPrintf final : public PrintTest {
 public:
   using PrintTest::PrintTest;
 
-  void run_test() override {
-    for (auto &print_endpoint : print_endpoints) {
-      print_endpoint->init();
-    }
-    run_and_collect_prints(16000);
-  };
+  void run_test() override { run_and_collect_prints(16000); };
 };
 
 TEST_MAIN(TestTriggerPredicatedPrintf)

--- a/sim/src/main/cc/midasexamples/TestTriggerWiringModule.cc
+++ b/sim/src/main/cc/midasexamples/TestTriggerWiringModule.cc
@@ -1,15 +1,14 @@
 // See LICENSE for license details.
 
 #include "TestHarness.h"
+#include "bridges/synthesized_assertions.h"
 
 class TestTriggerWiringModule final : public TestHarness {
 public:
   using TestHarness::TestHarness;
 
-  std::vector<std::unique_ptr<synthesized_assertions_t>> assert_endpoints;
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {
-    assert_endpoints.emplace_back(bridge);
-  }
+  const std::vector<synthesized_assertions_t *> assert_endpoints =
+      get_bridges<synthesized_assertions_t>();
 
   bool simulation_complete() {
     bool is_complete = false;
@@ -37,7 +36,7 @@ public:
     step(1);
     poke("reset", 0);
     step(10000, false);
-    while (!simif->done() && !simulation_complete()) {
+    while (!sim.done() && !simulation_complete()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
       }


### PR DESCRIPTION
This PR introduces the `widget_registry` class which centralizes the ownership of all bridges and widgets of a design.
To distinguish bridges, a simple RTTI mechanism is added to widgets to enable an LLVM-style `dyn_cast` method and categorization of widgets. The registry can then be queried to fetch widgets of lists of bridges of a particular kind.
`simif_t` is also changed to add method retrieving the functors for stream engines, allowing the registry to access them while constructing the stream engine widgets.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

https://docs.google.com/document/d/1ilBNn-Uy6P76GUQWGiALBvJIfKyQpjzzsaOu2RGl9u8#bookmark=id.utpeyue9vfk5

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
