### PR TITLE
Separate XSIM from f1 into simif_xsim

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -43,10 +43,11 @@ include $(TARGET_PROJECT_MAKEFRAG)
 include make/config.mk
 include make/library.mk
 include make/goldengate.mk
-include make/fpga.mk
 include make/verilator.mk
 include make/vcs.mk
 include make/driver.mk
+include make/fpga.mk
+include make/xsim.mk
 include make/unittest.mk
 include make/scala.mk
 

--- a/sim/make/driver.mk
+++ b/sim/make/driver.mk
@@ -22,9 +22,13 @@ $(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' -
 $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	mkdir -p $(OUTPUT_DIR)/build
 	cp $(header) $(OUTPUT_DIR)/build/
-	$(MAKE) -C $(simif_dir) f1 PLATFORM=f1 DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(OUTPUT_DIR)/build OUT_DIR=$(OUTPUT_DIR) DRIVER="$(DRIVER_CC)" \
-	TOP_DIR=$(chipyard_dir)
+	$(MAKE) -C $(simif_dir) driver MAIN=f1 PLATFORM=f1 \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(OUTPUT_DIR)/build \
+		OUT_DIR=$(OUTPUT_DIR) \
+		DRIVER="$(DRIVER_CC)" \
+		TOP_DIR=$(chipyard_dir)
 
 $(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
 	-idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
@@ -36,9 +40,13 @@ $(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN
 $(vitis): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	mkdir -p $(OUTPUT_DIR)/build
 	cp $(header) $(OUTPUT_DIR)/build/
-	$(MAKE) -C $(simif_dir) vitis PLATFORM=vitis DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(OUTPUT_DIR)/build OUT_DIR=$(OUTPUT_DIR) DRIVER="$(DRIVER_CC)" \
-	TOP_DIR=$(chipyard_dir)
+	$(MAKE) -C $(simif_dir) driver MAIN=vitis PLATFORM=vitis \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(OUTPUT_DIR)/build \
+		OUT_DIR=$(OUTPUT_DIR) \
+		DRIVER="$(DRIVER_CC)" \
+		TOP_DIR=$(chipyard_dir)
 
 tags: $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	ctags -R --exclude=@.ctagsignore .

--- a/sim/make/fpga.mk
+++ b/sim/make/fpga.mk
@@ -62,29 +62,6 @@ fpga: export CL_DIR := $(fpga_work_dir)
 fpga: $(fpga_delivery_files) $(base_dir)/scripts/checkpoints/$(target_sim_tuple)
 	cd $(fpga_build_dir)/scripts && ./aws_build_dcp_from_cl.sh -notify
 
-
-#############################
-# FPGA-level RTL Simulation #
-#############################
-
-# Run XSIM DUT
-.PHONY: xsim-dut
-xsim-dut: replace-rtl $(fpga_work_dir)/stamp
-	cd $(verif_dir)/scripts && $(MAKE) C_TEST=test_firesim
-
-# Compile XSIM Driver #
-xsim = $(GENERATED_DIR)/$(DESIGN)-$(PLATFORM)
-
-$(xsim): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) -D SIMULATION_XSIM -D NO_MAIN
-$(xsim): export LDFLAGS := $(LDFLAGS) $(common_ld_flags)
-$(xsim): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
-	$(MAKE) -C $(simif_dir) f1 PLATFORM=f1 DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) OUT_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" \
-	TOP_DIR=$(chipyard_dir)
-
-.PHONY: xsim
-xsim: $(xsim)
-
 #########################
 # Cleaning Recipes      #
 #########################

--- a/sim/make/xsim.mk
+++ b/sim/make/xsim.mk
@@ -1,0 +1,27 @@
+# See LICENSE for license details.
+
+#############################
+# FPGA-level RTL Simulation #
+#############################
+
+# Run XSIM DUT
+.PHONY: xsim-dut
+xsim-dut: replace-rtl $(fpga_work_dir)/stamp
+	cd $(verif_dir)/scripts && $(MAKE) C_TEST=test_firesim
+
+# Compile XSIM Driver #
+xsim = $(GENERATED_DIR)/$(DESIGN)-$(PLATFORM)
+
+$(xsim): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags)
+$(xsim): export LDFLAGS := $(LDFLAGS) $(common_ld_flags)
+$(xsim): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
+	$(MAKE) -C $(simif_dir) driver MAIN=f1_xsim PLATFORM=f1 \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(GENERATED_DIR) \
+		OUT_DIR=$(GENERATED_DIR) \
+		DRIVER="$(DRIVER_CC)" \
+		TOP_DIR=$(chipyard_dir)
+
+.PHONY: xsim
+xsim: $(xsim)

--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -14,6 +14,7 @@ r_dir = $(abspath ../resources)
 # 6) DRIVER: software driver written by user
 # 7) CLOCK_PERIOD(optional): clock period of tests
 # 8) VERILATOR_FLAGS(optional): set of verilator flags to add
+# 9) MAIN: platform-specific main to choose from
 ########################################################################
 
 PLATFORM ?= f1
@@ -35,7 +36,7 @@ $(bridge_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h) $(bridge_h)
 	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -include $(word 2, $^)
 
-platform_files := simif_$(PLATFORM)
+platform_files := simif_$(MAIN)
 platform_cc := $(addprefix $(midas_dir)/, $(addsuffix .cc, $(platform_files)))
 platform_o := $(addprefix $(GEN_DIR)/, $(addsuffix .o, $(platform_files)))
 
@@ -48,7 +49,8 @@ $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(design_h) $(DRIVER) $(driver_h) $(platf
 	$(CXX) $(CXXFLAGS) -include $< \
 	-o $@ $(DRIVER) $(platform_o) $(bridge_o) $(LDFLAGS)
 
-$(PLATFORM): $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
+.PHONY: driver
+driver: $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
 
 # Sources for building MIDAS-level simulators. Must be defined before sources VCS/Verilator Makefrags
 override CXXFLAGS += -std=c++17 -include $(design_h)
@@ -81,4 +83,4 @@ include rtlsim/Makefrag-vcs
 vcs: $(OUT_DIR)/$(DRIVER_NAME)
 vcs-debug: $(OUT_DIR)/$(DRIVER_NAME)-debug
 
-.PHONY: $(PLATFORM) verilator verilator-debug vcs vcs-debug
+.PHONY: verilator verilator-debug vcs vcs-debug

--- a/sim/midas/src/main/cc/simif_f1_xsim.cc
+++ b/sim/midas/src/main/cc/simif_f1_xsim.cc
@@ -1,0 +1,112 @@
+#include <cassert>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "bridges/cpu_managed_stream.h"
+#include "core/simif.h"
+
+class simif_f1_xsim_t final : public simif_t, public CPUManagedStreamIO {
+public:
+  simif_f1_xsim_t(const TargetConfig &config,
+                  const std::vector<std::string> &args);
+  ~simif_f1_xsim_t();
+
+  int run() { return simulation_run(); }
+
+  void write(size_t addr, uint32_t data) override;
+  uint32_t read(size_t addr) override;
+
+  uint32_t is_write_ready();
+  void check_rc(int rc, char *infostr);
+  void fpga_shutdown();
+  void fpga_setup(int slot_id);
+
+private:
+  uint32_t mmio_read(size_t addr) override { return read(addr); }
+  size_t cpu_managed_axi4_write(size_t addr, const char *data, size_t size);
+  size_t cpu_managed_axi4_read(size_t addr, char *data, size_t size);
+  uint64_t get_beat_bytes() const override {
+    return config.cpu_managed->beat_bytes();
+  }
+
+  const char *driver_to_xsim = "/tmp/driver_to_xsim";
+  const char *xsim_to_driver = "/tmp/xsim_to_driver";
+  int driver_to_xsim_fd;
+  int xsim_to_driver_fd;
+};
+
+simif_f1_xsim_t::simif_f1_xsim_t(const TargetConfig &config,
+                                 const std::vector<std::string> &args)
+    : simif_t(config, args) {
+  mkfifo(driver_to_xsim, 0666);
+  fprintf(stderr, "opening driver to xsim\n");
+  driver_to_xsim_fd = open(driver_to_xsim, O_WRONLY);
+  fprintf(stderr, "opening xsim to driver\n");
+  xsim_to_driver_fd = open(xsim_to_driver, O_RDONLY);
+
+  managed_stream.reset(new CPUManagedStreamWidget(*this));
+}
+
+void simif_f1_xsim_t::check_rc(int rc, char *infostr) {}
+
+void simif_f1_xsim_t::fpga_shutdown() {}
+
+void simif_f1_xsim_t::fpga_setup(int slot_id) {}
+
+simif_f1_xsim_t::~simif_f1_xsim_t() { fpga_shutdown(); }
+
+void simif_f1_xsim_t::write(size_t addr, uint32_t data) {
+  uint64_t cmd = (((uint64_t)(0x80000000 | addr)) << 32) | (uint64_t)data;
+  char *buf = (char *)&cmd;
+  ::write(driver_to_xsim_fd, buf, 8);
+}
+
+uint32_t simif_f1_xsim_t::read(size_t addr) {
+  uint64_t cmd = addr;
+  char *buf = (char *)&cmd;
+  ::write(driver_to_xsim_fd, buf, 8);
+
+  int gotdata = 0;
+  while (gotdata == 0) {
+    gotdata = ::read(xsim_to_driver_fd, buf, 8);
+    if (gotdata != 0 && gotdata != 8) {
+      printf("ERR GOTDATA %d\n", gotdata);
+    }
+  }
+  return *((uint64_t *)buf);
+}
+
+size_t
+simif_f1_xsim_t::cpu_managed_axi4_read(size_t addr, char *data, size_t size) {
+  assert(false); // PCIS is unsupported in FPGA-level metasimulation
+}
+
+size_t simif_f1_xsim_t::cpu_managed_axi4_write(size_t addr,
+                                               const char *data,
+                                               size_t size) {
+  assert(false); // PCIS is unsupported in FPGA-level metasimulation
+}
+
+uint32_t simif_f1_xsim_t::is_write_ready() {
+  uint64_t addr = 0x4;
+  uint64_t cmd = addr;
+  char *buf = (char *)&cmd;
+  ::write(driver_to_xsim_fd, buf, 8);
+
+  int gotdata = 0;
+  while (gotdata == 0) {
+    gotdata = ::read(xsim_to_driver_fd, buf, 8);
+    if (gotdata != 0 && gotdata != 8) {
+      printf("ERR GOTDATA %d\n", gotdata);
+    }
+  }
+  return *((uint64_t *)buf);
+}
+
+int main(int argc, char **argv) {
+  std::vector<std::string> args(argv + 1, argv + argc);
+  return simif_f1_xsim_t(conf_target, args).run();
+}


### PR DESCRIPTION
The XSIM implementation is largely disjoint from the F1 one. Separate it. This greatly simplifies the critical F1 implementation, allowing XSIM to be build alongside it.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
