### PR TITLE
Split config.h into AXI4 and Target configs

### DIFF
--- a/sim/midas/src/main/cc/core/axi4.h
+++ b/sim/midas/src/main/cc/core/axi4.h
@@ -1,5 +1,5 @@
-#ifndef __EMUL_AXI4
-#define __EMUL_AXI4
+#ifndef __CORE_AXI4
+#define __CORE_AXI4
 
 #include <cmath>
 #include <cstdint>
@@ -34,20 +34,4 @@ struct AXI4Config {
   uint64_t get_data_size() const { return beat_bytes() / sizeof(uint32_t); }
 };
 
-/**
- * Structure carrying the configuration of a target.
- */
-struct TargetConfig {
-  const AXI4Config ctrl;
-
-  const AXI4Config mem;
-  const unsigned mem_num_channels;
-
-  const std::optional<AXI4Config> cpu_managed;
-
-  const std::optional<AXI4Config> fpga_managed;
-
-  const char *target_name;
-};
-
-#endif // __EMUL_AXI4
+#endif // __CORE_AXI4

--- a/sim/midas/src/main/cc/core/target.h
+++ b/sim/midas/src/main/cc/core/target.h
@@ -1,0 +1,22 @@
+#ifndef __CORE_TARGET_H
+#define __CORE_TARGET_H
+
+#include "core/axi4.h"
+
+/**
+ * Structure carrying the configuration of a target.
+ */
+struct TargetConfig {
+  const AXI4Config ctrl;
+
+  const AXI4Config mem;
+  const unsigned mem_num_channels;
+
+  const std::optional<AXI4Config> cpu_managed;
+
+  const std::optional<AXI4Config> fpga_managed;
+
+  const char *target_name;
+};
+
+#endif // __CORE_TARGET_H

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -37,7 +37,8 @@ abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
     sb.append("#include <cstdbool>\n")
     sb.append("#include <vector>\n")
     sb.append("#include <optional>\n")
-    sb.append("#include \"core/config.h\"\n")
+    sb.append("#include \"core/axi4.h\"\n")
+    sb.append("#include \"core/target.h\"\n")
 
     top.module.genHeader(sb, target)
   }


### PR DESCRIPTION
The target config relies on the optional type, which cannot be compiled using verilator's fixed C++ standard version. This PR splits the problematic header into two, so the files which must be placed under Verilator can include headers that do not rely on any recent C++ features.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
