### PR TITLE
Remove the use of DPI utilities from dpi.cc

### DIFF
--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -56,15 +56,15 @@ override CXXFLAGS += -std=c++17 -include $(design_h)
 # Models of FPGA primitives that are used in host-level sim, but not in FPGATop
 sim_fpga_resource_models := $(v_dir)/BUFGCE.v
 
-emul_files := emul/simif_emul emul/mmio emul/mm
-emul_h     := $(driver_h) $(bridge_h) $(addprefix $(midas_dir)/, $(addsuffix .h, $(emul_files)))
+emul_dir   := $(midas_dir)/emul
+emul_h     := $(driver_h) $(bridge_h) $(emul_dir)/simif_emul.h $(emul_dir)/mmio.h $(emul_dir)/mm.h
 # This includes c sources and static libraries
-emul_cc    := $(DRIVER) $(bridge_cc) $(addprefix $(midas_dir)/, $(addsuffix .cc, $(emul_files)))
+emul_cc    := $(DRIVER) $(bridge_cc) $(emul_dir)/simif_emul.cc $(emul_dir)/mmio.cc $(emul_dir)/mm.cc $(emul_dir)/dpi.cc
 emul_v     := $(design_vh) $(design_v) $(sim_fpga_resource_models)
 
 verilator_conf := rtlsim/ml-verilator-conf.vlt
 verilator_wrapper_v := $(v_dir)/top.sv
-verilator_harness := $(midas_dir)/dpi.cc $(midas_dir)/simif_emul_verilator.cc
+verilator_harness := $(midas_dir)/simif_emul_verilator.cc
 top_module := emul
 include rtlsim/Makefrag-verilator
 
@@ -73,7 +73,7 @@ verilator-debug: $(OUT_DIR)/V$(DRIVER_NAME)-debug
 
 # Add an extra wrapper source for VCS simulators
 vcs_wrapper_v := $(v_dir)/top.sv
-vcs_harness := $(midas_dir)/dpi.cc $(midas_dir)/simif_emul_vcs.cc
+vcs_harness := $(midas_dir)/simif_emul_vcs.cc
 TB := emul
 VCS_FLAGS := -e vcs_main
 include rtlsim/Makefrag-vcs

--- a/sim/midas/src/main/cc/emul/dpi.cc
+++ b/sim/midas/src/main/cc/emul/dpi.cc
@@ -8,19 +8,11 @@
 
 #include <signal.h>
 
-#include <svdpi.h>
-
 #include "emul/mm.h"
 #include "emul/mmio.h"
 #include "emul/simif_emul.h"
 
 extern simif_emul_t *emulator;
-
-#ifdef VCS
-#include "vc_hdrs.h"
-#else
-#include "Vemul.h"
-#endif
 
 /**
  * Helper to encode sequential elements into a packed structure.
@@ -32,7 +24,7 @@ extern simif_emul_t *emulator;
  */
 class StructWriter {
 public:
-  StructWriter(svBitVecVal *vec) : vec(reinterpret_cast<uint64_t *>(vec)) {}
+  StructWriter(uint32_t *vec) : vec(reinterpret_cast<uint64_t *>(vec)) {}
 
   void putScalar(bool value) { putScalarOrVector(value, 1); }
 
@@ -41,24 +33,21 @@ public:
 
     unsigned idx = offset / 64;
     unsigned off = offset % 64;
+    offset += width;
 
     if (off == 0) {
       vec[idx] = value;
-      offset += width;
       return;
     }
 
     unsigned remaining = 64 - off;
     if (remaining >= width) {
       vec[idx] |= value << off;
-      offset += width;
       return;
     }
 
     vec[idx] |= value << off;
     vec[idx + 1] = value >> remaining;
-
-    offset += width;
   }
 
   void putVector(void *data, unsigned width) {
@@ -77,44 +66,47 @@ private:
  */
 class StructReader {
 public:
-  StructReader(const svBitVecVal *vec) : vec(vec) {}
+  StructReader(const uint32_t *vec)
+      : vec(reinterpret_cast<const uint64_t *>(vec)) {}
 
-  bool getScalar() { return svGetBitselBit(vec, offset++); }
+  bool getScalar() { return getScalarOrVector(1); }
 
-  uint64_t getScalarOrVector(int width) {
+  uint64_t getScalarOrVector(unsigned width) {
     assert(width >= 1 && width <= 64);
-    if (width == 1) {
-      return svGetBitselBit(vec, offset++);
-    }
-    if (width <= 32) {
-      svBitVecVal elem;
-      svGetPartselBit(&elem, vec, offset, width);
-      offset += width;
-      return elem;
-    }
-    svBitVecVal lo, hi;
-    svGetPartselBit(&lo, vec, offset, 32);
-    svGetPartselBit(&hi, vec, offset + 32, width - 32);
+
+    unsigned idx = offset / 64;
+    unsigned off = offset % 64;
     offset += width;
-    return lo | (((uint64_t)hi) << 32);
+
+    unsigned remaining = 64 - off;
+    if (remaining >= width) {
+      uint64_t value = (vec[idx] >> off) & ((1ull << width) - 1ull);
+      return value;
+    }
+
+    unsigned rest = width - remaining;
+
+    uint64_t lo = vec[idx] >> off;
+    uint64_t hi = vec[idx + 1] & ((1ull << rest) - 1ull);
+
+    return lo | (hi << (64 - off));
   }
 
-  std::vector<uint32_t> getVector(int width) {
+  std::vector<uint32_t> getVector(unsigned width) {
     std::vector<uint32_t> buffer(width);
     for (size_t i = 0; i < width; i++) {
-      svGetPartselBit(&buffer[i], vec, offset, 32);
-      offset += 32;
+      buffer[i] = getScalarOrVector(32);
     }
     return buffer;
   }
 
 private:
   size_t offset = 0;
-  const svBitVecVal *vec;
+  const uint64_t *vec;
 };
 
 namespace AXI4 {
-void rev_tick(bool rst, mm_t &mem, const svBitVecVal *io) {
+void rev_tick(bool rst, mm_t &mem, const uint32_t *io) {
   const AXI4Config &conf = mem.get_config();
   StructReader r(io);
   auto b_ready = r.getScalar();
@@ -153,7 +145,7 @@ void rev_tick(bool rst, mm_t &mem, const svBitVecVal *io) {
            b_ready);
 }
 
-void fwd_tick(bool rst, mmio_t &mmio, const svBitVecVal *io) {
+void fwd_tick(bool rst, mmio_t &mmio, const uint32_t *io) {
   const AXI4Config &conf = mmio.get_config();
   StructReader r(io);
   auto b_id = r.getScalarOrVector(conf.id_bits);
@@ -180,7 +172,7 @@ void fwd_tick(bool rst, mmio_t &mmio, const svBitVecVal *io) {
             b_valid);
 }
 
-void fwd_put(mm_t &mem, svBitVecVal *io) {
+void fwd_put(mm_t &mem, uint32_t *io) {
   const AXI4Config &conf = mem.get_config();
   StructWriter w(io);
   w.putScalarOrVector(mem.b_id(), conf.id_bits);
@@ -196,7 +188,7 @@ void fwd_put(mm_t &mem, svBitVecVal *io) {
   w.putScalar(mem.ar_ready());
 }
 
-void rev_put(mmio_t &mmio, svBitVecVal *io) {
+void rev_put(mmio_t &mmio, uint32_t *io) {
   const AXI4Config &conf = mmio.get_config();
   StructWriter w(io);
   w.putScalar(mmio.b_ready());
@@ -222,24 +214,24 @@ extern simif_emul_t *simulator;
 
 extern "C" {
 void simulator_tick(
-    /* INPUT  */ const svBit reset,
-    /* OUTPUT */ svBit *fin,
+    /* INPUT  */ const uint8_t reset,
+    /* OUTPUT */ uint8_t *fin,
 
-    /* INPUT  */ const svBitVecVal *ctrl_in,
-    /* INPUT  */ const svBitVecVal *cpu_managed_axi4_in,
-    /* INPUT  */ const svBitVecVal *fpga_managed_axi4_in,
-    /* INPUT  */ const svBitVecVal *mem_0_in,
-    /* INPUT  */ const svBitVecVal *mem_1_in,
-    /* INPUT  */ const svBitVecVal *mem_2_in,
-    /* INPUT  */ const svBitVecVal *mem_3_in,
+    /* INPUT  */ const uint32_t *ctrl_in,
+    /* INPUT  */ const uint32_t *cpu_managed_axi4_in,
+    /* INPUT  */ const uint32_t *fpga_managed_axi4_in,
+    /* INPUT  */ const uint32_t *mem_0_in,
+    /* INPUT  */ const uint32_t *mem_1_in,
+    /* INPUT  */ const uint32_t *mem_2_in,
+    /* INPUT  */ const uint32_t *mem_3_in,
 
-    /* OUTPUT */ svBitVecVal *ctrl_out,
-    /* OUTPUT */ svBitVecVal *cpu_managed_axi4_out,
-    /* OUTPUT */ svBitVecVal *fpga_managed_axi4_out,
-    /* OUTPUT */ svBitVecVal *mem_0_out,
-    /* OUTPUT */ svBitVecVal *mem_1_out,
-    /* OUTPUT */ svBitVecVal *mem_2_out,
-    /* OUTPUT */ svBitVecVal *mem_3_out) {
+    /* OUTPUT */ uint32_t *ctrl_out,
+    /* OUTPUT */ uint32_t *cpu_managed_axi4_out,
+    /* OUTPUT */ uint32_t *fpga_managed_axi4_out,
+    /* OUTPUT */ uint32_t *mem_0_out,
+    /* OUTPUT */ uint32_t *mem_1_out,
+    /* OUTPUT */ uint32_t *mem_2_out,
+    /* OUTPUT */ uint32_t *mem_3_out) {
   try {
     // The driver ucontext is initialized before spawning the VCS
     // context, so these pointers should be initialized.
@@ -249,9 +241,9 @@ void simulator_tick(
     mmio_t *cpu_managed_axi4 = simulator->get_cpu_managed_axi4();
     mm_t *fpga_managed_axi4 = simulator->get_fpga_managed_axi4();
 
-    std::array<svBitVecVal *, 4> mem_out{
+    std::array<uint32_t *, 4> mem_out{
         mem_0_out, mem_1_out, mem_2_out, mem_3_out};
-    std::array<const svBitVecVal *, 4> mem_in{
+    std::array<const uint32_t *, 4> mem_in{
         mem_0_in, mem_1_in, mem_2_in, mem_3_in};
 
     AXI4::fwd_tick(reset, *simulator->master, ctrl_in);

--- a/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/PlatformShim.scala
@@ -32,6 +32,8 @@ abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
   val top = LazyModule(new midas.core.FPGATop)
 
   def genHeader(sb: StringBuilder, target: String) {
+    sb.append("#ifdef __cplusplus\n")
+
     sb.append("#include <cstddef>\n")
     sb.append("#include <cstdint>\n")
     sb.append("#include <cstdbool>\n")
@@ -40,6 +42,8 @@ abstract class PlatformShim(implicit p: Parameters) extends LazyModule()(p) {
     sb.append("#include \"core/config.h\"\n")
 
     top.module.genHeader(sb, target)
+
+    sb.append("#endif // __cplusplus\n")
   }
 
   def genVHeader(sb: StringBuilder, target: String): Unit = {


### PR DESCRIPTION
dpi.cc accesses the underlying arrays using bit manipulation functions. This removes the reliance on the utilities provided in `svdpi.h`, allowing it to be independently compiled and fully shared with verilator.

This change also excludes the generated from C sources, as VCS attempted to compile a file with it included.

The DPI spec guarantees that packed arrays are passed as a pointer to 32-bit elements. The language in the spec does not managed the use of the `svdpi.h` header. Section H.7.7 specifies the layout, allowing us to interface through `uint32_t`.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
