### PR TITLE
[library] Package FireSim driver sources into libraries separate from verilator

### DIFF
--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -445,4 +445,4 @@ jobs:
         run: |
           export FIRESIM_ENV_SOURCED=1
           export FIRESIM_STANDALONE=1
-          make -C sim clang-tidy
+          make -C sim TARGET_PROJECT=midasexamples clang-tidy

--- a/sim/make/driver.mk
+++ b/sim/make/driver.mk
@@ -13,10 +13,15 @@ $(PLATFORM): $($(PLATFORM))
 .PHONY: driver
 driver: $(PLATFORM)
 
-$(f1): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
+F1_CXX_FLAGS := \
+	$(common_cxx_flags) \
+	$(DRIVER_CXXOPTS) \
 	-I$(platforms_dir)/f1/aws-fpga/sdk/userspace/include
-# We will copy shared libs into same directory as driver on runhost, so add $ORIGIN to rpath
-$(f1): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' -L /usr/local/lib64 -lfpga_mgmt
+
+F1_LD_FLAGS := \
+	$(common_ld_flags) \
+	-L/usr/local/lib64 \
+	-lfpga_mgmt
 
 # Compile Driver
 $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -27,15 +32,28 @@ $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
 		GEN_DIR=$(OUTPUT_DIR)/build \
 		OUT_DIR=$(OUTPUT_DIR) \
-		DRIVER="$(DRIVER_CC)" \
-		TOP_DIR=$(chipyard_dir)
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		PLATFORM_CXX_FLAGS="$(F1_CXX_FLAGS)" \
+		PLATFORM_LD_FLAGS="$(F1_LD_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"
 
-$(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
-	-idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
-# -ldl needed for Ubuntu 20.04 systems (is backwards compatible with U18.04 systems)
-$(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-	-L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil -ldl
+VITIS_CXX_FLAGS := \
+	$(common_cxx_flags) \
+	$(DRIVER_CXXOPTS) \
+	-idirafter ${CONDA_PREFIX}/include \
+	-idirafter /usr/include \
+	-idirafter $(XILINX_XRT)/include
 
+VITIS_LD_FLAGS := \
+	$(common_ld_flags) \
+	-L${CONDA_PREFIX}/lib \
+	-Wl,-rpath-link=/usr/lib/x86_64-linux-gnu \
+	-L$(XILINX_XRT)/lib \
+	-luuid \
+	-lxrt_coreutil
 
 # Compile Driver
 $(vitis): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -46,8 +64,13 @@ $(vitis): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
 		GEN_DIR=$(OUTPUT_DIR)/build \
 		OUT_DIR=$(OUTPUT_DIR) \
-		DRIVER="$(DRIVER_CC)" \
-		TOP_DIR=$(chipyard_dir)
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		PLATFORM_CXX_FLAGS="$(VITIS_CXX_FLAGS)" \
+		PLATFORM_LD_FLAGS="$(VITIS_LD_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"
 
 tags: $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 	ctags -R --exclude=@.ctagsignore .

--- a/sim/make/vcs.mk
+++ b/sim/make/vcs.mk
@@ -6,24 +6,35 @@
 
 VCS_CXXOPTS ?= -O2
 
+
 vcs = $(GENERATED_DIR)/$(DESIGN)
+
+.PHONY: vcs
+vcs: $(vcs)
+$(vcs): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
+	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) vcs \
+		PLATFORM=$(PLATFORM) \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(GENERATED_DIR) \
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"
+
 vcs_debug = $(GENERATED_DIR)/$(DESIGN)-debug
 
-$(vcs) $(vcs_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VCS_CXXOPTS) -I$(VCS_HOME)/include -D RTLSIM
-# VCS can mangle the ordering of libraries and object files at link time such
-# that some valid dependencies are pruned when --as-needed is set.
-# Conservatively set --no-as-needed in case --as-needed is defined in LDFLAGS.
-$(vcs) $(vcs_debug): export LDFLAGS := $(LDFLAGS) -Wl,--no-as-needed $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
-
-$(vcs): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
-	$(MAKE) -C $(simif_dir) vcs PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" TOP_DIR=$(chipyard_dir)
-
+.PHONY: vcs-debug
+vcs-debug: $(vcs-debug)
 $(vcs_debug): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
-	$(MAKE) -C $(simif_dir) vcs-debug PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" TOP_DIR=$(chipyard_dir)
-
-.PHONY: vcs vcs-debug
-vcs: $(vcs)
-vcs-debug: $(vcs_debug)
-
+	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) vcs-debug \
+		PLATFORM=$(PLATFORM) \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(GENERATED_DIR) \
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"

--- a/sim/make/verilator.mk
+++ b/sim/make/verilator.mk
@@ -4,23 +4,38 @@
 # Verilator MIDAS-Level Simulators #
 ####################################
 
-VERILATOR_CXXOPTS ?= -O0
 VERILATOR_MAKEFLAGS ?= -j8 VM_PARALLEL_BUILDS=1
 
 verilator = $(GENERATED_DIR)/V$(DESIGN)
+
+.PHONY: verilator
+verilator: $(verilator)
+$(verilator): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
+	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) verilator \
+		PLATFORM=$(PLATFORM) \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(GENERATED_DIR) \
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		VERILATOR_FLAGS="$(EXTRA_VERILATOR_FLAGS)" \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"
+
 verilator_debug = $(GENERATED_DIR)/V$(DESIGN)-debug
 
-$(verilator) $(verilator_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VERILATOR_CXXOPTS) -D RTLSIM
-$(verilator) $(verilator_debug): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
-
-$(verilator): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
-	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) verilator PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" TOP_DIR=$(chipyard_dir) VERILATOR_FLAGS="$(EXTRA_VERILATOR_FLAGS)"
-
+.PHONY: verilator-debug
+verilator-debug: $(verilator-debug)
 $(verilator_debug): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
-	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) verilator-debug PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" TOP_DIR=$(chipyard_dir) VERILATOR_FLAGS="$(EXTRA_VERILATOR_FLAGS)"
-
-.PHONY: verilator verilator-debug
-verilator: $(verilator)
-verilator-debug: $(verilator_debug)
+	$(MAKE) $(VERILATOR_MAKEFLAGS) -C $(simif_dir) verilator-debug \
+		PLATFORM=$(PLATFORM) \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(GENERATED_DIR) \
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		VERILATOR_FLAGS="$(EXTRA_VERILATOR_FLAGS)" \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"

--- a/sim/make/xsim.mk
+++ b/sim/make/xsim.mk
@@ -12,16 +12,29 @@ xsim-dut: replace-rtl $(fpga_work_dir)/stamp
 # Compile XSIM Driver #
 xsim = $(GENERATED_DIR)/$(DESIGN)-$(PLATFORM)
 
-$(xsim): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags)
-$(xsim): export LDFLAGS := $(LDFLAGS) $(common_ld_flags)
+XSIM_CXX_FLAGS := \
+	$(TARGET_CXX_FLAGS) \
+	$(common_cxx_flags) \
+	-DSIMULATION_XSIM \
+	-DNO_MAIN
+
+XSIM_LD_FLAGS := \
+	$(TARGET_LD_FLAGS) \
+	$(common_ld_flags)
+
 $(xsim): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
-	$(MAKE) -C $(simif_dir) driver MAIN=f1_xsim PLATFORM=f1 \
+	$(MAKE) -C $(simif_dir) f1 MAIN=f1_xsim PLATFORM=f1 \
 		DRIVER_NAME=$(DESIGN) \
 		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
 		GEN_DIR=$(GENERATED_DIR) \
 		OUT_DIR=$(GENERATED_DIR) \
-		DRIVER="$(DRIVER_CC)" \
-		TOP_DIR=$(chipyard_dir)
+		TOP_DIR=$(chipyard_dir) \
+		BASE_DIR=$(base_dir) \
+		DRIVER_CC="$(DRIVER_CC)" \
+		DRIVER_CXX_FLAGS="$(DRIVER_CXX_FLAGS)" \
+		PLATFORM_CXX_FLAGS="$(XSIM_CXX_FLAGS)" \
+		PLATFORM_LD_FLAGS="$(XSIM_LD_FLAGS)" \
+		TARGET_LD_FLAGS="$(TARGET_LD_FLAGS)"
 
 .PHONY: xsim
 xsim: $(xsim)

--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -1,6 +1,9 @@
 midas_dir = $(abspath .)
+
 bridge_dir = $(midas_dir)/bridges
 core_dir = $(midas_dir)/core
+emul_dir = $(midas_dir)/emul
+
 v_dir = $(abspath ../verilog)
 r_dir = $(abspath ../resources)
 
@@ -21,66 +24,253 @@ PLATFORM ?= f1
 OUT_DIR ?= $(GEN_DIR)
 CLOCK_PERIOD ?= 1.0
 
-override CXXFLAGS += -Wall -I$(midas_dir) -I$(GEN_DIR)
-override LDFLAGS += -L$(GEN_DIR) -lstdc++ -lpthread -lgmp
-
 design_v  := $(GEN_DIR)/$(GEN_FILE_BASENAME).sv
 design_h  := $(GEN_DIR)/$(GEN_FILE_BASENAME).const.h
 design_vh := $(GEN_DIR)/$(GEN_FILE_BASENAME).const.vh
 driver_h = $(foreach t, $(DRIVER), $(wildcard $(dir $(t))/*.h))
 
-bridge_h := $(wildcard $(bridge_dir)/*.h) $(wildcard $(core_dir)/*.h)
-bridge_cc := $(wildcard $(bridge_dir)/*.cc) $(wildcard $(core_dir)/*.cc)
-bridge_o := $(patsubst $(midas_dir)/%.cc, $(GEN_DIR)/%.o, $(bridge_cc))
-$(bridge_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h) $(bridge_h)
+################################################################################
+# FireSim driver library
+################################################################################
+
+library_ldflags := \
+	-lpthread \
+	-lgmp \
+	-Wl,-rpath='$$$$ORIGIN' \
+	$(LDFLAGS)
+
+library_cxxflags = \
+	-std=c++17 -Wall -Wno-unused-variable \
+	-I$(midas_dir) \
+	$(CXXFLAGS)
+
+core_h := $(wildcard $(core_dir)/*.h)
+core_cc := $(wildcard $(core_dir)/*.cc)
+core_o := $(patsubst $(core_dir)/%.cc, $(GEN_DIR)/core__%.o, $(core_cc))
+$(core_o): $(GEN_DIR)/core__%.o: $(core_dir)/%.cc $(driver_h)
+	$(CXX) $(library_cxxflags) -c -o $@ $<
+
+bridge_h := $(wildcard $(bridge_dir)/*.h)
+bridge_cc := $(wildcard $(bridge_dir)/*.cc)
+bridge_o := $(patsubst $(bridge_dir)/%.cc, $(GEN_DIR)/bridge__%.o, $(bridge_cc))
+$(bridge_o): $(GEN_DIR)/bridge__%.o: $(bridge_dir)/%.cc $(driver_h)
+	$(CXX) $(library_cxxflags) -c -o $@ $<
+
+emul_h := $(wildcard $(emul_dir)/*.h)
+emul_cc := $(wildcard $(emul_dir)/*.cc)
+emul_o := $(patsubst $(emul_dir)/%.cc, $(GEN_DIR)/emul__%.o, $(emul_cc))
+$(emul_o): $(GEN_DIR)/emul__%.o: $(emul_dir)/%.cc $(driver_h)
+	$(CXX) $(library_cxxflags) -c -o $@ $<
+
+$(GEN_DIR)/libfiresim.a: $(core_o) $(bridge_o)
+	rm -f $@
+	$(AR) rcs $@ $^
+
+$(GEN_DIR)/libfiresim-emul.a: $(emul_o)
+	rm -f $@
+	$(AR) rcs $@ $^
+
+################################################################################
+# Compiled design-specific driver
+################################################################################
+
+driver_cxxflags = \
+	-std=c++17 -Wall -Wno-unused-variable \
+	-I$(midas_dir) \
+	$(DRIVER_CXX_FLAGS) \
+	$(CXXFLAGS)
+
+driver_dir = $(abspath $(BASE_DIR)/..)
+driver_o = $(patsubst $(driver_dir)/%.cc, $(GEN_DIR)/driver/%.o, $(DRIVER_CC))
+$(driver_o): $(GEN_DIR)/driver/%.o: $(driver_dir)/%.cc $(driver_h)
 	mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -c -o $@ $< -include $(word 2, $^)
+	$(CXX) $(driver_cxxflags) -c -o $@ $<
 
-platform_files := simif_$(MAIN) main
-platform_cc := $(addprefix $(midas_dir)/, $(addsuffix .cc, $(platform_files)))
-platform_o := $(addprefix $(GEN_DIR)/, $(addsuffix .o, $(platform_files)))
+main_cc := $(midas_dir)/main.cc
+main_o := $(GEN_DIR)/driver/main.o
+$(main_o): $(main_cc) $(driver_h) $(core_h) $(bridge_h) $(emul_h)
+	$(CXX) $(driver_cxxflags) -I$(GEN_DIR) -c -o $@ $<
 
-$(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h)
-	mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) -c -o $@ $< -include $(word 2, $^)
+$(GEN_DIR)/libdriver.a: $(driver_o)
+	rm -f $@
+	$(AR) rcs $@ $^
 
-$(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(design_h) $(DRIVER) $(driver_h) $(platform_o) $(bridge_o)
-	mkdir -p $(OUT_DIR)
-	$(CXX) $(CXXFLAGS) -include $< \
-	-o $@ $(DRIVER) $(platform_o) $(bridge_o) $(LDFLAGS)
+################################################################################
+# Platform-specific drivers
+################################################################################
+
+platform_cxxflags := \
+	$(library_cxxflags)
+
+platform_ldflags := \
+	$(library_ldflags) \
+	$(PLATFORM_LD_FLAGS) \
+	$(TARGET_LD_FLAGS)
+
+platform_file := simif_$(MAIN)
+platform_cc := $(midas_dir)/$(platform_file).cc
+platform_o := $(GEN_DIR)/$(platform_file).o
+platform_libs := $(GEN_DIR)/libdriver.a $(GEN_DIR)/libfiresim.a
+
+$(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h) $(core_h) $(emul_h)
+	mkdir -p $(@D)
+	$(CXX) -o $@ -c $< $(PLATFORM_CXX_FLAGS) $(platform_cxxflags) -include $(design_h)
 
 .PHONY: driver
 driver: $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
+$(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(main_o) $(platform_o) $(platform_libs)
+	mkdir -p $(@D)
+	$(CXX) -o $@ -Wl,--start-group $^ -Wl,--end-group  $(platform_ldflags)
 
-# Sources for building MIDAS-level simulators. Must be defined before sources VCS/Verilator Makefrags
-override CXXFLAGS += -std=c++17 -include $(design_h)
+################################################################################
+# Verilog harness
+################################################################################
 
 # Models of FPGA primitives that are used in host-level sim, but not in FPGATop
 sim_fpga_resource_models := $(v_dir)/BUFGCE.v
 
-emul_dir   := $(midas_dir)/emul
-emul_h     := $(driver_h) $(bridge_h) $(emul_dir)/simif_emul.h $(emul_dir)/mmio.h $(emul_dir)/mm.h
-# This includes c sources and static libraries
-emul_cc    := $(DRIVER) $(bridge_cc) $(emul_dir)/simif_emul.cc $(emul_dir)/mmio.cc $(emul_dir)/mm.cc $(emul_dir)/dpi.cc $(midas_dir)/main.cc
-emul_v     := $(design_vh) $(design_v) $(sim_fpga_resource_models)
+emul_libs  := $(main_o) $(GEN_DIR)/libdriver.a $(GEN_DIR)/libfiresim-emul.a $(GEN_DIR)/libfiresim.a
+emul_h     := $(driver_h) $(core_h) $(bridge_h) $(emul_h)
+emul_v     := $(design_vh) $(design_v) $(sim_fpga_resource_models) $(v_dir)/top.sv
+emul_top   := emul
+
+################################################################################
+# Verilator
+################################################################################
+
+VERILATOR ?= verilator
 
 verilator_conf := rtlsim/ml-verilator-conf.vlt
-verilator_wrapper_v := $(v_dir)/top.sv
-verilator_harness := $(midas_dir)/simif_emul_verilator.cc
-top_module := emul
-include rtlsim/Makefrag-verilator
+verilator_cc := $(midas_dir)/simif_emul_verilator.cc
 
-verilator: $(OUT_DIR)/V$(DRIVER_NAME)
-verilator-debug: $(OUT_DIR)/V$(DRIVER_NAME)-debug
+verilator_flags := \
+	--top-module $(emul_top) \
+ 	--cc \
+ 	--exe \
+	--timescale 1ns/1ps \
+	$(TIMESCALE_OPTS) \
+	-Wno-STMTDLY \
+	-O3 \
+	--output-split 10000 \
+	--output-split-cfuncs 100 \
+	$(VERILATOR_FLAGS)
 
-# Add an extra wrapper source for VCS simulators
-vcs_wrapper_v := $(v_dir)/top.sv
-vcs_harness := $(midas_dir)/simif_emul_vcs.cc
-TB := emul
-VCS_FLAGS := -e vcs_main
-include rtlsim/Makefrag-vcs
+verilator_cflags := \
+	-include $(design_h) \
+	-I$(midas_dir) \
+	$(CXXFLAGS)
 
+verilator_ldflags := \
+	$(library_ldflags) \
+	$(TARGET_LD_FLAGS) \
+	$(LDFLAGS)
+
+verilator_exe := $(OUT_DIR)/V$(DRIVER_NAME)
+verilator_exe_csrc = $(GEN_DIR)/V$(DRIVER_NAME).csrc
+
+.PHONY: verilator
+verilator: $(verilator_exe)
+$(verilator_exe): $(verilator_exe_csrc)/MAKE $(emul_libs) $(verilator_cc)
+	$(MAKE) -C $(verilator_exe_csrc) -f V$(emul_top).mk
+
+$(verilator_exe_csrc)/MAKE: $(emul_v)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+
+	$(VERILATOR) $(verilator_flags) \
+		-Mdir $(verilator_exe_csrc) \
+		-o $(verilator_exe) \
+		-CFLAGS "-include $(@D)/V$(emul_top).h $(verilator_cflags)" \
+		-LDFLAGS "-Wl,--start-group $(emul_libs) -Wl,--end-group $(verilator_ldflags)" \
+		$(verilator_conf) \
+		$(emul_v) $(verilator_cc)
+
+verilator_exe_debug := $(OUT_DIR)/V$(DRIVER_NAME)-debug
+verilator_exe_debug_csrc = $(GEN_DIR)/V$(DRIVER_NAME)-debug.csrc
+
+.PHONY: verilator-debug
+verilator-debug: $(verilator_exe_debug) $(emul_libs)
+$(verilator_exe_debug): $(verilator_exe_debug_csrc)/MAKE $(emul_libs) $(verilator_cc)
+	$(MAKE) -C $(verilator_exe_debug_csrc) -f V$(emul_top).mk
+
+$(verilator_exe_debug_csrc)/MAKE: $(emul_v)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+
+	$(VERILATOR) $(verilator_flags) --trace \
+		-Mdir $(verilator_exe_debug_csrc) \
+		-o $(verilator_exe_debug) \
+		-CFLAGS "-include $(@D)/V$(emul_top).h $(verilator_cflags)" \
+		-LDFLAGS "-Wl,--start-group $(emul_libs) -Wl,--end-group $(verilator_ldflags)" \
+		$(verilator_conf) \
+		$(emul_v) $(verilator_cc)
+
+################################################################################
+# VCS
+################################################################################
+
+VCS ?= vcs -full64
+
+vcs_cc := $(midas_dir)/simif_emul_vcs.cc
+
+vcs_cflags := \
+	-include $(design_h) \
+	-I$(midas_dir) \
+	$(CXXFLAGS)
+
+vcs_ldflags := \
+	$(library_ldflags) \
+	$(TARGET_LD_FLAGS) \
+	$(LDFLAGS)
+
+vcs_flags := \
+	$(VCS_FLAGS) \
+	-e vcs_main \
+	-quiet \
+	-timescale=1ns/1ps \
+	+v2k +rad +vcs+initreg+random +vcs+lic+wait \
+	-notice -line +lint=all,noVCDE,noONGS,noUI -quiet -debug_acc+pp+dmptf -debug_region+cell+encrypt +no_notifier \
+	-cpp $(CXX) \
+	-top $(emul_top) \
+	+vc+list \
+	-sverilog \
+	-assert svaext \
+	+define+CLOCK_PERIOD=$(CLOCK_PERIOD) \
+	+define+RANDOMIZE_GARBAGE_ASSIGN \
+	+define+RANDOMIZE_INVALID_ASSIGN \
+	+define+STOP_COND=!$(emul_top).reset \
+	+define+PRINTF_COND=!$(emul_top).reset
+
+
+.PHONY: vcs
 vcs: $(OUT_DIR)/$(DRIVER_NAME)
+
+vcs_exe := $(OUT_DIR)/$(DRIVER_NAME)
+vcs_exe_csrc := $(GEN_DIR)/$(DRIVER_NAME).csrc
+
+$(vcs_exe): $(emul_v) $(vcs_cc) $(emul_libs)
+	mkdir -p $(OUT_DIR)
+	rm -rf $(vcs_exe_csrc)
+	rm -rf $(vcs_exe).daidir
+	$(VCS) $(vcs_flags) -o $@ \
+		-Mdir=$(vcs_exe_csrc) \
+		$(emul_v) $(vcs_cc) \
+		-CFLAGS "$(vcs_cflags)" \
+		-LDFLAGS "-Wl,--start-group $(emul_libs) -Wl,--end-group $(vcs_ldflags)"
+
+.PHONY: vcs-debug
 vcs-debug: $(OUT_DIR)/$(DRIVER_NAME)-debug
 
-.PHONY: verilator verilator-debug vcs vcs-debug
+vcs_exe_debug := $(OUT_DIR)/$(DRIVER_NAME)-debug
+vcs_exe_debug_csrc := $(GEN_DIR)/$(DRIVER_NAME)-debug.csrc
+
+$(vcs_exe_debug): $(emul_v) $(vcs_cc) $(emul_libs)
+	mkdir -p $(OUT_DIR)
+	rm -rf $(vcs_exe_debug_csrc)
+	rm -rf $(vcs_exe_debug).daidir
+	$(VCS) $(vcs_flags) -o $@ \
+		+define+DEBUG \
+		-Mdir=$(vcs_exe_debug_csrc) \
+		$(emul_v) $(vcs_cc) \
+		-CFLAGS "$(vcs_cflags)" \
+		-LDFLAGS "-Wl,--start-group $(emul_libs) -Wl,--end-group $(vcs_ldflags)"

--- a/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
+++ b/sim/midas/src/main/cc/bridges/cpu_managed_stream.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 
+#include "core/config.h"
 #include "core/stream_engine.h"
 
 class simif_t;

--- a/sim/midas/src/main/cc/bridges/loadmem.cc
+++ b/sim/midas/src/main/cc/bridges/loadmem.cc
@@ -1,10 +1,9 @@
 // See LICENSE for license details.
 
 #include "loadmem.h"
+#include "core/simif.h"
 
 #include <fstream>
-
-#include "core/simif.h"
 
 char loadmem_t::KIND;
 

--- a/sim/midas/src/main/cc/core/simif.h
+++ b/sim/midas/src/main/cc/core/simif.h
@@ -17,6 +17,7 @@
 #include "core/widget_registry.h"
 
 class StreamEngine;
+class StreamEngine;
 class simulation_t;
 class CPUManagedStreamIO;
 class FPGAManagedStreamIO;

--- a/sim/midas/src/main/cc/simif_emul_verilator.cc
+++ b/sim/midas/src/main/cc/simif_emul_verilator.cc
@@ -3,7 +3,7 @@
 #include <signal.h>
 
 #include <verilated.h>
-#ifdef VM_TRACE
+#if VM_TRACE
 #include <verilated_vcd_c.h>
 #endif
 
@@ -31,7 +31,7 @@ private:
   void tick();
 
   std::unique_ptr<Vemul> top;
-#ifdef VM_TRACE
+#if VM_TRACE
   std::unique_ptr<VerilatedVcdC> tfp;
 #endif
 };

--- a/sim/src/main/makefrag/bridges/driver.mk
+++ b/sim/src/main/makefrag/bridges/driver.mk
@@ -24,7 +24,7 @@ DRIVER_CC := \
 			$(addsuffix .cc, fesvr/* bridges/tracerv/*) \
 		))
 
-TARGET_CXX_FLAGS := \
+DRIVER_CXX_FLAGS := \
 		-isystem $(testchipip_csrc_dir) \
 		-I$(RISCV)/include \
 		-I$(firesim_lib_dir) \

--- a/sim/src/main/makefrag/fasedtests/driver.mk
+++ b/sim/src/main/makefrag/fasedtests/driver.mk
@@ -5,8 +5,15 @@
 ##########################
 
 driver_dir = $(firesim_base_dir)/src/main/cc
-DRIVER_H = $(shell find $(driver_dir) -name "*.h")
-DRIVER_CC = $(wildcard $(addprefix $(driver_dir)/, $(addsuffix .cc, fasedtests/* firesim/systematic_scheduler)))
 
-TARGET_CXX_FLAGS := -g -O2 -I$(driver_dir) -I$(driver_dir)/fasedtests -I$(RISCV)/include
+DRIVER_H = $(shell find $(driver_dir) -name "*.h")
+
+DRIVER_CC =  \
+	  $(driver_dir)/fasedtests/fasedtests_top.cc \
+	  $(driver_dir)/fasedtests/test_harness_bridge.cc
+
+DRIVER_CXX_FLAGS := \
+	-I$(driver_dir) \
+	-I$(driver_dir)/fasedtests
+
 TARGET_LD_FLAGS :=

--- a/sim/src/main/makefrag/firesim/driver.mk
+++ b/sim/src/main/makefrag/firesim/driver.mk
@@ -1,5 +1,9 @@
 # See LICENSE for license details.
 
+ifndef RISCV
+$(error Missing path to RISC-V toolchain)
+endif
+
 # DOC include start: Bridge Build System Changes
 ##########################
 # Driver Sources & Flags #
@@ -39,6 +43,7 @@ DROMAJO_REQS = $(DROMAJO_H) $(DROMAJO_ROM) $(DROMAJO_DTB)
 
 firesim_lib_dir = $(firesim_base_dir)/firesim-lib/src/main/cc
 driver_dir = $(firesim_base_dir)/src/main/cc
+
 DRIVER_H = \
 	$(shell find $(driver_dir) -name "*.h") \
 	$(shell find $(firesim_lib_dir) -name "*.h") \
@@ -46,14 +51,14 @@ DRIVER_H = \
 	$(TESTCHIPIP_CSRC_DIR)/testchip_tsi.h
 
 DRIVER_CC = \
-	$(addprefix $(driver_dir)/firesim/, $(addsuffix .cc, firesim_top)) \
+	$(driver_dir)/firesim/firesim_top.cc \
 	$(wildcard $(addprefix $(firesim_lib_dir)/, $(addsuffix .cc, bridges/* fesvr/* bridges/tracerv/*)))  \
 	$(RISCV)/lib/libfesvr.a \
 	$(DROMAJO_LIB_DIR)/lib$(DROMAJO_LIB_NAME).a \
 	$(TESTCHIPIP_CSRC_DIR)/testchip_tsi.cc
 
 # Disable missing override warning for testchipip.
-TARGET_CXX_FLAGS += -g \
+DRIVER_CXX_FLAGS += \
 	-isystem $(RISCV)/include \
 	-isystem $(TESTCHIPIP_CSRC_DIR) \
 	-isystem $(DROMAJO_INCLUDE_DIR) \
@@ -61,5 +66,14 @@ TARGET_CXX_FLAGS += -g \
 	-I$(firesim_lib_dir) \
 	-I$(GENERATED_DIR) \
 	-Wno-inconsistent-missing-override
-TARGET_LD_FLAGS += -L$(CONDA_PREFIX)/lib -l:libdwarf.so -l:libelf.so -lz
+
+TARGET_LD_FLAGS += \
+	$(RISCV)/lib/libfesvr.a \
+	$(DROMAJO_LIB_DIR)/lib$(DROMAJO_LIB_NAME).a \
+	-L$(CONDA_PREFIX)/lib \
+	-l:libdwarf.so \
+	-l:libelf.so \
+	-lz \
+	-lrt
+
 # DOC include end: Bridge Build System Changes

--- a/sim/src/main/makefrag/midasexamples/driver.mk
+++ b/sim/src/main/makefrag/midasexamples/driver.mk
@@ -4,13 +4,13 @@
 ##########################
 
 driver_dir = $(firesim_base_dir)/src/main/cc
-firesim_lib_dir = $(firesim_base_dir)/firesim-lib/src/main/cc/
+
 DRIVER_H = $(shell find $(driver_dir) -name "*.h")
 DRIVER_CC := \
 		$(driver_dir)/midasexamples/TestHarness.cc \
 		$(driver_dir)/midasexamples/Test$(DESIGN).cc
 
-TARGET_CXX_FLAGS := \
+DRIVER_CXX_FLAGS := \
 		-I$(driver_dir) \
 		-I$(driver_dir)/midasexamples \
 		-g


### PR DESCRIPTION
This PR splits the driver into libraries, which are linked together to form a simulator or a driver.
The main benefit is ensuring that most parts of drivers and simulators are compiled with the same compilation option.
Moving forward, care must be taken to not add conditional compilation to the shared parts of the driver to ensure compatibility.

* `libfiresim.a`: shared core components and bridges
* `libfiresim-emul.a`: core components + emulator-specific bits, used by VCS and Verilator
* `libdriver.a`: user-defined simulation-specific bits

The platform-specific files lose their headers to further indicate that they should not be re-used or instantiated in a context other than the one enforced.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
