### PR TITLE
Added a root widget class and a low-overhead RTTI mechanism

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/blockdev.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/blockdev.cc
@@ -6,6 +6,8 @@
 #include <string.h>
 #include <string>
 
+char blockdev_t::KIND;
+
 /* Block Device Endpoint Driver
  *
  * This works in conjunction with
@@ -33,13 +35,13 @@
  * Setup software driver state:
  * Check if we have been given a file to use as a disk, record size and
  * number of sectors to pass to widget */
-blockdev_t::blockdev_t(simif_t *sim,
+blockdev_t::blockdev_t(simif_t &sim,
                        const std::vector<std::string> &args,
                        uint32_t num_trackers,
                        uint32_t latency_bits,
                        const BLOCKDEVBRIDGEMODULE_struct &mmio_addrs,
                        int blkdevno)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs) {
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs) {
   this->_file = NULL;
   this->logfile = NULL;
   _ntags = num_trackers;

--- a/sim/firesim-lib/src/main/cc/bridges/blockdev.h
+++ b/sim/firesim-lib/src/main/cc/bridges/blockdev.h
@@ -63,7 +63,10 @@ struct blkdev_write_tracker {
 
 class blockdev_t : public bridge_driver_t {
 public:
-  blockdev_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  blockdev_t(simif_t &sim,
              const std::vector<std::string> &args,
              uint32_t num_trackers,
              uint32_t latency_bits,

--- a/sim/firesim-lib/src/main/cc/bridges/dromajo.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/dromajo.cc
@@ -15,10 +15,12 @@
 
 // #define DEBUG
 
+char dromajo_t::KIND;
+
 /**
  * Constructor for Dromajo
  */
-dromajo_t::dromajo_t(simif_t *sim,
+dromajo_t::dromajo_t(simif_t &sim,
                      StreamEngine &stream,
                      std::vector<std::string> &args,
                      const DROMAJOBRIDGEMODULE_struct &mmio_addrs,
@@ -31,7 +33,7 @@ dromajo_t::dromajo_t(simif_t *sim,
                      int num_traces,
                      int stream_idx,
                      int stream_depth)
-    : streaming_bridge_driver_t(sim, stream), mmio_addrs(mmio_addrs),
+    : streaming_bridge_driver_t(sim, stream, &KIND), mmio_addrs(mmio_addrs),
       config(config), stream_idx(stream_idx), stream_depth(stream_depth) {
   // setup max constants given from the RTL
   this->_num_traces = num_traces;

--- a/sim/firesim-lib/src/main/cc/bridges/dromajo.h
+++ b/sim/firesim-lib/src/main/cc/bridges/dromajo.h
@@ -24,7 +24,10 @@ struct dromajo_config_t {
 
 class dromajo_t : public streaming_bridge_driver_t {
 public:
-  dromajo_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  dromajo_t(simif_t &sim,
             StreamEngine &stream,
             std::vector<std::string> &args,
             const DROMAJOBRIDGEMODULE_struct &mmio_addrs,

--- a/sim/firesim-lib/src/main/cc/bridges/groundtest.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/groundtest.cc
@@ -2,10 +2,12 @@
 
 #include "groundtest.h"
 
-groundtest_t::groundtest_t(simif_t *sim,
+char groundtest_t::KIND;
+
+groundtest_t::groundtest_t(simif_t &sim,
                            const std::vector<std::string> &args,
                            const GROUNDTESTBRIDGEMODULE_struct &mmio_addrs)
-    : bridge_driver_t(sim), sim(sim), mmio_addrs(mmio_addrs) {}
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs) {}
 
 groundtest_t::~groundtest_t() {}
 

--- a/sim/firesim-lib/src/main/cc/bridges/groundtest.h
+++ b/sim/firesim-lib/src/main/cc/bridges/groundtest.h
@@ -10,7 +10,10 @@ typedef struct GROUNDTESTBRIDGEMODULE_struct {
 
 class groundtest_t : public bridge_driver_t {
 public:
-  groundtest_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  groundtest_t(simif_t &sim,
                const std::vector<std::string> &args,
                const GROUNDTESTBRIDGEMODULE_struct &mmio_addrs);
   ~groundtest_t();
@@ -23,7 +26,6 @@ public:
 
 private:
   bool _success = false;
-  simif_t *sim;
   const GROUNDTESTBRIDGEMODULE_struct mmio_addrs;
 };
 

--- a/sim/firesim-lib/src/main/cc/bridges/serial.h
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.h
@@ -3,7 +3,10 @@
 #define __SERIAL_H
 
 #include "core/bridge_driver.h"
-#include "fesvr/firesim_tsi.h"
+
+class loadmem_t;
+class firesim_tsi_t;
+class firesim_loadmem_t;
 
 template <class T>
 struct serial_data_t {
@@ -35,22 +38,27 @@ typedef struct SERIALBRIDGEMODULE_struct {
 
 class serial_t : public bridge_driver_t {
 public:
-  serial_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  serial_t(simif_t &simif,
            const std::vector<std::string> &args,
            const SERIALBRIDGEMODULE_struct &mmio_addrs,
-           int serialno,
+           loadmem_t &loadmem_widget,
            bool has_mem,
-           int64_t mem_host_offset);
+           int64_t mem_host_offset,
+           int serialno);
   ~serial_t();
   virtual void init();
   virtual void tick();
-  virtual bool terminate() { return fesvr->done(); }
-  virtual int exit_code() { return fesvr->exit_code(); }
+  virtual bool terminate();
+  virtual int exit_code();
   virtual void finish(){};
 
 private:
   const SERIALBRIDGEMODULE_struct mmio_addrs;
-  simif_t *sim;
+  loadmem_t &loadmem_widget;
+
   firesim_tsi_t *fesvr;
   bool has_mem;
   // host memory offset based on the number of memory models and their size

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.cc
@@ -2,9 +2,11 @@
 
 #include "simplenic.h"
 
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+
 #include <iostream>
-#include <stdio.h>
-#include <string.h>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -12,6 +14,8 @@
 #include <unistd.h>
 
 #include <sys/mman.h>
+
+char simplenic_t::KIND;
 
 // DO NOT MODIFY PARAMS BELOW THIS LINE
 #define TOKENS_PER_BIGTOKEN 7
@@ -47,7 +51,7 @@ static void simplify_frac(int n, int d, int *nn, int *dd) {
     fflush(this->niclog);                                                      \
   }
 
-simplenic_t::simplenic_t(simif_t *sim,
+simplenic_t::simplenic_t(simif_t &sim,
                          StreamEngine &stream,
                          const std::vector<std::string> &args,
                          const SIMPLENICBRIDGEMODULE_struct &mmio_addrs,
@@ -56,7 +60,7 @@ simplenic_t::simplenic_t(simif_t *sim,
                          const int stream_to_cpu_depth,
                          const int stream_from_cpu_idx,
                          const int stream_from_cpu_depth)
-    : streaming_bridge_driver_t(sim, stream), mmio_addrs(mmio_addrs),
+    : streaming_bridge_driver_t(sim, stream, &KIND), mmio_addrs(mmio_addrs),
       stream_to_cpu_idx(stream_to_cpu_idx),
       stream_from_cpu_idx(stream_from_cpu_idx) {
   const char *niclogfile = NULL;

--- a/sim/firesim-lib/src/main/cc/bridges/simplenic.h
+++ b/sim/firesim-lib/src/main/cc/bridges/simplenic.h
@@ -22,7 +22,10 @@ typedef struct SIMPLENICBRIDGEMODULE_struct {
 
 class simplenic_t : public streaming_bridge_driver_t {
 public:
-  simplenic_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  simplenic_t(simif_t &sim,
               StreamEngine &stream,
               const std::vector<std::string> &args,
               const SIMPLENICBRIDGEMODULE_struct &addrs,

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
@@ -1,11 +1,14 @@
 // See LICENSE for license details
 
 #include "tracerv.h"
+#include "bridges/tracerv/trace_tracker.h"
+#include "bridges/tracerv/tracerv_processing.h"
 
-#include <inttypes.h>
-#include <limits.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cinttypes>
+#include <climits>
+#include <cstdio>
+#include <cstring>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -14,13 +17,15 @@
 
 #include <sys/mman.h>
 
+char tracerv_t::KIND;
+
 // put FIREPERF in a mode that writes a simple log for processing later.
 // useful for iterating on software side only without re-running on FPGA.
 // #define FIREPERF_LOGGER
 
 constexpr uint64_t valid_mask = (1ULL << 40);
 
-tracerv_t::tracerv_t(simif_t *sim,
+tracerv_t::tracerv_t(simif_t &sim,
                      StreamEngine &stream,
                      const std::vector<std::string> &args,
                      const TRACERVBRIDGEMODULE_struct &mmio_addrs,
@@ -31,7 +36,7 @@ tracerv_t::tracerv_t(simif_t *sim,
                      const unsigned int clock_multiplier,
                      const unsigned int clock_divisor,
                      int tracerno)
-    : streaming_bridge_driver_t(sim, stream), mmio_addrs(mmio_addrs),
+    : streaming_bridge_driver_t(sim, stream, &KIND), mmio_addrs(mmio_addrs),
       stream_idx(stream_idx), stream_depth(stream_depth),
       max_core_ipc(max_core_ipc),
       clock_info(clock_domain_name, clock_multiplier, clock_divisor) {

--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.h
@@ -2,11 +2,13 @@
 #ifndef __TRACERV_H
 #define __TRACERV_H
 
-#include "bridges/tracerv/trace_tracker.h"
-#include "bridges/tracerv/tracerv_processing.h"
 #include "core/bridge_driver.h"
 #include "core/clock_info.h"
+
 #include <vector>
+
+class TraceTracker;
+class ObjdumpedBinary;
 
 typedef struct TRACERVBRIDGEMODULE_struct {
   uint64_t initDone;
@@ -28,7 +30,10 @@ typedef struct TRACERVBRIDGEMODULE_struct {
 
 class tracerv_t : public streaming_bridge_driver_t {
 public:
-  tracerv_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  tracerv_t(simif_t &sim,
             StreamEngine &stream,
             const std::vector<std::string> &args,
             const TRACERVBRIDGEMODULE_struct &mmio_addrs,

--- a/sim/firesim-lib/src/main/cc/bridges/uart.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.cc
@@ -14,6 +14,8 @@
 #ifndef _WIN32
 #include <unistd.h>
 
+char uart_t::KIND;
+
 // name length limit for ptys
 #define SLAVENAMELEN 256
 
@@ -179,11 +181,11 @@ create_handler(const std::vector<std::string> &args, int uartno) {
   return std::make_unique<uart_pty_handler>(uartno);
 }
 
-uart_t::uart_t(simif_t *sim,
+uart_t::uart_t(simif_t &simif,
                const std::vector<std::string> &args,
                const UARTBRIDGEMODULE_struct &mmio_addrs,
                int uartno)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs),
+    : bridge_driver_t(simif, &KIND), mmio_addrs(mmio_addrs),
       handler(create_handler(args, uartno)) {}
 
 uart_t::~uart_t() {}

--- a/sim/firesim-lib/src/main/cc/bridges/uart.h
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.h
@@ -36,8 +36,11 @@ public:
 
 class uart_t final : public bridge_driver_t {
 public:
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
   /// Creates a bridge which interacts with standard streams or PTY.
-  uart_t(simif_t *sim,
+  uart_t(simif_t &simif,
          const std::vector<std::string> &args,
          const UARTBRIDGEMODULE_struct &mmio_addrs,
          int uartno);

--- a/sim/midas/src/main/cc/bridges/autocounter.cc
+++ b/sim/midas/src/main/cc/bridges/autocounter.cc
@@ -1,12 +1,14 @@
 
 #include "autocounter.h"
 
+#include <cassert>
 #include <cinttypes>
+#include <climits>
+#include <cstdio>
+#include <cstring>
+
 #include <iostream>
-#include <limits.h>
 #include <regex>
-#include <stdio.h>
-#include <string.h>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -15,7 +17,9 @@
 
 #include <sys/mman.h>
 
-autocounter_t::autocounter_t(simif_t *sim,
+char autocounter_t::KIND;
+
+autocounter_t::autocounter_t(simif_t &sim,
                              const std::vector<std::string> &args,
                              const AUTOCOUNTERBRIDGEMODULE_struct &mmio_addrs,
                              AddressMap addr_map,
@@ -31,7 +35,7 @@ autocounter_t::autocounter_t(simif_t *sim,
                              const unsigned int clock_multiplier,
                              const unsigned int clock_divisor,
                              int autocounterno)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs), addr_map(addr_map),
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs), addr_map(addr_map),
       event_count(event_count),
       event_types(event_types, event_types + event_count),
       event_widths(event_widths, event_widths + event_count),

--- a/sim/midas/src/main/cc/bridges/autocounter.h
+++ b/sim/midas/src/main/cc/bridges/autocounter.h
@@ -22,7 +22,10 @@ typedef struct AUTOCOUNTERBRIDGEMODULE_struct {
 
 class autocounter_t : public bridge_driver_t {
 public:
-  autocounter_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  autocounter_t(simif_t &sim,
                 const std::vector<std::string> &args,
                 const AUTOCOUNTERBRIDGEMODULE_struct &mmio_addrs,
                 AddressMap addr_map,

--- a/sim/midas/src/main/cc/bridges/clock.cc
+++ b/sim/midas/src/main/cc/bridges/clock.cc
@@ -4,20 +4,22 @@
 
 #include "core/simif.h"
 
-clockmodule_t::clockmodule_t(simif_t *sim,
+char clockmodule_t::KIND;
+
+clockmodule_t::clockmodule_t(simif_t &simif,
                              const CLOCKBRIDGEMODULE_struct &mmio_addrs)
-    : sim(sim), mmio_addrs(mmio_addrs) {}
+    : widget_t(simif, &KIND), mmio_addrs(mmio_addrs) {}
 
 uint64_t clockmodule_t::tcycle() {
-  sim->write(mmio_addrs.tCycle_latch, 1);
-  uint32_t cycle_l = sim->read(mmio_addrs.tCycle_0);
-  uint32_t cycle_h = sim->read(mmio_addrs.tCycle_1);
+  simif.write(mmio_addrs.tCycle_latch, 1);
+  uint32_t cycle_l = simif.read(mmio_addrs.tCycle_0);
+  uint32_t cycle_h = simif.read(mmio_addrs.tCycle_1);
   return (((uint64_t)cycle_h) << 32) | cycle_l;
 }
 
 uint64_t clockmodule_t::hcycle() {
-  sim->write(mmio_addrs.hCycle_latch, 1);
-  uint32_t cycle_l = sim->read(mmio_addrs.hCycle_0);
-  uint32_t cycle_h = sim->read(mmio_addrs.hCycle_1);
+  simif.write(mmio_addrs.hCycle_latch, 1);
+  uint32_t cycle_l = simif.read(mmio_addrs.hCycle_0);
+  uint32_t cycle_h = simif.read(mmio_addrs.hCycle_1);
   return (((uint64_t)cycle_h) << 32) | cycle_l;
 }

--- a/sim/midas/src/main/cc/bridges/clock.h
+++ b/sim/midas/src/main/cc/bridges/clock.h
@@ -3,6 +3,8 @@
 #ifndef __CLOCK_H
 #define __CLOCK_H
 
+#include "core/widget.h"
+
 #include <cstdint>
 
 class simif_t;
@@ -16,9 +18,12 @@ typedef struct CLOCKBRIDGEMODULE_struct {
   uint64_t tCycle_latch;
 } CLOCKBRIDGEMODULE_struct;
 
-class clockmodule_t final {
+class clockmodule_t final : public widget_t {
 public:
-  clockmodule_t(simif_t *sim, const CLOCKBRIDGEMODULE_struct &mmio_addrs);
+  /// The identifier for the bridge type.
+  static char KIND;
+
+  clockmodule_t(simif_t &simif, const CLOCKBRIDGEMODULE_struct &mmio_addrs);
 
   /**
    * Provides the current target cycle of the fastest clock.
@@ -34,7 +39,6 @@ public:
   uint64_t hcycle();
 
 private:
-  simif_t *sim;
   const CLOCKBRIDGEMODULE_struct mmio_addrs;
 };
 

--- a/sim/midas/src/main/cc/bridges/fased_memory_timing_model.cc
+++ b/sim/midas/src/main/cc/bridges/fased_memory_timing_model.cc
@@ -50,14 +50,16 @@ void AddrRangeCounter::finish() {
   write(enable, 0);
 }
 
+char FASEDMemoryTimingModel::KIND;
+
 FASEDMemoryTimingModel::FASEDMemoryTimingModel(
-    simif_t *sim,
+    simif_t &simif,
     AddressMap addr_map,
     const std::vector<std::string> &args,
     std::string stats_file_name,
     size_t mem_size,
     std::string suffix)
-    : FpgaModel(sim, addr_map), mem_size(mem_size) {
+    : FpgaModel(&simif, addr_map), widget_t(simif, &KIND), mem_size(mem_size) {
 
   for (auto &arg : args) {
     if (arg.find("+mm_") == 0 && arg.find(suffix) != std::string::npos) {
@@ -104,19 +106,19 @@ FASEDMemoryTimingModel::FASEDMemoryTimingModel(
   stats_file << std::endl;
 
   if (addr_map.w_reg_exists("hostReadLatencyHist_enable")) {
-    histograms.push_back(Histogram(sim, addr_map, "hostReadLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "hostWriteLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "targetReadLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "targetWriteLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "ingressReadLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "ingressWriteLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "totalReadLatency"));
-    histograms.push_back(Histogram(sim, addr_map, "totalWriteLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "hostReadLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "hostWriteLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "targetReadLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "targetWriteLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "ingressReadLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "ingressWriteLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "totalReadLatency"));
+    histograms.push_back(Histogram(&simif, addr_map, "totalWriteLatency"));
   }
 
   if (addr_map.w_reg_exists("readRanges_enable")) {
-    rangectrs.push_back(AddrRangeCounter(sim, addr_map, "read"));
-    rangectrs.push_back(AddrRangeCounter(sim, addr_map, "write"));
+    rangectrs.push_back(AddrRangeCounter(&simif, addr_map, "read"));
+    rangectrs.push_back(AddrRangeCounter(&simif, addr_map, "write"));
   }
 }
 

--- a/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
+++ b/sim/midas/src/main/cc/bridges/fased_memory_timing_model.h
@@ -11,11 +11,12 @@
  *
  */
 
+#include "bridges/fpga_model.h"
+#include "core/widget.h"
+
 #include <fstream>
 #include <set>
 #include <unordered_map>
-
-#include "fpga_model.h"
 
 typedef struct FASEDMEMORYTIMINGMODEL_struct {
 } FASEDMEMORYTIMINGMODEL_struct;
@@ -65,9 +66,12 @@ private:
   std::string addr = name + "Hist_addr";
 };
 
-class FASEDMemoryTimingModel : public FpgaModel {
+class FASEDMemoryTimingModel : public FpgaModel, public widget_t {
 public:
-  FASEDMemoryTimingModel(simif_t *s,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  FASEDMemoryTimingModel(simif_t &simif,
                          AddressMap addr_map,
                          const std::vector<std::string> &args,
                          std::string stats_file_name,

--- a/sim/midas/src/main/cc/bridges/heartbeat.cc
+++ b/sim/midas/src/main/cc/bridges/heartbeat.cc
@@ -1,9 +1,14 @@
+
 #include "heartbeat.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 
-heartbeat_t::heartbeat_t(simif_t *sim, const std::vector<std::string> &args)
-    : bridge_driver_t(sim), sim(sim) {
+#include "core/simif.h"
+
+char heartbeat_t::KIND;
+
+heartbeat_t::heartbeat_t(simif_t &sim, const std::vector<std::string> &args)
+    : bridge_driver_t(sim, &KIND) {
   auto interval_arg = std::string("+heartbeat-polling-interval=");
   for (auto arg : args) {
     if (arg.find(interval_arg) == 0) {
@@ -24,7 +29,7 @@ heartbeat_t::heartbeat_t(simif_t *sim, const std::vector<std::string> &args)
 void heartbeat_t::tick() {
   if (trip_count == polling_interval) {
     trip_count = 0;
-    uint64_t current_cycle = sim->actual_tcycle();
+    uint64_t current_cycle = simif.actual_tcycle();
     has_timed_out |= current_cycle == last_cycle;
 
     time_t current_time;

--- a/sim/midas/src/main/cc/bridges/heartbeat.h
+++ b/sim/midas/src/main/cc/bridges/heartbeat.h
@@ -1,8 +1,9 @@
 #ifndef __HEARTBEAT_H
 #define __HEARTBEAT_H
 
-#include "core/bridge_driver.h"
 #include <fstream>
+
+#include "core/bridge_driver.h"
 
 // Periodically checks that the target is advancing by polling an FPGA-hosted
 // cycle count, which it writes out to a file.  The causes of an apparently
@@ -14,9 +15,12 @@
 // for expanded discussion.
 
 class heartbeat_t : public bridge_driver_t {
-
 public:
-  heartbeat_t(simif_t *sim, const std::vector<std::string> &args);
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  heartbeat_t(simif_t &sim, const std::vector<std::string> &args);
+
   virtual void init(){};
   virtual void tick();
   virtual bool terminate() { return has_timed_out; };
@@ -25,7 +29,6 @@ public:
 
 private:
   std::ofstream log;
-  simif_t *sim;
   time_t start_time;
 
   bool has_timed_out = false;

--- a/sim/midas/src/main/cc/bridges/loadmem.cc
+++ b/sim/midas/src/main/cc/bridges/loadmem.cc
@@ -6,11 +6,13 @@
 
 #include "core/simif.h"
 
-loadmem_t::loadmem_t(simif_t *sim,
+char loadmem_t::KIND;
+
+loadmem_t::loadmem_t(simif_t &simif,
                      const LOADMEMWIDGET_struct &mmio_addrs,
                      const AXI4Config &mem_conf,
                      unsigned mem_data_chunk)
-    : sim(sim), mmio_addrs(mmio_addrs), mem_conf(mem_conf),
+    : widget_t(simif, &KIND), mmio_addrs(mmio_addrs), mem_conf(mem_conf),
       mem_data_chunk(mem_data_chunk) {}
 
 void loadmem_t::load_mem_from_file(const std::string &filename) {
@@ -41,24 +43,24 @@ void loadmem_t::load_mem_from_file(const std::string &filename) {
 void loadmem_t::read_mem(size_t addr, mpz_t &value) {
   // NB: mpz_t variables may not export <size> <uint32_t> beats, if initialized
   // with an array of zeros.
-  sim->write(mmio_addrs.R_ADDRESS_H, addr >> 32);
-  sim->write(mmio_addrs.R_ADDRESS_L, addr & ((1ULL << 32) - 1));
+  simif.write(mmio_addrs.R_ADDRESS_H, addr >> 32);
+  simif.write(mmio_addrs.R_ADDRESS_L, addr & ((1ULL << 32) - 1));
   uint32_t data[mem_data_chunk];
   for (size_t i = 0; i < mem_data_chunk; i++) {
-    data[i] = sim->read(mmio_addrs.R_DATA);
+    data[i] = simif.read(mmio_addrs.R_DATA);
   }
   mpz_import(value, mem_data_chunk, -1, sizeof(uint32_t), 0, 0, data);
 }
 
 void loadmem_t::write_mem(size_t addr, mpz_t &value) {
-  sim->write(mmio_addrs.W_ADDRESS_H, addr >> 32);
-  sim->write(mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
-  sim->write(mmio_addrs.W_LENGTH, 1);
+  simif.write(mmio_addrs.W_ADDRESS_H, addr >> 32);
+  simif.write(mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
+  simif.write(mmio_addrs.W_LENGTH, 1);
   size_t size;
   uint32_t *data =
       (uint32_t *)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
   for (size_t i = 0; i < mem_data_chunk; i++) {
-    sim->write(mmio_addrs.W_DATA, i < size ? data[i] : 0);
+    simif.write(mmio_addrs.W_DATA, i < size ? data[i] : 0);
   }
 }
 
@@ -67,21 +69,21 @@ static size_t ceil_div(size_t a, size_t b) { return ((a)-1) / (b) + 1; }
 void loadmem_t::write_mem_chunk(size_t addr, mpz_t &value, size_t bytes) {
   const unsigned mem_data_chunk_bytes = mem_data_chunk * sizeof(uint32_t);
 
-  sim->write(mmio_addrs.W_ADDRESS_H, addr >> 32);
-  sim->write(mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
+  simif.write(mmio_addrs.W_ADDRESS_H, addr >> 32);
+  simif.write(mmio_addrs.W_ADDRESS_L, addr & ((1ULL << 32) - 1));
 
   size_t num_beats = ceil_div(bytes, mem_data_chunk_bytes);
-  sim->write(mmio_addrs.W_LENGTH, num_beats);
+  simif.write(mmio_addrs.W_LENGTH, num_beats);
   size_t size;
   uint32_t *data =
       (uint32_t *)mpz_export(NULL, &size, -1, sizeof(uint32_t), 0, 0, value);
   for (size_t i = 0; i < num_beats * mem_data_chunk; i++) {
-    sim->write(mmio_addrs.W_DATA, i < size ? data[i] : 0);
+    simif.write(mmio_addrs.W_DATA, i < size ? data[i] : 0);
   }
 }
 
 void loadmem_t::zero_out_dram() {
-  sim->write(mmio_addrs.ZERO_OUT_DRAM, 1);
-  while (!sim->read(mmio_addrs.ZERO_FINISHED))
+  simif.write(mmio_addrs.ZERO_OUT_DRAM, 1);
+  while (!simif.read(mmio_addrs.ZERO_FINISHED))
     ;
 }

--- a/sim/midas/src/main/cc/bridges/loadmem.h
+++ b/sim/midas/src/main/cc/bridges/loadmem.h
@@ -7,6 +7,9 @@
 
 #include <gmp.h>
 
+#include "core/config.h"
+#include "core/widget.h"
+
 class simif_t;
 
 typedef struct LOADMEMWIDGET_struct {
@@ -21,9 +24,12 @@ typedef struct LOADMEMWIDGET_struct {
   uint64_t R_DATA;
 } LOADMEMWIDGET_struct;
 
-class loadmem_t final {
+class loadmem_t final : public widget_t {
 public:
-  loadmem_t(simif_t *sim,
+  /// The identifier for the bridge type.
+  static char KIND;
+
+  loadmem_t(simif_t &simif,
             const LOADMEMWIDGET_struct &mmio_addrs,
             const AXI4Config &mem_conf,
             unsigned mem_data_chunk);
@@ -41,7 +47,6 @@ public:
   unsigned get_mem_data_chunk() const { return mem_data_chunk; }
 
 private:
-  simif_t *sim;
   const LOADMEMWIDGET_struct mmio_addrs;
   const AXI4Config mem_conf;
   const unsigned mem_data_chunk;

--- a/sim/midas/src/main/cc/bridges/master.cc
+++ b/sim/midas/src/main/cc/bridges/master.cc
@@ -2,15 +2,17 @@
 
 #include "core/simif.h"
 
-master_t::master_t(simif_t *sim, const SIMULATIONMASTER_struct &mmio_addrs)
-    : sim(sim), mmio_addrs(mmio_addrs) {}
+char master_t::KIND;
 
-bool master_t::is_init_done() { return sim->read(mmio_addrs.INIT_DONE); }
+master_t::master_t(simif_t &simif, const SIMULATIONMASTER_struct &mmio_addrs)
+    : widget_t(simif, &KIND), mmio_addrs(mmio_addrs) {}
 
-bool master_t::is_done() { return sim->read(mmio_addrs.DONE); }
+bool master_t::is_init_done() { return simif.read(mmio_addrs.INIT_DONE); }
+
+bool master_t::is_done() { return simif.read(mmio_addrs.DONE); }
 
 void master_t::step(size_t n, bool blocking) {
-  sim->write(mmio_addrs.STEP, n);
+  simif.write(mmio_addrs.STEP, n);
 
   if (blocking) {
     while (!is_done())

--- a/sim/midas/src/main/cc/bridges/master.h
+++ b/sim/midas/src/main/cc/bridges/master.h
@@ -3,6 +3,8 @@
 #ifndef __MASTER_H
 #define __MASTER_H
 
+#include "core/widget.h"
+
 #include <cstdint>
 
 class simif_t;
@@ -13,9 +15,12 @@ typedef struct SIMULATIONMASTER_struct {
   uint64_t INIT_DONE;
 } SIMULATIONMASTER_struct;
 
-class master_t final {
+class master_t final : public widget_t {
 public:
-  master_t(simif_t *sim, const SIMULATIONMASTER_struct &mmio_addrs);
+  /// The identifier for the bridge type.
+  static char KIND;
+
+  master_t(simif_t &simif, const SIMULATIONMASTER_struct &mmio_addrs);
 
   /**
    * Check whether the device is initialised.
@@ -33,7 +38,6 @@ public:
   void step(size_t n, bool blocking);
 
 private:
-  simif_t *sim;
   const SIMULATIONMASTER_struct mmio_addrs;
 };
 

--- a/sim/midas/src/main/cc/bridges/peek_poke.h
+++ b/sim/midas/src/main/cc/bridges/peek_poke.h
@@ -22,8 +22,11 @@ typedef struct PEEKPOKEBRIDGEMODULE_struct {
  * Care must be taken to avoid deadlock, since calls to step. must be blocking
  * for peeks and pokes to capture and drive values at the correct cycles.
  */
-class peek_poke_t final {
+class peek_poke_t final : public widget_t {
 public:
+  /// The identifier for the bridge type.
+  static char KIND;
+
   struct port {
     uint64_t address;
     uint32_t chunks;
@@ -31,7 +34,7 @@ public:
 
   using port_map = std::map<std::string, port, std::less<>>;
 
-  peek_poke_t(simif_t *simif,
+  peek_poke_t(simif_t &simif,
               const PEEKPOKEBRIDGEMODULE_struct &mmio_addrs,
               unsigned poke_size,
               const uint32_t *input_addrs,
@@ -60,10 +63,6 @@ public:
    */
   bool unstable() const { return req_unstable; }
 
-protected:
-  /// Simulation interface.
-  simif_t *simif;
-
 private:
   /// Base MMIO port mapping.
   const PEEKPOKEBRIDGEMODULE_struct mmio_addrs;
@@ -78,7 +77,7 @@ private:
 
   bool wait_on(size_t flag_addr, double timeout) {
     midas_time_t start = timestamp();
-    while (!simif->read(flag_addr))
+    while (!simif.read(flag_addr))
       if (diff_secs(timestamp(), start) > timeout)
         return false;
     return true;

--- a/sim/midas/src/main/cc/bridges/plusargs.cc
+++ b/sim/midas/src/main/cc/bridges/plusargs.cc
@@ -2,6 +2,8 @@
 #include <iomanip>
 #include <iostream>
 
+char plusargs_t::KIND;
+
 /**
  * The default value is passed here (via the FireSim-generated.const.h).
  * All macros should be passed to this constructor.
@@ -19,7 +21,7 @@
  * @param [in] slice_count The number of MMIO used to represent the value
  * @param [in] slice_addrs The MMIO addresses of the slices
  */
-plusargs_t::plusargs_t(simif_t *sim,
+plusargs_t::plusargs_t(simif_t &sim,
                        const std::vector<std::string> &args,
                        const PLUSARGSBRIDGEMODULE_struct &mmio_addrs,
                        const std::string_view name_orig,
@@ -27,7 +29,8 @@ plusargs_t::plusargs_t(simif_t *sim,
                        const uint32_t bit_width,
                        const uint32_t slice_count,
                        const uint32_t *slice_addrs)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs), slice_count(slice_count),
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs),
+      slice_count(slice_count),
       slice_addrs(slice_addrs, slice_addrs + slice_count) {
   std::string_view name = name_orig;
 

--- a/sim/midas/src/main/cc/bridges/plusargs.h
+++ b/sim/midas/src/main/cc/bridges/plusargs.h
@@ -23,7 +23,10 @@ typedef struct PLUSARGSBRIDGEMODULE_struct {
  */
 class plusargs_t : public bridge_driver_t {
 public:
-  plusargs_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  plusargs_t(simif_t &sim,
              const std::vector<std::string> &args,
              const PLUSARGSBRIDGEMODULE_struct &mmio_addrs,
              const std::string_view name,

--- a/sim/midas/src/main/cc/bridges/reset_pulse.cc
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.cc
@@ -1,13 +1,15 @@
 
 #include "reset_pulse.h"
 
-reset_pulse_t::reset_pulse_t(simif_t *sim,
+char reset_pulse_t::KIND;
+
+reset_pulse_t::reset_pulse_t(simif_t &sim,
                              const std::vector<std::string> &args,
                              const RESETPULSEBRIDGEMODULE_struct &mmio_addrs,
                              unsigned int max_pulse_length,
                              unsigned int default_pulse_length,
                              int reset_index)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs),
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs),
       max_pulse_length(max_pulse_length),
       default_pulse_length(default_pulse_length) {
 

--- a/sim/midas/src/main/cc/bridges/reset_pulse.h
+++ b/sim/midas/src/main/cc/bridges/reset_pulse.h
@@ -11,9 +11,11 @@ typedef struct RESETPULSEBRIDGEMODULE_struct {
 #include "core/bridge_driver.h"
 
 class reset_pulse_t : public bridge_driver_t {
-
 public:
-  reset_pulse_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  reset_pulse_t(simif_t &sim,
                 const std::vector<std::string> &args,
                 const RESETPULSEBRIDGEMODULE_struct &mmio_addrs,
                 unsigned int max_pulse_length,
@@ -25,6 +27,8 @@ public:
   virtual bool terminate() { return false; };
   virtual int exit_code() { return 0; };
   virtual void finish(){};
+
+  unsigned get_max_pulse_length() const { return max_pulse_length; }
 
 private:
   const RESETPULSEBRIDGEMODULE_struct mmio_addrs;

--- a/sim/midas/src/main/cc/bridges/synthesized_assertions.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_assertions.cc
@@ -1,13 +1,16 @@
 #include "synthesized_assertions.h"
+
 #include <fstream>
 #include <iostream>
 
+char synthesized_assertions_t::KIND;
+
 synthesized_assertions_t::synthesized_assertions_t(
-    simif_t *sim,
+    simif_t &sim,
     const std::vector<std::string> &args,
     const ASSERTBRIDGEMODULE_struct &mmio_addrs,
     const char *const *msgs)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs), msgs(msgs) {
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs), msgs(msgs) {
   for (auto &arg : args) {
     if (arg.find("+disable-asserts") == 0)
       enable = false;

--- a/sim/midas/src/main/cc/bridges/synthesized_assertions.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_assertions.h
@@ -14,7 +14,10 @@ typedef struct ASSERTBRIDGEMODULE_struct {
 
 class synthesized_assertions_t : public bridge_driver_t {
 public:
-  synthesized_assertions_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  synthesized_assertions_t(simif_t &sim,
                            const std::vector<std::string> &args,
                            const ASSERTBRIDGEMODULE_struct &mmio_addrs,
                            const char *const *msgs);

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.cc
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.cc
@@ -1,10 +1,14 @@
+#include "synthesized_prints.h"
+
+#include <cassert>
+
 #include <iomanip>
 #include <iostream>
 
-#include "synthesized_prints.h"
+char synthesized_prints_t::KIND;
 
 synthesized_prints_t::synthesized_prints_t(
-    simif_t *sim,
+    simif_t &sim,
     StreamEngine &stream,
     const std::vector<std::string> &args,
     const PRINTBRIDGEMODULE_struct &mmio_addrs,
@@ -21,7 +25,7 @@ synthesized_prints_t::synthesized_prints_t(
     const unsigned int clock_multiplier,
     const unsigned int clock_divisor,
     int printno)
-    : streaming_bridge_driver_t(sim, stream), mmio_addrs(mmio_addrs),
+    : streaming_bridge_driver_t(sim, stream, &KIND), mmio_addrs(mmio_addrs),
       print_count(print_count), token_bytes(token_bytes),
       idle_cycles_mask(idle_cycles_mask), print_offsets(print_offsets),
       format_strings(format_strings), argument_counts(argument_counts),

--- a/sim/midas/src/main/cc/bridges/synthesized_prints.h
+++ b/sim/midas/src/main/cc/bridges/synthesized_prints.h
@@ -29,9 +29,11 @@ typedef struct PRINTBRIDGEMODULE_struct {
 } PRINTBRIDGEMODULE_struct;
 
 class synthesized_prints_t : public streaming_bridge_driver_t {
-
 public:
-  synthesized_prints_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  synthesized_prints_t(simif_t &sim,
                        StreamEngine &stream,
                        const std::vector<std::string> &args,
                        const PRINTBRIDGEMODULE_struct &mmio_addrs,

--- a/sim/midas/src/main/cc/bridges/termination.cc
+++ b/sim/midas/src/main/cc/bridges/termination.cc
@@ -1,14 +1,19 @@
 #include "termination.h"
+
+#include <cassert>
+
 #include <iostream>
 
-termination_t::termination_t(simif_t *sim,
+char termination_t::KIND;
+
+termination_t::termination_t(simif_t &sim,
                              const std::vector<std::string> &args,
                              const TERMINATIONBRIDGEMODULE_struct &mmio_addrs,
                              unsigned int num_messages,
                              unsigned int *is_err,
                              const char *const *msgs)
-    : bridge_driver_t(sim), mmio_addrs(mmio_addrs), num_messages(num_messages),
-      is_err(is_err), msgs(msgs) {
+    : bridge_driver_t(sim, &KIND), mmio_addrs(mmio_addrs),
+      num_messages(num_messages), is_err(is_err), msgs(msgs) {
   // tick-rate to decide sampling rate of MMIOs per number of ticks
   std::string tick_rate_arg = std::string("+termination-bridge-tick-rate=");
   for (auto &arg : args) {

--- a/sim/midas/src/main/cc/bridges/termination.h
+++ b/sim/midas/src/main/cc/bridges/termination.h
@@ -15,7 +15,10 @@ typedef struct TERMINATIONBRIDGEMODULE_struct {
 
 class termination_t : public bridge_driver_t {
 public:
-  termination_t(simif_t *sim,
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
+  termination_t(simif_t &sim,
                 const std::vector<std::string> &args,
                 const TERMINATIONBRIDGEMODULE_struct &mmio_addrs,
                 unsigned int num_messages,

--- a/sim/midas/src/main/cc/core/bridge_driver.cc
+++ b/sim/midas/src/main/cc/core/bridge_driver.cc
@@ -1,4 +1,13 @@
+// See LICENSE for license details.
+
 #include "bridge_driver.h"
+#include "simif.h"
+
+void bridge_driver_t::write(size_t addr, uint32_t data) {
+  simif.write(addr, data);
+}
+
+uint32_t bridge_driver_t::read(size_t addr) { return simif.read(addr); }
 
 size_t streaming_bridge_driver_t::pull(unsigned stream_idx,
                                        void *data,

--- a/sim/midas/src/main/cc/core/bridge_driver.h
+++ b/sim/midas/src/main/cc/core/bridge_driver.h
@@ -12,12 +12,12 @@
  *
  * Bridge Drivers are the CPU-hosted component of a Target-to-Host Bridge. A
  * Bridge Driver interacts with their accompanying FPGA-hosted BridgeModule
- * using MMIO (via read() and write() methods) or bridge streams (via pull()
- * and push()).
+ * using MMIO (via read() and write() methods).
  */
-class bridge_driver_t {
+class bridge_driver_t : public widget_t {
 public:
-  bridge_driver_t(simif_t *s) : sim(s) {}
+  using widget_t::widget_t;
+
   virtual ~bridge_driver_t(){};
   // Initialize BridgeModule state -- this can't be done in the constructor
   // currently
@@ -42,12 +42,9 @@ public:
   // DOC include end: Bridge Driver Interface
 
 protected:
-  void write(size_t addr, uint32_t data) { sim->write(addr, data); }
+  void write(size_t addr, uint32_t data);
 
-  uint32_t read(size_t addr) { return sim->read(addr); }
-
-private:
-  simif_t *sim;
+  uint32_t read(size_t addr);
 };
 
 /**
@@ -57,8 +54,8 @@ private:
  */
 class streaming_bridge_driver_t : public bridge_driver_t {
 public:
-  streaming_bridge_driver_t(simif_t *s, StreamEngine &stream)
-      : bridge_driver_t(s), stream(stream) {}
+  streaming_bridge_driver_t(simif_t &s, StreamEngine &stream, const void *kind)
+      : bridge_driver_t(s, kind), stream(stream) {}
 
   /**
    *  @brief Logical byte width of Bridge streams

--- a/sim/midas/src/main/cc/core/constructor.h
+++ b/sim/midas/src/main/cc/core/constructor.h
@@ -4,7 +4,7 @@
 // of the `add_bridge_driver` method with appropriate types.
 
 #ifdef PEEKPOKEBRIDGEMODULE_0_PRESENT
-add_bridge_driver(new peek_poke_t(simif,
+add_bridge_driver(new peek_poke_t(*simif,
                                   PEEKPOKEBRIDGEMODULE_0_substruct_create,
                                   POKE_SIZE,
                                   (const uint32_t *)INPUT_ADDRS,
@@ -22,7 +22,7 @@ RESETPULSEBRIDGEMODULE_checks;
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_RESET_PULSE(FUNC, IDX)                                     \
-  FUNC(new reset_pulse_t(simif,                                                \
+  FUNC(new reset_pulse_t(*simif,                                               \
                          args,                                                 \
                          RESETPULSEBRIDGEMODULE_##IDX##_substruct_create,      \
                          RESETPULSEBRIDGEMODULE_##IDX##_max_pulse_length,      \
@@ -43,35 +43,35 @@ UARTBRIDGEMODULE_checks;
 
 #ifdef UARTBRIDGEMODULE_0_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_0_substruct_create, 0));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_0_substruct_create, 0));
 #endif
 #ifdef UARTBRIDGEMODULE_1_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_1_substruct_create, 1));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_1_substruct_create, 1));
 #endif
 #ifdef UARTBRIDGEMODULE_2_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_2_substruct_create, 2));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_2_substruct_create, 2));
 #endif
 #ifdef UARTBRIDGEMODULE_3_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_3_substruct_create, 3));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_3_substruct_create, 3));
 #endif
 #ifdef UARTBRIDGEMODULE_4_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_4_substruct_create, 4));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_4_substruct_create, 4));
 #endif
 #ifdef UARTBRIDGEMODULE_5_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_5_substruct_create, 5));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_5_substruct_create, 5));
 #endif
 #ifdef UARTBRIDGEMODULE_6_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_6_substruct_create, 6));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_6_substruct_create, 6));
 #endif
 #ifdef UARTBRIDGEMODULE_7_PRESENT
 add_bridge_driver(
-    new uart_t(simif, args, UARTBRIDGEMODULE_7_substruct_create, 7));
+    new uart_t(*simif, args, UARTBRIDGEMODULE_7_substruct_create, 7));
 #endif
 
 #ifdef FASEDMEMORYTIMINGMODEL_checks
@@ -80,7 +80,7 @@ FASEDMEMORYTIMINGMODEL_checks;
 
 #define INSTANTIATE_FASED(FUNC, IDX)                                           \
   FUNC(new FASEDMemoryTimingModel(                                             \
-      simif,                                                                   \
+      *simif,                                                                  \
       AddressMap(FASEDMEMORYTIMINGMODEL_##IDX##_R_num_registers,               \
                  (const unsigned int *)FASEDMEMORYTIMINGMODEL_##IDX##_R_addrs, \
                  (const char *const *)FASEDMEMORYTIMINGMODEL_##IDX##_R_names,  \
@@ -146,12 +146,13 @@ SERIALBRIDGEMODULE_checks;
 #endif // SERIALBRIDGEMODULE_checks
 
 #define INSTANTIATE_SERIAL(FUNC, IDX)                                          \
-  FUNC(new serial_t(simif,                                                     \
+  FUNC(new serial_t(*simif,                                                    \
                     args,                                                      \
                     SERIALBRIDGEMODULE_##IDX##_substruct_create,               \
-                    IDX,                                                       \
+                    simif->get_loadmem(),                                      \
                     SERIALBRIDGEMODULE_##IDX##_has_memory,                     \
-                    SERIALBRIDGEMODULE_##IDX##_memory_offset));
+                    SERIALBRIDGEMODULE_##IDX##_memory_offset,                  \
+                    IDX));
 
 #ifdef SERIALBRIDGEMODULE_0_PRESENT
 INSTANTIATE_SERIAL(add_bridge_driver, 0)
@@ -207,7 +208,7 @@ BLOCKDEVBRIDGEMODULE_checks;
 #endif // BLOCKDEVBRIDGEMODULE_checks
 
 #ifdef BLOCKDEVBRIDGEMODULE_0_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_0_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_0_latency_bits,
@@ -215,7 +216,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  0));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_1_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_1_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_1_latency_bits,
@@ -223,7 +224,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  1));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_2_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_2_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_2_latency_bits,
@@ -231,7 +232,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  2));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_3_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_3_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_3_latency_bits,
@@ -239,7 +240,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  3));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_4_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_4_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_4_latency_bits,
@@ -247,7 +248,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  4));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_5_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_5_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_5_latency_bits,
@@ -255,7 +256,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  5));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_6_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_6_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_6_latency_bits,
@@ -263,7 +264,7 @@ add_bridge_driver(new blockdev_t(simif,
                                  6));
 #endif
 #ifdef BLOCKDEVBRIDGEMODULE_7_PRESENT
-add_bridge_driver(new blockdev_t(simif,
+add_bridge_driver(new blockdev_t(*simif,
                                  args,
                                  BLOCKDEVBRIDGEMODULE_7_num_trackers,
                                  BLOCKDEVBRIDGEMODULE_7_latency_bits,
@@ -276,7 +277,7 @@ SIMPLENICBRIDGEMODULE_checks;
 #endif // SIMPLENICBRIDGEMODULE_checks
 
 #define INSTANTIATE_SIMPLENIC(FUNC, IDX)                                       \
-  FUNC(new simplenic_t(simif,                                                  \
+  FUNC(new simplenic_t(*simif,                                                 \
                        simif->get_managed_stream(),                            \
                        args,                                                   \
                        SIMPLENICBRIDGEMODULE_##IDX##_substruct_create,         \
@@ -317,7 +318,7 @@ TRACERVBRIDGEMODULE_checks;
 
 // Bridge Driver Instantiation Template
 #define INSTANTIATE_TRACERV(FUNC, IDX)                                         \
-  FUNC(new tracerv_t(simif,                                                    \
+  FUNC(new tracerv_t(*simif,                                                   \
                      simif->get_managed_stream(),                              \
                      args,                                                     \
                      TRACERVBRIDGEMODULE_##IDX##_substruct_create,             \
@@ -428,7 +429,7 @@ INSTANTIATE_TRACERV(add_bridge_driver, 31)
 
 #ifdef DROMAJOBRIDGEMODULE_0_PRESENT
     add_bridge_driver(new dromajo_t(
-            simif, args,
+            *simif, args,
             DROMAJOBRIDGEMODULE_0_substruct_create,
             dromajo_config_t{
                 .resetVector = DROMAJO_RESET_VECTOR,
@@ -457,35 +458,35 @@ GROUNDTESTBRIDGEMODULE_checks;
 
 #ifdef GROUNDTESTBRIDGEMODULE_0_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_0_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_0_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_1_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_1_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_1_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_2_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_2_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_2_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_3_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_3_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_3_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_4_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_4_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_4_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_5_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_5_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_5_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_6_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_6_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_6_substruct_create));
 #endif
 #ifdef GROUNDTESTBRIDGEMODULE_7_PRESENT
     add_bridge_driver(new groundtest_t(
-            simif, args, GROUNDTESTBRIDGEMODULE_7_substruct_create));
+            *simif, args, GROUNDTESTBRIDGEMODULE_7_substruct_create));
 #endif
 
 #ifdef AUTOCOUNTERBRIDGEMODULE_checks
@@ -494,7 +495,7 @@ AUTOCOUNTERBRIDGEMODULE_checks;
 
 #define INSTANTIATE_AUTOCOUNTER(FUNC, IDX)                                     \
   FUNC(new autocounter_t(                                                      \
-      simif,                                                                   \
+      *simif,                                                                  \
       args,                                                                    \
       AUTOCOUNTERBRIDGEMODULE_##IDX##_substruct_create,                        \
       AddressMap(                                                              \
@@ -547,42 +548,42 @@ ASSERTBRIDGEMODULE_checks;
 #endif // ASSERTBRIDGEMODULE_checks
 
 #ifdef ASSERTBRIDGEMODULE_0_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_0_substruct_create,
                                                    ASSERTBRIDGEMODULE_0_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_1_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_1_substruct_create,
                                                    ASSERTBRIDGEMODULE_1_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_2_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_2_substruct_create,
                                                    ASSERTBRIDGEMODULE_2_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_3_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_3_substruct_create,
                                                    ASSERTBRIDGEMODULE_3_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_4_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_4_substruct_create,
                                                    ASSERTBRIDGEMODULE_4_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_5_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_5_substruct_create,
                                                    ASSERTBRIDGEMODULE_5_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_6_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_6_substruct_create,
                                                    ASSERTBRIDGEMODULE_6_assert_messages));
 #endif
 #ifdef ASSERTBRIDGEMODULE_7_PRESENT
-    add_bridge_driver(new synthesized_assertions_t(simif, args,
+    add_bridge_driver(new synthesized_assertions_t(*simif, args,
                                                    ASSERTBRIDGEMODULE_7_substruct_create,
                                                    ASSERTBRIDGEMODULE_7_assert_messages));
 #endif
@@ -592,7 +593,7 @@ PRINTBRIDGEMODULE_checks;
 #endif // PRINTBRIDGEMODULE_checks
 
 #define INSTANTIATE_PRINTF(FUNC, IDX)                                          \
-  FUNC(new synthesized_prints_t(simif,                                         \
+  FUNC(new synthesized_prints_t(*simif,                                        \
                                 simif->get_managed_stream(),                   \
                                 args,                                          \
                                 PRINTBRIDGEMODULE_##IDX##_substruct_create,    \
@@ -640,7 +641,7 @@ PLUSARGSBRIDGEMODULE_checks;
 #endif // PLUSARGSBRIDGEMODULE_checks
 
 #define INSTANTIATE_PLUSARGS(FUNC, IDX)                                        \
-  FUNC(new plusargs_t(simif,                                                   \
+  FUNC(new plusargs_t(*simif,                                                  \
                       args,                                                    \
                       PLUSARGSBRIDGEMODULE_##IDX##_substruct_create,           \
                       PLUSARGSBRIDGEMODULE_##IDX##_name,                       \
@@ -679,7 +680,7 @@ TERMINATIONBRIDGEMODULE_checks;
 #endif // TERMINATIONBRIDGEMODULE_checks
 
 #define INSTANTIATE_TERMINATION(FUNC, IDX)                                     \
-  FUNC(new termination_t(simif,                                                \
+  FUNC(new termination_t(*simif,                                               \
                          args,                                                 \
                          TERMINATIONBRIDGEMODULE_##IDX##_substruct_create,     \
                          TERMINATIONBRIDGEMODULE_##IDX##_message_count,        \

--- a/sim/midas/src/main/cc/core/simif.cc
+++ b/sim/midas/src/main/cc/core/simif.cc
@@ -9,12 +9,12 @@ create_simulation(const std::vector<std::string> &args, simif_t *simif);
 
 simif_t::simif_t(const TargetConfig &config,
                  const std::vector<std::string> &args)
-    : config(config), loadmem(this,
+    : config(config), loadmem(*this,
                               LOADMEMWIDGET_0_substruct_create,
                               config.mem,
                               LOADMEMWIDGET_0_mem_data_chunk),
-      clock(this, CLOCKBRIDGEMODULE_0_substruct_create),
-      master(this, SIMULATIONMASTER_0_substruct_create),
+      clock(*this, CLOCKBRIDGEMODULE_0_substruct_create),
+      master(*this, SIMULATIONMASTER_0_substruct_create),
       sim(create_simulation(args, this)) {
   for (auto &arg : args) {
     if (arg.find("+fastloadmem") == 0) {

--- a/sim/midas/src/main/cc/core/widget.cc
+++ b/sim/midas/src/main/cc/core/widget.cc
@@ -1,0 +1,8 @@
+// See LICENSE for license details.
+
+#include "widget.h"
+
+widget_t::widget_t(simif_t &simif, const void *kind)
+    : simif(simif), kind(kind) {}
+
+widget_t::~widget_t() {}

--- a/sim/midas/src/main/cc/core/widget.h
+++ b/sim/midas/src/main/cc/core/widget.h
@@ -1,0 +1,91 @@
+// See LICENSE for license details.
+
+#ifndef __WIDGET_H
+#define __WIDGET_H
+
+class widget_t;
+class widget_registry_t;
+class simif_t;
+
+template <class T>
+bool widget_isa(widget_t *widget);
+
+/**
+ * Base class of all drivers interfacing with a widget on the simulation.
+ *
+ * Widgets are all registered in the widget registry and are constructed
+ * automatically based on information retrieved from the target.
+ *
+ * A per-class kind uniquely identifies each widget types and allows them
+ * to be classified and retrieved from the registry.
+ */
+class widget_t {
+public:
+  /**
+   * Constructor for widgets.
+   *
+   * @param simif  Reference to the interface providing MMIO access.
+   * @param kind A unique token to identify the widget kind.
+   */
+  widget_t(simif_t &simif, const void *kind);
+
+  virtual ~widget_t();
+
+protected:
+  /**
+   * Reference to the MMIO interface.
+   */
+  simif_t &simif;
+
+private:
+  /**
+   * Unique token identifying the widget kind.
+   */
+  const void *kind;
+
+  // The type check must access the kind.
+  template <class T>
+  friend T *widget_isa(widget_t *widget);
+
+  // Bridge registry must access the kind.
+  friend class widget_registry_t;
+};
+
+/**
+ * Type check of widgets.
+ *
+ * Uses a custom type information encoding to identify widgets without relying
+ * on C++ RTTI. This mechanism is identical to that used by LLVM to register
+ * and identify passes, even ones loaded dynamically through shared libraries.
+ *
+ * Each class provides a `KIND` field, which is an uninitialized item.
+ * Constructors set the `kind` to a pointer to this field, which is guaranteed
+ * to be unique across the application, allowing widgets of different kinds to
+ * be distinguished without involving RTTI.
+ */
+template <class T>
+bool widget_isa(widget_t *widget) {
+  return widget->kind == &T::KIND;
+}
+
+/**
+ * Dynamic cast between widgets, return nullptr on mismatch.
+ */
+template <class T>
+T *widget_dyn_cast(widget_t *widget) {
+  if (!widget_isa<T>(widget))
+    return nullptr;
+  return static_cast<T *>(widget);
+}
+
+/**
+ * Cast between widgets, aborting on mismatched types.
+ */
+template <class T>
+T *widget_cast(widget_t *widget) {
+  if (auto *target = widget_dyn_cast<T>(widget))
+    return target;
+  abort();
+}
+
+#endif // __WIDGET_H

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -103,7 +103,7 @@ void fasedtests_top_t::simulation_init() {
                  (const unsigned int *)FASEDMEMORYTIMINGMODEL_0_W_addrs,
                  (const char *const *)FASEDMEMORYTIMINGMODEL_0_W_names);
   add_bridge_driver(
-      new test_harness_bridge_t(simif, peek_poke.get(), fased_addr_map, args));
+      new test_harness_bridge_t(*simif, *peek_poke, fased_addr_map, args));
 
   for (auto &e : fpga_models) {
     e->init();

--- a/sim/src/main/cc/fasedtests/test_harness_bridge.cc
+++ b/sim/src/main/cc/fasedtests/test_harness_bridge.cc
@@ -2,13 +2,14 @@
 
 #include "test_harness_bridge.h"
 
+char test_harness_bridge_t::KIND;
+
 test_harness_bridge_t::test_harness_bridge_t(
-    simif_t *simif,
-    peek_poke_t *peek_poke,
+    simif_t &simif,
+    peek_poke_t &peek_poke,
     AddressMap addr_map,
     const std::vector<std::string> &args)
-    : bridge_driver_t(simif), simif(simif), peek_poke(peek_poke),
-      addr_map(addr_map) {
+    : bridge_driver_t(simif, &KIND), peek_poke(peek_poke), addr_map(addr_map) {
 
   for (auto &arg : args) {
     // Record all uarch events we want to validate
@@ -27,11 +28,11 @@ test_harness_bridge_t::test_harness_bridge_t(
 // against expected values
 void test_harness_bridge_t::tick() {
   // Wait for reset to complete.
-  if (simif->actual_tcycle() < 100)
+  if (simif.actual_tcycle() < 100)
     return;
 
   // use a non-blocking sample since this signal is monotonic
-  done = peek_poke->sample_value("done");
+  done = peek_poke.sample_value("done");
   if (done) {
     error = 0;
     // Iterate through all uarch values we want to validate

--- a/sim/src/main/cc/fasedtests/test_harness_bridge.h
+++ b/sim/src/main/cc/fasedtests/test_harness_bridge.h
@@ -13,17 +13,19 @@ class test_harness_bridge_t : public bridge_driver_t {
 private:
   int error = 0;
   bool done = false;
-  simif_t *simif;
-  peek_poke_t *peek_poke;
+  peek_poke_t &peek_poke;
   AddressMap addr_map;
   std::unordered_map<std::string, uint32_t> expected_uarchevent_values;
 
 public:
+  /// The identifier for the bridge type used for casts.
+  static char KIND;
+
   /**
    * @param addr_map This matches the addr map pass to the FASED timing model
    */
-  test_harness_bridge_t(simif_t *simif,
-                        peek_poke_t *peek_poke,
+  test_harness_bridge_t(simif_t &simif,
+                        peek_poke_t &peek_poke,
                         AddressMap addr_map,
                         const std::vector<std::string> &args);
   virtual ~test_harness_bridge_t(){};

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -100,7 +100,7 @@ int firesim_top_t::exit_code() {
 }
 
 void firesim_top_t::simulation_init() {
-  add_bridge_driver(new heartbeat_t(simif, args));
+  add_bridge_driver(new heartbeat_t(*simif, args));
 
   // DOC include start: Bridge Driver Registration
   // Here we instantiate our driver once for each bridge in the target

--- a/sim/src/main/cc/midasexamples/AssertTest.h
+++ b/sim/src/main/cc/midasexamples/AssertTest.h
@@ -1,0 +1,25 @@
+// See LICENSE for license details.
+
+#ifndef MIDASEXAMPLES_ASSERTTEST_H
+#define MIDASEXAMPLES_ASSERTTEST_H
+
+#include "TestHarness.h"
+#include "bridges/synthesized_assertions.h"
+
+class AssertTest : public TestHarness {
+public:
+  using TestHarness::TestHarness;
+
+  virtual ~AssertTest() {}
+
+  const std::vector<synthesized_assertions_t *> assert_endpoints =
+      get_bridges<synthesized_assertions_t>();
+
+  void simulation_init() override {
+    for (auto &assert_endpoint : assert_endpoints) {
+      assert_endpoint->init();
+    }
+  }
+};
+
+#endif // MIDASEXAMPLES_ASSERTTEST_H


### PR DESCRIPTION
The widget/bridge hierarchy is now rooted at widgets. In order to dynamically distinguish classes, an RTTI mechanism was added, along with `widget_cast` and `widget_isa` methods.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
