### PR TITLE
Re-enable compilation of the Dromajo bridge

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/dromajo.h
+++ b/sim/firesim-lib/src/main/cc/bridges/dromajo.h
@@ -7,23 +7,34 @@
 #include <string>
 #include <vector>
 
-#ifdef DROMAJOBRIDGEMODULE_0_PRESENT
-
 typedef struct DROMAJOBRIDGEMODULE_struct {
 
 } DROMAJOBRIDGEMODULE_struct;
 
-class dromajo_t : public bridge_driver_t {
+struct dromajo_config_t {
+  const char *resetVector;
+  const char *mmioStart;
+  const char *mmioEnd;
+  const char *memSize;
+  const char *plicBase;
+  const char *plicSize;
+  const char *clintBase;
+  const char *clintSize;
+};
+
+class dromajo_t : public streaming_bridge_driver_t {
 public:
   dromajo_t(simif_t *sim,
+            StreamEngine &stream,
             std::vector<std::string> &args,
+            const DROMAJOBRIDGEMODULE_struct &mmio_addrs,
+            const dromajo_config_t &config,
             int iaddr_width,
             int insn_width,
             int wdata_width,
             int cause_width,
             int tval_width,
             int num_traces,
-            const DROMAJOBRIDGEMODULE_struct &mmio_addrs,
             int stream_idx,
             int stream_depth);
   ~dromajo_t();
@@ -36,6 +47,7 @@ public:
 
 private:
   const DROMAJOBRIDGEMODULE_struct mmio_addrs;
+  const dromajo_config_t config;
   simif_t *_sim;
 
   int invoke_dromajo(uint8_t *buf);
@@ -67,9 +79,6 @@ private:
 
   // other misc members
   uint32_t _num_traces;
-  long _dma_addr;
-  const unsigned int stream_count_address;
-  const unsigned int stream_full_address;
   uint8_t _trace_idx;
   bool dromajo_failed;
   int dromajo_exit_code;
@@ -81,6 +90,10 @@ private:
   std::string dromajo_bootrom;
   std::string dromajo_bin;
   dromajo_cosim_state_t *dromajo_state;
+
+  // stream config
+  int stream_idx;
+  int stream_depth;
 };
-#endif // DROMAJOBRIDGEMODULE_0_PRESENT
+
 #endif // __DROMAJO_H

--- a/sim/midas/src/main/cc/core/constructor.h
+++ b/sim/midas/src/main/cc/core/constructor.h
@@ -429,13 +429,23 @@ INSTANTIATE_TRACERV(add_bridge_driver, 31)
 #ifdef DROMAJOBRIDGEMODULE_0_PRESENT
     add_bridge_driver(new dromajo_t(
             simif, args,
+            DROMAJOBRIDGEMODULE_0_substruct_create,
+            dromajo_config_t{
+                .resetVector = DROMAJO_RESET_VECTOR,
+                .mmioStart = DROMAJO_MMIO_START,
+                .mmioEnd = DROMAJO_MMIO_END,
+                .memSize = DROMAJO_MEM_SIZE,
+                .plicBase = DROMAJO_PLIC_BASE,
+                .plicSize = DROMAJO_PLIC_SIZE,
+                .clintBase = DROMAJO_CLINT_BASE,
+                .clintSize = DROMAJO_CLINT_SIZE,
+            },
             DROMAJOBRIDGEMODULE_0_iaddr_width,
             DROMAJOBRIDGEMODULE_0_insn_width,
             DROMAJOBRIDGEMODULE_0_wdata_width,
             DROMAJOBRIDGEMODULE_0_cause_width,
             DROMAJOBRIDGEMODULE_0_tval_width,
             DROMAJOBRIDGEMODULE_0_num_traces,
-            DROMAJOBRIDGEMODULE_0_substruct_create,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_dma_address,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_count_address,
             DROMAJOBRIDGEMODULE_0_to_cpu_stream_full_address)


### PR DESCRIPTION
The Dromajo bit suffers from a fair bit of bit rot. This patch fixes breakages from stream engines and MMIO port rewrites. The Dromajo bridge is now compiled as part of the support library, ensuring at least the C++ side is kept updated. Due to its use of an additional header, it is an interesting bridge to keep maintaining. The bridge is not tested as the Scala counterpart does not compile with Chipyard at the moment.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
