### PR TITLE
Moved simulation step control to the PeekPoke bridge

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -16,18 +16,18 @@ firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0c7427323dc4e5a5b
+    agfi: agfi-0ba7b280b17e28c95
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0c546c4a268d17914
+    agfi: agfi-03abaafca020aefe0
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-088f1ca75400ee1d4
+    agfi: agfi-0cd4af5a3cc4f7c18
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-00ef454202a525d3c
+    agfi: agfi-037c336192e0a4d26
     deploy_triplet_override: null
     custom_runtime_config: null

--- a/sim/midas/src/main/cc/bridges/master.cc
+++ b/sim/midas/src/main/cc/bridges/master.cc
@@ -8,14 +8,3 @@ master_t::master_t(simif_t &simif, const SIMULATIONMASTER_struct &mmio_addrs)
     : widget_t(simif, &KIND), mmio_addrs(mmio_addrs) {}
 
 bool master_t::is_init_done() { return simif.read(mmio_addrs.INIT_DONE); }
-
-bool master_t::is_done() { return simif.read(mmio_addrs.DONE); }
-
-void master_t::step(size_t n, bool blocking) {
-  simif.write(mmio_addrs.STEP, n);
-
-  if (blocking) {
-    while (!is_done())
-      ;
-  }
-}

--- a/sim/midas/src/main/cc/bridges/master.h
+++ b/sim/midas/src/main/cc/bridges/master.h
@@ -10,8 +10,6 @@
 class simif_t;
 
 struct SIMULATIONMASTER_struct {
-  uint64_t STEP;
-  uint64_t DONE;
   uint64_t INIT_DONE;
 };
 
@@ -26,16 +24,6 @@ public:
    * Check whether the device is initialised.
    */
   bool is_init_done();
-
-  /**
-   * Check whether the simulation is complete.
-   */
-  bool is_done();
-
-  /**
-   * Request the simulation to advance a given number of steps.
-   */
-  void step(size_t n, bool blocking);
 
 private:
   const SIMULATIONMASTER_struct mmio_addrs;

--- a/sim/midas/src/main/cc/bridges/peek_poke.h
+++ b/sim/midas/src/main/cc/bridges/peek_poke.h
@@ -9,8 +9,9 @@
 #include "core/simif.h"
 
 struct PEEKPOKEBRIDGEMODULE_struct {
+  uint64_t STEP;
+  uint64_t DONE;
   uint64_t PRECISE_PEEKABLE;
-  uint64_t READY;
 };
 
 /**
@@ -63,6 +64,16 @@ public:
    */
   bool unstable() const { return req_unstable; }
 
+  /**
+   * Check whether the cycle horizon has been reached.
+   */
+  bool is_done();
+
+  /**
+   * Advance the cycle horizon a given number of steps.
+   */
+  void step(size_t n, bool blocking);
+
 private:
   /// Base MMIO port mapping.
   const PEEKPOKEBRIDGEMODULE_struct mmio_addrs;
@@ -83,8 +94,8 @@ private:
     return true;
   }
 
-  bool wait_on_ready(double timeout) {
-    return wait_on(mmio_addrs.READY, timeout);
+  bool wait_on_done(double timeout) {
+    return wait_on(mmio_addrs.DONE, timeout);
   }
 
   bool wait_on_stable_peeks(double timeout) {

--- a/sim/midas/src/main/cc/core/simif.h
+++ b/sim/midas/src/main/cc/core/simif.h
@@ -53,21 +53,6 @@ public:
   virtual ~simif_t();
 
 public:
-  /**
-   * Returns true if the simulation is complete.
-   */
-  inline bool done() { return registry->get_widget<master_t>().is_done(); }
-
-  /**
-   * Advance the simulation a given number of steps.
-   */
-  inline void take_steps(size_t n, bool blocking) {
-    return registry->get_widget<master_t>().step(n, blocking);
-  }
-
-  // Host-platform interface. See simif_f1; simif_emul for implementation
-  // examples
-
   /** Bridge / Widget MMIO methods */
 
   /**

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -339,8 +339,6 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
   // transformations can inject hardware synchronous to correct clock.
   HostClockSource.annotate(clock)
 
-  val master  = outer.master
-
   val ctrl = IO(Flipped(WidgetMMIO()))
   val mem = IO(Vec(p(HostMemNumChannels), AXI4Bundle(p(HostMemChannelKey).axi4BundleParams)))
 
@@ -375,12 +373,6 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
   // Instantiate bridge widgets.
   outer.bridgeModuleMap.map({ case (bridgeAnno, bridgeMod) =>
     val widgetChannelPrefix = s"${bridgeAnno.target.ref}"
-    bridgeMod match {
-      case peekPoke: PeekPokeBridgeModule =>
-        peekPoke.module.io.step <> master.module.io.step
-        master.module.io.done := peekPoke.module.io.idle
-      case _ =>
-    }
     bridgeMod.module.hPort.connectChannels2Port(bridgeAnno, simIo)
   })
 

--- a/sim/midas/src/main/scala/midas/widgets/Master.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Master.scala
@@ -11,32 +11,11 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 
 class SimulationMasterIO(implicit val p: Parameters) extends WidgetIO()(p){
-  val done = Input(Bool())
-  val step = Decoupled(UInt(p(CtrlNastiKey).dataBits.W))
 }
-
-object Pulsify {
-  def apply(in: Bool, pulseLength: Int): Unit = {
-    require(pulseLength > 0)
-    if (pulseLength > 1) {
-      val count = Counter(pulseLength)
-      when(in){count.inc()}
-      when(count.value === (pulseLength - 1).U) {
-        in := false.B
-        count.value := 0.U
-      }
-    } else {
-      when(in) {in := false.B}
-    }
-  }
-}
-
 
 class SimulationMaster(implicit p: Parameters) extends Widget()(p) {
   lazy val module = new WidgetImp(this) {
     val io = IO(new SimulationMasterIO)
-    genAndAttachQueue(io.step, "STEP")
-    genRORegInit(io.done, "DONE", 0.U)
 
     val initDelay = RegInit(64.U)
     when (initDelay =/= 0.U) { initDelay := initDelay - 1.U }

--- a/sim/midas/src/main/scala/midas/widgets/Pulsify.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Pulsify.scala
@@ -1,0 +1,32 @@
+// See LICENSE for license details.
+
+package midas
+package widgets
+
+import chisel3._
+import chisel3.util._
+
+/** Takes a Bool and forces it to deassert after pulseLength cycles by using Chisel last-connect semantics, effectively
+  * "stretching" the pulse.
+  *
+  * @param in
+  *   The wire to override
+  *
+  * @param pulseLength
+  *   the number of cycles to stretch the pulse over.
+  */
+object Pulsify {
+  def apply(in: Bool, pulseLength: Int): Unit = {
+    require(pulseLength > 0)
+    if (pulseLength > 1) {
+      val count = Counter(pulseLength)
+      when(in) { count.inc() }
+      when(count.value === (pulseLength - 1).U) {
+        in          := false.B
+        count.value := 0.U
+      }
+    } else {
+      when(in) { in := false.B }
+    }
+  }
+}

--- a/sim/src/main/cc/bridges/BridgeHarness.cc
+++ b/sim/src/main/cc/bridges/BridgeHarness.cc
@@ -21,13 +21,13 @@ void BridgeHarness::simulation_init() {
 int BridgeHarness::simulation_run() {
   // Reset the DUT.
   peek_poke.poke("reset", 1, /*blocking=*/true);
-  sim.take_steps(1, /*blocking=*/true);
+  peek_poke.step(1, /*blocking=*/true);
   peek_poke.poke("reset", 0, /*blocking=*/true);
-  sim.take_steps(1, /*blocking=*/true);
+  peek_poke.step(1, /*blocking=*/true);
 
   // Tick until all requests are serviced.
-  sim.take_steps(get_step_limit(), /*blocking=*/false);
-  for (unsigned i = 0; i < get_tick_limit() && !sim.done(); ++i) {
+  peek_poke.step(get_step_limit(), /*blocking=*/false);
+  for (unsigned i = 0; i < get_tick_limit() && !peek_poke.is_done(); ++i) {
     for (auto &bridge : sim.get_registry().get_all_bridges()) {
       bridge->tick();
     }

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -91,10 +91,11 @@ void fasedtests_top_t::simulation_init() {
 }
 
 int fasedtests_top_t::simulation_run() {
+  auto &peek_poke = sim.get_registry().get_widget<peek_poke_t>();
   while (!simulation_complete() && !finished_scheduled_tasks()) {
     run_scheduled_tasks();
-    sim.take_steps(get_largest_stepsize(), false);
-    while (!sim.done() && !simulation_complete()) {
+    peek_poke.step(get_largest_stepsize(), false);
+    while (!peek_poke.is_done() && !simulation_complete()) {
       for (auto &e : sim.get_registry().get_all_bridges())
         e->tick();
     }

--- a/sim/src/main/cc/firesim/firesim_top.cc
+++ b/sim/src/main/cc/firesim/firesim_top.cc
@@ -2,6 +2,7 @@
 
 #include "bridges/fased_memory_timing_model.h"
 #include "bridges/heartbeat.h"
+#include "bridges/peek_poke.h"
 #include "core/bridge_driver.h"
 #include "core/simif.h"
 #include "core/simulation.h"
@@ -84,10 +85,11 @@ void firesim_top_t::simulation_init() {
 }
 
 int firesim_top_t::simulation_run() {
+  auto &peek_poke = sim.get_registry().get_widget<peek_poke_t>();
   while (!simulation_complete() && !finished_scheduled_tasks()) {
     run_scheduled_tasks();
-    sim.take_steps(get_largest_stepsize(), false);
-    while (!sim.done() && !simulation_complete()) {
+    peek_poke.step(get_largest_stepsize(), false);
+    while (!peek_poke.is_done() && !simulation_complete()) {
       for (auto &e : sim.get_registry().get_all_bridges())
         e->tick();
     }

--- a/sim/src/main/cc/midasexamples/AutoCounterTest.h
+++ b/sim/src/main/cc/midasexamples/AutoCounterTest.h
@@ -24,7 +24,7 @@ public:
 
   void run_and_collect(int cycles) {
     step(cycles, false);
-    while (!sim.done()) {
+    while (!peek_poke.is_done()) {
       for (auto &autocounter_endpoint : autocounter_endpoints) {
         autocounter_endpoint->tick();
       }

--- a/sim/src/main/cc/midasexamples/PrintfTest.h
+++ b/sim/src/main/cc/midasexamples/PrintfTest.h
@@ -23,7 +23,7 @@ public:
 
   void run_and_collect_prints(int cycles) {
     step(cycles, false);
-    while (!sim.done()) {
+    while (!peek_poke.is_done()) {
       for (auto &print_endpoint : print_endpoints) {
         print_endpoint->tick();
       }

--- a/sim/src/main/cc/midasexamples/TestAssertGlobalResetCondition.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertGlobalResetCondition.cc
@@ -9,7 +9,7 @@ public:
   void run_test() override {
     target_reset(2);
     step(40000, false);
-    while (!sim.done()) {
+    while (!peek_poke.is_done()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
         if (ep->terminate()) {

--- a/sim/src/main/cc/midasexamples/TestAssertModule.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertModule.cc
@@ -45,7 +45,7 @@ public:
       }
 
       auto &assert_endpoint = *assert_endpoints[0];
-      while (!sim.done()) {
+      while (!peek_poke.is_done()) {
         assert_endpoint.tick();
         if (assert_endpoint.terminate()) {
           assert_endpoint.resume();

--- a/sim/src/main/cc/midasexamples/TestAssertTorture.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertTorture.cc
@@ -8,8 +8,8 @@ public:
 
   void run_test() override {
     target_reset(2);
-    step(40000, false);
-    while (!sim.done()) {
+    peek_poke.step(40000, false);
+    while (!peek_poke.is_done()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
         if (ep->terminate()) {

--- a/sim/src/main/cc/midasexamples/TestHarness.cc
+++ b/sim/src/main/cc/midasexamples/TestHarness.cc
@@ -28,7 +28,7 @@ void TestHarness::step(uint32_t n, bool blocking) {
   if (log) {
     std::cerr << "* STEP " << n << " -> " << t + n << " *" << std::endl;
   }
-  sim.take_steps(n, blocking);
+  peek_poke.step(n, blocking);
   t += n;
 }
 

--- a/sim/src/main/cc/midasexamples/TestMulticlockAssertModule.cc
+++ b/sim/src/main/cc/midasexamples/TestMulticlockAssertModule.cc
@@ -23,7 +23,7 @@ public:
     poke("halfrate_cycle", 129);
 
     step(256, false);
-    while (!sim.done()) {
+    while (!peek_poke.is_done()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
         if (ep->terminate()) {

--- a/sim/src/main/cc/midasexamples/TestTerminationModuleAssert.cc
+++ b/sim/src/main/cc/midasexamples/TestTerminationModuleAssert.cc
@@ -15,7 +15,7 @@ public:
   void step_assume_continue(int count) {
     step(count, false);
     expected_cycle_at_bridge += count;
-    while (!sim.done()) {
+    while (!peek_poke.is_done()) {
       terminator.tick();
       assert(!terminator.terminate() && "Unexpected termination signaled.");
     }

--- a/sim/src/main/cc/midasexamples/TestTriggerWiringModule.cc
+++ b/sim/src/main/cc/midasexamples/TestTriggerWiringModule.cc
@@ -36,7 +36,7 @@ public:
     step(1);
     poke("reset", 0);
     step(10000, false);
-    while (!sim.done() && !simulation_complete()) {
+    while (!peek_poke.is_done() && !simulation_complete()) {
       for (auto &ep : assert_endpoints) {
         ep->tick();
       }


### PR DESCRIPTION
The `STEP` and `DONE` fields of the simulation master were fully determined by the behaviour of the peek poke bridge. Since that stepping logic is closely tied to peek-poke logic, this PR moves it into that bridge. Temporarily, the `firesim_top` harness now uses PeekPoke to drive the simulation. This will be removed in a future PR.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

The memory mapping changes as ports were moved from `SimulationMaster` to the `PeekPoke` bridge.

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
