### PR TITLE
Enable clang-tidy on C++ sources

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,74 @@
+Checks: >
+        -*,
+        clang-diagnostic-*,
+        #misc-*,
+        #-misc-const-correctness,
+        #-misc-unused-parameters,
+        #-misc-non-private-member-variables-in-classes,
+        #bugprone-argument-comment,
+        #bugprone-assert-side-effect,
+        #bugprone-branch-clone,
+        #bugprone-copy-constructor-init,
+        #bugprone-dangling-handle,
+        #bugprone-dynamic-static-initializers,
+        #bugprone-macro-parentheses,
+        #bugprone-macro-repeated-side-effects,
+        #bugprone-misplaced-widening-cast,
+        #bugprone-move-forwarding-reference,
+        #bugprone-multiple-statement-macro,
+        #bugprone-suspicious-semicolon,
+        #bugprone-swapped-arguments,
+        #bugprone-terminating-continue,
+        #bugprone-unused-raii,
+        #bugprone-unused-return-value,
+        #modernize-use-bool-literals,
+        #modernize-loop-convert,
+        #modernize-make-unique,
+        #modernize-raw-string-literal,
+        #modernize-use-equals-default,
+        #modernize-use-default-member-init,
+        #modernize-use-emplace,
+        ##modernize-use-nullptr,
+        #modernize-use-override,
+        #modernize-use-using,
+        #performance-for-range-copy,
+        #performance-implicit-conversion-in-loop,
+        #performance-inefficient-algorithm,
+        #performance-inefficient-vector-operation,
+        #performance-move-const-arg,
+        #performance-no-automatic-move,
+        #performance-trivially-destructible,
+        #performance-unnecessary-copy-initialization,
+        #performance-unnecessary-value-param,
+        #readability-identifier-naming,
+        #readability-avoid-const-params-in-decls,
+        #readability-const-return-type,
+        #readability-container-size-empty,
+        #readability-inconsistent-declaration-parameter-name,
+        #readability-misleading-indentation,
+        #readability-redundant-control-flow,
+        #readability-redundant-smartptr-get,
+        #readability-simplify-boolean-expr,
+        #readability-simplify-subscript-expr,
+        readability-use-anyofallof
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           1
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           1

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -380,8 +380,8 @@ jobs:
           cat /tmp/sphinx-err*.log
       - uses: ./.github/actions/job-end
 
-  clang-format:
-    name: clang-format
+  cpp-lint:
+    name: cpp-lint
     runs-on: ubuntu-20.04
     steps:
       # Clone the repository (shallow to save time).
@@ -391,11 +391,18 @@ jobs:
           fetch-depth: 2
           submodules: false
 
-      # Install clang-format
-      - name: Install clang-format
+      # Checkout chipyard submodules.
+      - name: Checkout chipyard
+        run: |
+          git submodule update --init target-design/chipyard
+          cd target-design/chipyard
+          git submodule update --init generators/testchipip
+
+      # Install clang linters
+      - name: Install Clang linters
         run: |
           sudo apt update
-          sudo apt install clang-format -y
+          sudo apt install clang-format clang-tidy-12 parallel -y
 
       # Run 'clang-format', comparing against the base commit hash.
       # If anything got reformatted, fail and output a patch.
@@ -414,3 +421,10 @@ jobs:
             git checkout .
             exit 1
           fi
+
+      # Run clang-tidy on the entire codebase. Error will be logged.
+      - name: Run clang-tidy
+        run: |
+          export FIRESIM_ENV_SOURCED=1
+          export FIRESIM_STANDALONE=1
+          make -C sim clang-tidy

--- a/docs/Developer-Docs/GoldenGate-and-Driver-Development.rst
+++ b/docs/Developer-Docs/GoldenGate-and-Driver-Development.rst
@@ -158,5 +158,9 @@ C/C++ guidelines
 The C++ sources are formatted using ``clang-format`` and all submitted pull-requests
 must be formatted prior to being accepted and merged. The sources follow the coding
 style defined `here <https://github.com/firesim/firesim/blob/main/.clang_format>`_.
+Additionally, ``clang-tidy`` is also run on CI to lint and validate C++ sources.
+The tool follows the guidelines and configuration of LLVM.
 
 ``git clang-format`` can be used before committing to ensure that files are properly formatted.
+``make -C sim clang-tidy`` can be used to run ``clang-tidy``. `make -C sim clang-tidy-fix`
+automatically applies most fixes, but some errors and warnings require user intervention.

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -66,7 +66,8 @@ include make/xsim.mk
 include $(TARGET_PROJECT_MAKEFRAG)/metasim.mk
 
 include make/unittest.mk
-include make/scala.mk
+include make/scala-lint.mk
+include make/cpp-lint.mk
 
 #########################
 # Cleaning Recipes      #

--- a/sim/firesim-lib/src/main/cc/bridges/serial.h
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.h
@@ -2,27 +2,12 @@
 #ifndef __SERIAL_H
 #define __SERIAL_H
 
+#include "bridges/serial_data.h"
 #include "core/bridge_driver.h"
 
 class loadmem_t;
 class firesim_tsi_t;
 class firesim_loadmem_t;
-
-template <class T>
-struct serial_data_t {
-  struct {
-    T bits;
-    bool valid;
-    bool ready;
-    bool fire() { return valid && ready; }
-  } in;
-  struct {
-    T bits;
-    bool ready;
-    bool valid;
-    bool fire() { return valid && ready; }
-  } out;
-};
 
 typedef struct SERIALBRIDGEMODULE_struct {
   uint64_t in_bits;

--- a/sim/firesim-lib/src/main/cc/bridges/serial_data.h
+++ b/sim/firesim-lib/src/main/cc/bridges/serial_data.h
@@ -1,0 +1,19 @@
+#ifndef __SERIAL_DATA_H
+#define __SERIAL_DATA_H
+
+template <class T>
+struct serial_data_t {
+  struct {
+    T bits;
+    bool valid;
+    bool ready;
+    bool fire() { return valid && ready; }
+  } in;
+  struct {
+    T bits;
+    bool ready;
+    bool valid;
+    bool fire() { return valid && ready; }
+  } out;
+};
+#endif // __SERIAL_DATA_H

--- a/sim/firesim-lib/src/main/cc/bridges/uart.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.cc
@@ -1,6 +1,8 @@
 // See LICENSE for license details
 
 #include "uart.h"
+#include "core/simif.h"
+
 #include <fcntl.h>
 #include <sys/stat.h>
 

--- a/sim/firesim-lib/src/main/cc/bridges/uart.h
+++ b/sim/firesim-lib/src/main/cc/bridges/uart.h
@@ -3,10 +3,15 @@
 #ifndef __UART_H
 #define __UART_H
 
+#include "bridges/serial_data.h"
+#include "core/bridge_driver.h"
+
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <signal.h>
-
-#include "serial.h"
+#include <string>
+#include <vector>
 
 /**
  * Structure carrying the addresses of all fixed MMIO ports.

--- a/sim/make/cpp-lint.mk
+++ b/sim/make/cpp-lint.mk
@@ -1,0 +1,41 @@
+# See LICENSE for license details.
+
+
+################################################################################
+# clang-tidy
+################################################################################
+
+testchipip_csrc_dir = $(chipyard_dir)/generators/testchipip/src/main/resources/testchipip/csrc
+
+clang_tidy_files := $(shell \
+	find $(firesim_base_dir) -name '*.cc' -or -name '*.h' \
+		| grep -v generic_vharness.cc \
+		| grep -v TestPointerChaser.cc \
+		| grep -v simif.cc \
+		| grep -v simif_ \
+		| grep -v tracerv \
+		| grep -v dromajo \
+		| grep -v serial \
+		| grep -v fesvr \
+		| grep -v firesim_top \
+)
+
+clang_tidy_flags :=\
+	-I$(firesim_base_dir)/midas/src/main/cc \
+	-I$(firesim_base_dir)/firesim-lib/src/main/cc \
+	-I$(testchipip_csrc_dir) \
+	-std=c++17 \
+	-x c++
+
+# Checks the files in parallel without applying fixes.
+.PHONY: clang-tidy
+clang-tidy:
+	@echo $(clang_tidy_files) \
+		| tr ' ' '\n' \
+	 	| parallel -I% --max-args 1 clang-tidy % -- $(clang_tidy_flags)
+
+
+# Applies fixes to issues detected.
+.PHONY: clang-tidy-fix
+clang-tidy-fix:
+	@clang-tidy -fix $(clang_tidy_files) -- $(clang_tidy_flags)

--- a/sim/make/scala-build.mk
+++ b/sim/make/scala-build.mk
@@ -139,3 +139,11 @@ test: $(FIRESIM_MAIN_CP) $(FIRESIM_TEST_CP) $(TARGET_CP)
 .PHONY: testOnly
 testOnly: $(FIRESIM_MAIN_CP) $(FIRESIM_TEST_CP) $(TARGET_CP)
 	cd $(base_dir) && java -cp $$(cat $(FIRESIM_TEST_CP)) org.scalatest.run $(SCALA_TEST)
+
+################################################################################
+# ScalaDoc
+################################################################################
+
+.PHONY: scaladoc
+scaladoc:
+	cd $(base_dir) && $(SBT) "project {file:$(firesim_base_dir)}firesim" "unidoc"

--- a/sim/make/scala-lint.mk
+++ b/sim/make/scala-lint.mk
@@ -1,13 +1,6 @@
 # See LICENSE for license details.
 
 #########################
-# ScalaDoc              #
-#########################
-.PHONY: scaladoc
-scaladoc:
-	cd $(base_dir) && $(SBT) "project {file:$(firesim_base_dir)}firesim" "unidoc"
-
-#########################
 # Scalafmt              #
 #########################
 
@@ -28,3 +21,4 @@ scalafmtAll:
 		firesimLib / scalafmtAll; \
 		midas / scalafmtAll ; \
 		targetutils / scalafmtAll ;"
+

--- a/sim/midas/src/main/cc/core/constructor.h
+++ b/sim/midas/src/main/cc/core/constructor.h
@@ -29,9 +29,15 @@ RESETPULSEBRIDGEMODULE_checks;
                          RESETPULSEBRIDGEMODULE_##IDX##_default_pulse_length,  \
                          IDX));
 
+#ifdef CLOCKBRIDGEMODULE_checks
 CLOCKBRIDGEMODULE_checks;
+#endif // CLOCKBRIDGEMODULE_checks
+#ifdef LOADMEMWIDGET_checks
 LOADMEMWIDGET_checks;
+#endif // LOADMEMWIDGET_checks
+#ifdef SIMULATIONMASTER_checks
 SIMULATIONMASTER_checks;
+#endif // SIMULATIONMASTER_checks
 
 #ifdef RESETPULSEBRIDGEMODULE_0_PRESENT
 INSTANTIATE_RESET_PULSE(add_bridge_driver, 0)

--- a/sim/midas/src/main/cc/core/stream_engine.h
+++ b/sim/midas/src/main/cc/core/stream_engine.h
@@ -4,6 +4,7 @@
 #define __BRIDGES_BRIDGE_STREAM_DRIVER_H
 
 #include <memory>
+#include <vector>
 
 class FPGAToCPUStreamDriver {
 public:

--- a/sim/midas/src/main/cc/core/systematic_scheduler.h
+++ b/sim/midas/src/main/cc/core/systematic_scheduler.h
@@ -2,6 +2,7 @@
 #ifndef __SYSTEMATIC_SCHEDULER_H
 #define __SYSTEMATIC_SCHEDULER_H
 
+#include <cstdint>
 #include <functional>
 #include <vector>
 

--- a/sim/midas/src/main/cc/core/widget.h
+++ b/sim/midas/src/main/cc/core/widget.h
@@ -3,6 +3,8 @@
 #ifndef __WIDGET_H
 #define __WIDGET_H
 
+#include <cstdlib>
+
 class widget_t;
 class widget_registry_t;
 class simif_t;

--- a/sim/midas/src/main/cc/emul/mm.h
+++ b/sim/midas/src/main/cc/emul/mm.h
@@ -3,6 +3,8 @@
 #ifndef __EMUL_MM_H
 #define __EMUL_MM_H
 
+#include "core/config.h"
+
 #include <cstring>
 #include <queue>
 #include <stdint.h>

--- a/sim/midas/src/main/cc/emul/mmio.h
+++ b/sim/midas/src/main/cc/emul/mmio.h
@@ -3,10 +3,12 @@
 #ifndef __MMIO_H
 #define __MMIO_H
 
+#include "core/config.h"
+
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <queue>
-#include <stddef.h>
-#include <stdint.h>
 #include <vector>
 
 struct mmio_req_addr_t {

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -95,15 +95,8 @@ void fasedtests_top_t::simulation_init() {
   }
 
   // Test harness.
-  AddressMap fased_addr_map =
-      AddressMap(FASEDMEMORYTIMINGMODEL_0_R_num_registers,
-                 (const unsigned int *)FASEDMEMORYTIMINGMODEL_0_R_addrs,
-                 (const char *const *)FASEDMEMORYTIMINGMODEL_0_R_names,
-                 FASEDMEMORYTIMINGMODEL_0_W_num_registers,
-                 (const unsigned int *)FASEDMEMORYTIMINGMODEL_0_W_addrs,
-                 (const char *const *)FASEDMEMORYTIMINGMODEL_0_W_names);
-  add_bridge_driver(
-      new test_harness_bridge_t(*simif, *peek_poke, fased_addr_map, args));
+  add_bridge_driver(new test_harness_bridge_t(
+      *simif, *peek_poke, fpga_models[0]->get_addr_map(), args));
 
   for (auto &e : fpga_models) {
     e->init();

--- a/sim/src/main/cc/midasexamples/AssertTest.h
+++ b/sim/src/main/cc/midasexamples/AssertTest.h
@@ -12,10 +12,13 @@ public:
 
   virtual ~AssertTest() {}
 
-  const std::vector<synthesized_assertions_t *> assert_endpoints =
-      get_bridges<synthesized_assertions_t>();
+  std::vector<std::unique_ptr<synthesized_assertions_t>> assert_endpoints;
+  void add_bridge_driver(synthesized_assertions_t *bridge) override {
+    assert_endpoints.emplace_back(bridge);
+  }
 
   void simulation_init() override {
+    TestHarness::simulation_init();
     for (auto &assert_endpoint : assert_endpoints) {
       assert_endpoint->init();
     }

--- a/sim/src/main/cc/midasexamples/PassthroughModelTest.h
+++ b/sim/src/main/cc/midasexamples/PassthroughModelTest.h
@@ -15,10 +15,11 @@ public:
 
   int latency = 1;
   int length = 1 << 16;
-  void run_test() {
+
+  void run_test() override {
     target_reset();
     step(length);
   }
 };
 
-#endif MIDASEXAMPLES_PASSTHROUGHMODELS_H
+#endif // MIDASEXAMPLES_PASSTHROUGHMODELS_H

--- a/sim/src/main/cc/midasexamples/TestAssertModule.cc
+++ b/sim/src/main/cc/midasexamples/TestAssertModule.cc
@@ -1,22 +1,14 @@
 // See LICENSE for license details.
 
+#include "AssertTest.h"
 #include "TestHarness.h"
 
-#include "bridges/synthesized_assertions.h"
-
-class TestAssertModule final : public TestHarness {
+class TestAssertModule final : public AssertTest {
 public:
-  using TestHarness::TestHarness;
-
-  std::unique_ptr<synthesized_assertions_t> assert_endpoint;
-  void add_bridge_driver(synthesized_assertions_t *bridge) override {
-    assert(!assert_endpoint && "multiple bridges registered");
-    assert_endpoint.reset(bridge);
-  }
+  using AssertTest::AssertTest;
 
   void run_test() override {
     int assertions_thrown = 0;
-    assert_endpoint->init();
     poke("reset", 1);
     poke("io_a", 0);
     poke("io_b", 0);
@@ -48,10 +40,11 @@ public:
                                      std::to_string(test_case));
         break;
       }
+      auto &assert_endpoint = *assert_endpoints[0];
       while (!simif->done()) {
-        assert_endpoint->tick();
-        if (assert_endpoint->terminate()) {
-          assert_endpoint->resume();
+        assert_endpoint.tick();
+        if (assert_endpoint.terminate()) {
+          assert_endpoint.resume();
           assertions_thrown++;
         }
       }

--- a/sim/src/main/cc/midasexamples/TestPrintfCycleBounds.cc
+++ b/sim/src/main/cc/midasexamples/TestPrintfCycleBounds.cc
@@ -12,12 +12,12 @@ public:
     }
     poke("reset", 1);
     poke("io_a", 0);
-    poke(io_b, 0);
+    poke("io_b", 0);
     step(1);
     poke("reset", 0);
     step(1);
     poke("io_a", 1);
-    poke(io_b, 1);
+    poke("io_b", 1);
     run_and_collect_prints(16000);
   };
 };

--- a/sim/src/main/cc/midasexamples/TestResetPulseBridgeTest.cc
+++ b/sim/src/main/cc/midasexamples/TestResetPulseBridgeTest.cc
@@ -16,9 +16,9 @@ public:
 
   // Since we rely on an assertion firing to catch a failure, just run a
   // similation that is at least the length of the expected pulse.
-  void run_test() {
+  void run_test() override {
     rb->init();
-    step(2 * RESETPULSEBRIDGEMODULE_0_max_pulse_length);
+    step(2 * rb->get_max_pulse_length());
   }
 };
 

--- a/sim/src/main/cc/midasexamples/TestTerminationModule.cc
+++ b/sim/src/main/cc/midasexamples/TestTerminationModule.cc
@@ -30,9 +30,9 @@ public:
     int termination_code = random() % 8;
     lv_validinCycle = lv_validinCycle + validinCycle;
     lv_msginCycle = lv_msginCycle + msginCycle;
-    poke(io_validInCycle, lv_validinCycle);
-    poke(io_msgInCycle, lv_msginCycle);
-    poke(io_doneErrCode, termination_code);
+    poke("io_validInCycle", lv_validinCycle);
+    poke("io_msgInCycle", lv_msginCycle);
+    poke("io_doneErrCode", termination_code);
     step(reset_length);
     poke("reset", 0);
     if (termination_code % 2 != 0) {


### PR DESCRIPTION
This PR adds a new make target, `clang-tidy` to run clang-tidy on all C++ sources. Only a dummy check is enabled, as this patch applies the minimal number of fixes to compile headers and sources with clang without the header. In a subsequent PR, more checks will be enabled and the files will be formatted.

`clang-tidy` can be executed using `make -C sim clang-tidy`. It will automatically apply fixes to known issues.

The config included in this PR is derived from LLVM, but most checks are now commented out.

Bridges with heavy dependencies (dromajo, tracerv, serial) are now skipped in order to avoid pulling them into this quick check.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
