### PR TITLE
Fix loadmem bug in firesim_tsi.cc

### DIFF
--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
@@ -34,6 +34,10 @@ protected:
   void load_mem_write(addr_t addr, size_t nbytes, const void *src) override;
   void load_mem_read(addr_t addr, size_t nbytes, void *dst) override;
 
+  // This must be exactly the same as hKey.dataBits
+  // TODO: Avoid hardcoding this value here
+  size_t chunk_align() override { return 8; }
+
   std::deque<firesim_loadmem_t> loadmem_write_reqs;
   std::deque<firesim_loadmem_t> loadmem_read_reqs;
   std::deque<char> loadmem_write_data;

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
@@ -34,7 +34,8 @@ protected:
   void load_mem_write(addr_t addr, size_t nbytes, const void *src) override;
   void load_mem_read(addr_t addr, size_t nbytes, void *dst) override;
 
-  // This must be exactly the same as hKey.dataBits
+  // This must be exactly the same as hKey.dataBits in the LoadMem widget
+  // See discussion here: https://github.com/firesim/firesim/pull/1401
   // TODO: Avoid hardcoding this value here
   size_t chunk_align() override { return 8; }
 


### PR DESCRIPTION
The default chunk_align (32b) was less than the default host-DRAM interface (64b), which caused drops on some loadmem_writes. Fix this for now by setting chunk_align to 8.

This error would manifest only when the address written had `(addr + len) % 8 == {5|6|7}`. 
For example, writing 0x6 bytes to 0x100 would result in a sequence of writes:
1. write 2 bytes to 0x104
2. write 4 bytes to 0x100

The second write would generate a 8-byte write to 0x100, clobbering the first write.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->
None

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
