### PR TITLE
Allowed the driver to control clock token delivery

### DIFF
--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -11,23 +11,19 @@
 
 # DOCREF START: Example HWDB Entry
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0d460a200ae495922
+    agfi: agfi-05e902fe7b6acca58
     deploy_triplet_override: null
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0b155e871724da4ec
+    agfi: agfi-05885e75f423cf782
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-05f131d5c193fb6eb
+    agfi: agfi-045ff5af3042a23e1
     deploy_triplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0907c26232a024151
-    deploy_triplet_override: null
-    custom_runtime_config: null
-firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-07711bd02627fe114
+    agfi: agfi-080d4ab99ab866c46
     deploy_triplet_override: null
     custom_runtime_config: null

--- a/sim/firesim-lib/src/main/scala/bridges/SerialBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/SerialBridge.scala
@@ -100,7 +100,7 @@ class SerialBridgeModule(serialBridgeParams: SerialBridgeParams)(implicit p: Par
           "serial",
           Seq(
               CppBoolean(serialBridgeParams.memoryRegionNameOpt.isDefined),
-              UInt32(offsetConst)
+              Int64(offsetConst)
           ),
           hasLoadMem = true
       )

--- a/sim/midas/src/main/cc/bridges/clock.cc
+++ b/sim/midas/src/main/cc/bridges/clock.cc
@@ -26,3 +26,11 @@ uint64_t clockmodule_t::hcycle() {
   uint32_t cycle_h = simif.read(mmio_addrs.hCycle_1);
   return (((uint64_t)cycle_h) << 32) | cycle_l;
 }
+
+void clockmodule_t::credit(uint32_t credits) {
+  simif.write(mmio_addrs.CREDIT, credits);
+}
+
+bool clockmodule_t::has_credits() {
+  return simif.read(mmio_addrs.HAS_CREDIT) != 0;
+}

--- a/sim/midas/src/main/cc/bridges/clock.h
+++ b/sim/midas/src/main/cc/bridges/clock.h
@@ -12,6 +12,8 @@
 class simif_t;
 
 struct CLOCKBRIDGEMODULE_struct {
+  uint64_t HAS_CREDIT;
+  uint64_t CREDIT;
   uint64_t hCycle_0;
   uint64_t hCycle_1;
   uint64_t hCycle_latch;
@@ -42,6 +44,22 @@ public:
    * Returns the current host cycle as measured by a hardware counter
    */
   uint64_t hcycle();
+
+  /**
+   * Credit the bridge to deliver <credit> more base clock cycles.
+   *
+   * Note, if a total of N credits have been granted, no intermediate positive
+   * edges in other, out-of-phase clock domains will be simulated.  In other
+   * words, the simulation will halt after the Nth positive edge in the base
+   * clock domain + a delta in which combinational logic driven by that
+   * launching edge has been resolved.
+   */
+  void credit(uint32_t credits);
+
+  /**
+   * Check whether there are any credits remaining.
+   */
+  bool has_credits();
 
 private:
   const CLOCKBRIDGEMODULE_struct mmio_addrs;

--- a/sim/src/main/cc/bridges/BridgeHarness.cc
+++ b/sim/src/main/cc/bridges/BridgeHarness.cc
@@ -1,11 +1,13 @@
 // See LICENSE for license details.
 
 #include "BridgeHarness.h"
-
 #include "bridges/blockdev.h"
+#include "bridges/clock.h"
 #include "bridges/tracerv.h"
 #include "bridges/uart.h"
 #include "core/bridge_driver.h"
+
+#include <limits>
 
 BridgeHarness::BridgeHarness(widget_registry_t &registry,
                              const std::vector<std::string> &args)
@@ -15,6 +17,10 @@ BridgeHarness::BridgeHarness(widget_registry_t &registry,
 BridgeHarness::~BridgeHarness() = default;
 
 int BridgeHarness::simulation_run() {
+  // Let the design run.
+  registry.get_widget<clockmodule_t>().credit(
+      std::numeric_limits<uint32_t>::max());
+
   // Reset the DUT.
   peek_poke.poke("reset", 1, /*blocking=*/true);
   peek_poke.step(1, /*blocking=*/true);

--- a/sim/src/main/cc/bridges/BridgeHarness.h
+++ b/sim/src/main/cc/bridges/BridgeHarness.h
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 #ifndef MIDAEXAMPLES_BRIDGEHARNESS_H
 #define MIDAEXAMPLES_BRIDGEHARNESS_H
 

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -67,6 +67,10 @@ fasedtests_top_t::fasedtests_top_t(simif_t &simif,
 }
 
 int fasedtests_top_t::simulation_run() {
+  auto &peek_poke = registry.get_widget<peek_poke_t>();
+  registry.get_widget<clockmodule_t>().credit(
+      std::numeric_limits<uint32_t>::max());
+
   // Run the simulation until the target reports it is finished by setting
   // the done output flag or the desired number of cycles completes.
   while (!done && !finished_scheduled_tasks()) {

--- a/sim/src/main/cc/midasexamples/TestHarness.cc
+++ b/sim/src/main/cc/midasexamples/TestHarness.cc
@@ -1,7 +1,11 @@
-#include <cinttypes>
-#include <iostream>
+// See LICENSE for license details.
 
 #include "TestHarness.h"
+#include "bridges/clock.h"
+
+#include <cinttypes>
+#include <iostream>
+#include <limits>
 
 static const char *blocking_fail =
     "The test environment has starved the simulator, preventing forward "
@@ -22,6 +26,15 @@ TestHarness::TestHarness(widget_registry_t &registry,
 }
 
 TestHarness::~TestHarness() = default;
+
+int TestHarness::simulation_run() {
+  // Let the design run.
+  registry.get_widget<clockmodule_t>().credit(
+      std::numeric_limits<uint32_t>::max());
+
+  run_test();
+  return teardown();
+}
 
 void TestHarness::step(uint32_t n, bool blocking) {
   if (n == 0)

--- a/sim/src/main/cc/midasexamples/TestHarness.h
+++ b/sim/src/main/cc/midasexamples/TestHarness.h
@@ -1,11 +1,13 @@
+// See LICENSE for license details.
+
 #ifndef MIDAEXAMPLES_TESTHARNESS_H
 #define MIDAEXAMPLES_TESTHARNESS_H
-
-#include <random>
 
 #include "bridges/peek_poke.h"
 #include "core/simif.h"
 #include "core/simulation.h"
+
+#include <random>
 
 /**
  * Base class for simple unit tests.
@@ -27,10 +29,7 @@ public:
    */
   virtual void run_test() = 0;
 
-  int simulation_run() override {
-    run_test();
-    return teardown();
-  }
+  int simulation_run() override;
 
   void step(uint32_t n, bool blocking = true);
   void target_reset(int pulse_length = 5);


### PR DESCRIPTION
The `ClockBridge` now exposes two registers, `CREDIT` and `CREDIT_COUNT` which can be used to set and query the number of clock tokens which the bridge is allowed to deliver to the target. Tests which rely on `PeekPokeBridge` credit the system with a maximal number of tokens. `firesim_top` also infinitely credits the system alongside a dummy `PeekPokeBridge`, but in future PRs the sole control mechanism should be that through the clock bridge.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

AGFI must be regenerated since the register mapping of the clock bridge changed.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
