### PR TITLE
Fix Vitis driver compilation + Fix CY-as-top driver builds

### DIFF
--- a/sim/make/goldengate.mk
+++ b/sim/make/goldengate.mk
@@ -50,7 +50,7 @@ $(simulator_verilog).intermediate: $(FIRRTL_FILE) $(ANNO_FILE) $(FIRESIM_MAIN_CP
 .PHONY: conf
 conf: $(fame_annos)
 	mkdir -p $(GENERATED_DIR)
-	cd $(base_dir) && $(SBT) "project $(firesim_sbt_project)" "runMain midas.stage.RuntimeConfigGeneratorMain \
+	cd $(base_dir) && $(SBT) "project $(FIRESIM_SBT_PROJECT)" "runMain midas.stage.RuntimeConfigGeneratorMain \
 		-td $(GENERATED_DIR) \
 		-faf $(fame_annos) \
 		-ggcp $(PLATFORM_CONFIG_PACKAGE) \

--- a/sim/make/scala-build.mk
+++ b/sim/make/scala-build.mk
@@ -33,14 +33,14 @@ SBT_COMMAND ?= shell
 SBT_NON_THIN ?= $(subst $(SBT_CLIENT_FLAG),,$(SBT))
 .PHONY: sbt
 sbt:
-	cd $(base_dir) && $(SBT_NON_THIN) ";project $(firesim_sbt_project); $(SBT_COMMAND)"
+	cd $(base_dir) && $(SBT_NON_THIN) ";project $(FIRESIM_SBT_PROJECT); $(SBT_COMMAND)"
 
 ################################################################################
 # Target Configuration
 ################################################################################
 
 # Target project containing the generator of the design.
-TARGET_SBT_PROJECT ?= $(firesim_sbt_project)
+TARGET_SBT_PROJECT ?= $(FIRESIM_SBT_PROJECT)
 
 # If the target project is not the implicit FireSim one, this definition must
 # enumerate all directories containing the sources of the generator.
@@ -85,24 +85,24 @@ firesim_test_srcs = $(foreach dir, $(firesim_source_dirs), \
 # FireSim project. This ensures that SBT is invoked once in parallel builds.
 $(BUILD_DIR)/firesim.build: $(SCALA_BUILDTOOL_DEPS) $(firesim_main_srcs) $(firesim_test_srcs)
 	@mkdir -p $(@D)
-	$(SBT_NON_THIN) "set showSuccess := false; project $(1); compile; package"
+	$(SBT_NON_THIN) "set showSuccess := false; project $(FIRESIM_SBT_PROJECT); compile; package"
 	@touch $@
 
 
 FIRESIM_MAIN_CP := $(BUILD_DIR)/firesim-main.classpath
 $(FIRESIM_MAIN_CP): $(BUILD_DIR)/firesim.build
 	@mkdir -p $(@D)
-	cd $(base_dir) && $(call build_classpath,$(firesim_sbt_project),runtime)
+	cd $(base_dir) && $(call build_classpath,$(FIRESIM_SBT_PROJECT),runtime)
 
 
 FIRESIM_TEST_CP := $(BUILD_DIR)/firesim-test.classpath
 $(FIRESIM_TEST_CP): $(BUILD_DIR)/firesim.build
 	@mkdir -p $(@D)
-	cd $(base_dir) && $(call build_classpath,$(firesim_sbt_project),test)
+	cd $(base_dir) && $(call build_classpath,$(FIRESIM_SBT_PROJECT),test)
 
 # If the target project is the main FireSim project, provide the test classpath
 # as it defines the target configs and parameters for designs to elaborate.
-ifneq ($(firesim_sbt_project),$(TARGET_SBT_PROJECT))
+ifneq ($(FIRESIM_SBT_PROJECT),$(TARGET_SBT_PROJECT))
 
 target_srcs = $(foreach dir,$(TARGET_SOURCE_DIRS), \
 	$(call find_sources_in_dir, $(dir), 'src/main/scala'))
@@ -134,7 +134,7 @@ target-classpath: $(TARGET_CP)
 
 .PHONY: test
 test: $(FIRESIM_MAIN_CP) $(FIRESIM_TEST_CP) $(TARGET_CP)
-	cd $(base_dir) && $(SBT_NON_THIN) ";project $(firesim_sbt_project); test"
+	cd $(base_dir) && $(SBT_NON_THIN) ";project $(FIRESIM_SBT_PROJECT); test"
 
 .PHONY: testOnly
 testOnly: $(FIRESIM_MAIN_CP) $(FIRESIM_TEST_CP) $(TARGET_CP)

--- a/sim/midas/src/main/cc/simif_f1.cc
+++ b/sim/midas/src/main/cc/simif_f1.cc
@@ -26,10 +26,13 @@ public:
   void fpga_shutdown();
   void fpga_setup(int slot_id);
 
+  CPUManagedStreamIO &get_cpu_managed_stream_io() override { return *this; }
+
 private:
   uint32_t mmio_read(size_t addr) override { return read(addr); }
-  size_t cpu_managed_axi4_write(size_t addr, const char *data, size_t size);
-  size_t cpu_managed_axi4_read(size_t addr, char *data, size_t size);
+  size_t
+  cpu_managed_axi4_write(size_t addr, const char *data, size_t size) override;
+  size_t cpu_managed_axi4_read(size_t addr, char *data, size_t size) override;
   uint64_t get_beat_bytes() const override {
     return config.cpu_managed->beat_bytes();
   }

--- a/sim/midas/src/main/cc/simif_f1_xsim.cc
+++ b/sim/midas/src/main/cc/simif_f1_xsim.cc
@@ -24,10 +24,13 @@ public:
   void fpga_shutdown();
   void fpga_setup(int slot_id);
 
+  CPUManagedStreamIO &get_cpu_managed_stream_io() override { return *this; }
+
 private:
   uint32_t mmio_read(size_t addr) override { return read(addr); }
-  size_t cpu_managed_axi4_write(size_t addr, const char *data, size_t size);
-  size_t cpu_managed_axi4_read(size_t addr, char *data, size_t size);
+  size_t
+  cpu_managed_axi4_write(size_t addr, const char *data, size_t size) override;
+  size_t cpu_managed_axi4_read(size_t addr, char *data, size_t size) override;
   uint64_t get_beat_bytes() const override {
     return config.cpu_managed->beat_bytes();
   }

--- a/sim/midas/src/main/cc/simif_vitis.cc
+++ b/sim/midas/src/main/cc/simif_vitis.cc
@@ -124,13 +124,6 @@ uint32_t simif_vitis_t::read(size_t addr) {
   return value & 0xFFFFFFFF;
 }
 
-AXIStreamIO &simif_vitis_t::get_cpu_managed_stream_io() override {
-  std::cerr << "FPGA-to-CPU Bridge streams are not yet supported on "
-               "vitis-based FPGA deployments."
-            << std::endl;
-  exit(1);
-}
-
 uint32_t simif_vitis_t::is_write_ready() {
   uint64_t addr = 0x4;
   uint32_t value;

--- a/sim/midas/src/main/cc/simif_vitis.cc
+++ b/sim/midas/src/main/cc/simif_vitis.cc
@@ -26,6 +26,8 @@ public:
 
   uint32_t is_write_ready();
 
+  FPGAManagedStreamIO &get_fpga_managed_stream_io() override { return *this; }
+
 private:
   uint32_t mmio_read(size_t addr) override { return read(addr); }
 

--- a/sim/src/main/makefrag/firesim/build.mk
+++ b/sim/src/main/makefrag/firesim/build.mk
@@ -2,7 +2,7 @@
 
 $(FIRRTL_FILE) $(ANNO_FILE): $(TARGET_CP)
 	@mkdir -p $(@D)
-	java -cp $$(cat $(TARGET_CP)) chipyard.Generator \
+	cd $(base_dir) && java -cp $$(cat $(TARGET_CP)) chipyard.Generator \
 		--target-dir $(GENERATED_DIR) \
 		--name $(long_name) \
 		--top-module $(DESIGN_PACKAGE).$(DESIGN) \

--- a/sim/src/main/makefrag/firesim/config.mk
+++ b/sim/src/main/makefrag/firesim/config.mk
@@ -19,11 +19,7 @@ PLATFORM_CONFIG ?= BaseF1Config
 TARGET_SRC_DIRS ?= $(chipyard_dir)/generators/
 
 # Project for the target.
-ifdef FIRESIM_STANDALONE
-	TARGET_SBT_PROJECT := {file:${chipyard_dir}}firechip
-else
-	TARGET_SBT_PROJECT := firechip
-endif
+TARGET_SBT_PROJECT := {file:${chipyard_dir}}firechip
 
 # Directory where sources are located.
 TARGET_SOURCE_DIRS = $(chipyard_dir)/generators


### PR DESCRIPTION
Fixes #1390 issues listed in #1403 

- Capitalizes all `firesim_sbt_project` to be consistent
- `firesim.build` recipe now directly uses the `FIRESIM_SBT_PROJECT` instead of `$(1)`
- `AXIStreamIO` in `simif_vitis.cc` was undefined. I think its just safe to remove this overridden function and default to the exit behavior given in `simif.cc`
- Adds a `cd $(base_dir)` when calling the Chipyard generator. Needed for https://github.com/ucb-bar/chipyard/blob/95f30d0411645b12dfc5c0b14f9af0a5a678a991/generators/firechip/src/main/scala/TargetConfigs.scala#L29-L30 to properly find the right BootRom path (if this isn't done it will try to read the BootRom from the `target-rtl` location which is an uninitialized submodule instead of the `../../../` path).
- Modifies the `TARGET_SBT_PROJECT` since this SBT invocation is done in the `firesim/sim` directory instead of `chipyard` main directory.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
