### PR TITLE
Force using 2022.1 Vitis

### DIFF
--- a/docs/Advanced-Usage/Vitis.rst
+++ b/docs/Advanced-Usage/Vitis.rst
@@ -10,10 +10,9 @@ Setup
 
 First, install and setup Vitis/Vivado/XRT to use the U250.
 
-* Install Vitis/Vivado 2021 or higher (refer to the Xilinx website for the installers)
+* Install Vitis/Vivado 2022.1 (refer to the Xilinx website for the installers)
 * Install XRT depending on the version of Vitis/Vivado (**IMPORTANT**)
-    * Vitis/Vivado 2021.x: build and install XRT manually based off the following commit: https://github.com/Xilinx/XRT/commit/63269b8d4aa04099459c68b283f8512748fb39d6
-    * Vitis/Vivado 2022.x: install XRT normally (refer to the Xilinx website for the installer)
+    * Vitis/Vivado 2022.1: install XRT normally (refer to the Xilinx website for the installer)
 * Install the U250 board package corresponding to the Vitis/Vivado/XRT version (refer to the Xilinx website for the installers)
 
 Verify that the U250 FPGA can be used for emulations.


### PR DESCRIPTION
To make it easier for users, just enforce that 2022.1 is used (since that is tested and works).

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
