### PR TITLE
Fix Vitis driver CI check

### DIFF
--- a/.github/scripts/build-vitis-driver.py
+++ b/.github/scripts/build-vitis-driver.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from fabric.api import prefix, run, cd, execute # type: ignore
+from fabric.api import prefix, run, execute # type: ignore
 
 from ci_variables import ci_env
 
@@ -13,7 +13,7 @@ def build_vitis_driver():
 
     with prefix(f"cd {ci_env['GITHUB_WORKSPACE']}"):
         with prefix('source sourceme-f1-manager.sh --skip-ssh-setup'):
-            with cd("sim"):
+            with prefix("cd ./sim"):
                 run("make vitis")
 
 if __name__ == "__main__":

--- a/.github/scripts/build-vitis-driver.py
+++ b/.github/scripts/build-vitis-driver.py
@@ -14,7 +14,7 @@ def build_vitis_driver():
     with prefix(f"cd {ci_env['GITHUB_WORKSPACE']}"):
         with prefix('source sourceme-f1-manager.sh --skip-ssh-setup'):
             with prefix("cd ./sim"):
-                run("make vitis")
+                run("make PLATFORM=vitis vitis")
 
 if __name__ == "__main__":
     execute(build_vitis_driver, hosts=["localhost"])


### PR DESCRIPTION
#1414 was merged a bit too early with auto-merge. The bug was that using the `cd()` fabric function instead of `prefix()` results in the `cd()` function being called before the `prefix()` function thus causing the `cd` to fail. This changes it to just use `prefix`'es instead. Additionally, you need to change the `PLATFORM` make flag for there to be a `vitis` target or else it will error.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
