### PR TITLE
Passed memory region offsets to genHeader

### DIFF
--- a/sim/firesim-lib/src/main/scala/bridges/BlockDevBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/BlockDevBridge.scala
@@ -251,8 +251,8 @@ class BlockDevBridgeModule(blockDevExternal: BlockDeviceConfig, hostP: Parameter
 
     genCRFile()
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
-      super.genHeader(base, sb)
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
+      super.genHeader(base, memoryRegions, sb)
       sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_latency_bits", UInt32(latencyBits)))
       sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_num_trackers", UInt32(nTrackers)))
     }

--- a/sim/firesim-lib/src/main/scala/bridges/DromajoBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/DromajoBridge.scala
@@ -144,8 +144,8 @@ class DromajoBridgeModule(key: DromajoKey)(implicit p: Parameters) extends Bridg
     genCRFile()
 
     // modify the output header file
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
-      super.genHeader(base, sb)
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
+      super.genHeader(base, memoryRegions, sb)
 
       sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_iaddr_width", UInt32(iaddrWidth)))
       sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_insn_width", UInt32(insnWidth)))

--- a/sim/firesim-lib/src/main/scala/bridges/SerialBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/SerialBridge.scala
@@ -88,14 +88,14 @@ class SerialBridgeModule(serialBridgeParams: SerialBridgeParams)(implicit p: Par
 
     genCRFile()
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       val memoryRegionNameOpt = serialBridgeParams.memoryRegionNameOpt
-      val offsetConstName = memoryRegionNameOpt.map(GetMemoryRegionOffsetConstName(_)).getOrElse("0")
+      val offsetConst = memoryRegionNameOpt.map(memoryRegions(_)).getOrElse(BigInt(0))
       sb.append(genMacro(s"${headerWidgetName}_has_memory", memoryRegionNameOpt.isDefined.toString))
-      sb.append(genMacro(s"${headerWidgetName}_memory_offset", offsetConstName))
+      sb.append(genMacro(s"${headerWidgetName}_memory_offset", UInt64(offsetConst)))
     }
   }
 }

--- a/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
@@ -211,10 +211,10 @@ class TracerVBridgeModule(key: TracerVKey)(implicit p: Parameters)
     }
 
     genCRFile()
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genConstStatic(s"${headerWidgetName}_max_core_ipc", UInt32(traces.size)))
       emitClockDomainInfo(headerWidgetName, sb)
     }

--- a/sim/midas/src/main/scala/midas/core/CPUManagedStreamEngine.scala
+++ b/sim/midas/src/main/scala/midas/core/CPUManagedStreamEngine.scala
@@ -200,9 +200,9 @@ class CPUManagedStreamEngine(p: Parameters, val params: StreamEngineParameters) 
 
     genCRFile()
 
-    override def genHeader(base: BigInt, sb: StringBuilder) {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder) {
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
 
       def serializeStreamParameters(prefix: String, params: Seq[StreamDriverParameters]): Unit = {
         val numStreams = params.size

--- a/sim/midas/src/main/scala/midas/core/FPGAManagedStreamEngine.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGAManagedStreamEngine.scala
@@ -247,9 +247,9 @@ class FPGAManagedStreamEngine(p: Parameters, val params: StreamEngineParameters)
 
     genCRFile()
 
-    override def genHeader(base: BigInt, sb: StringBuilder) {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder) {
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
 
       def serializeStreamParameters(prefix: String, params: Seq[ToCPUStreamDriverParameters]): Unit = {
         val numStreams = params.size

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -554,12 +554,12 @@ class FASEDMemoryTimingModel(completeConfig: CompleteConfig, hostParams: Paramet
 
     genCRFile()
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       def genCPPmap(mapName: String, map: Map[String, BigInt]): String = {
         val prefix = s"const std::map<std::string, int> $mapName = {\n"
         map.foldLeft(prefix)((str, kvp) => str + s""" {\"${kvp._1}\", ${kvp._2}},\n""") + "};\n"
       }
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_target_addr_bits", UInt32(p(NastiKey).addrBits)))
     }
 

--- a/sim/midas/src/main/scala/midas/widgets/AssertBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AssertBridge.scala
@@ -64,10 +64,10 @@ class AssertBridgeModule(params: AssertBridgeParameters)(implicit p: Parameters)
     attach(enable, "enable")
     genCRFile()
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genConstStatic(s"${headerWidgetName}_assert_count", UInt32(assertMessages.size)))
       sb.append(genArray(s"${headerWidgetName}_assert_messages", assertMessages.map(CStrLit)))
     }

--- a/sim/midas/src/main/scala/midas/widgets/AutoCounterBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/AutoCounterBridge.scala
@@ -160,7 +160,7 @@ class AutoCounterBridgeModule(key: AutoCounterParameters)(implicit p: Parameters
     attach(btht_queue.io.deq.valid, "countersready", ReadOnly)
     Pulsify(genWORegInit(btht_queue.io.deq.ready, "readdone", false.B), 1)
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       headerComment(sb)
       // Exclude counter addresses as their names can vary across AutoCounter instances, but 
       // we only generate a single struct typedef

--- a/sim/midas/src/main/scala/midas/widgets/LoadMem.scala
+++ b/sim/midas/src/main/scala/midas/widgets/LoadMem.scala
@@ -179,8 +179,8 @@ class LoadMemWidget(val totalDRAMAllocated: BigInt)(implicit p: Parameters) exte
   def memDataChunk: Long =
     ((hKey.dataBits - 1) / p(CtrlNastiKey).dataBits) + 1
 
-  override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
-    super.genHeader(base, sb)
+  override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
+    super.genHeader(base, memoryRegions, sb)
     import CppGenerationUtils._
     sb.append(genConstStatic(s"${getWName.toUpperCase}_mem_data_chunk", UInt32(memDataChunk)))
   }

--- a/sim/midas/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -149,14 +149,14 @@ class PeekPokeBridgeModule(key: PeekPokeKey)(implicit p: Parameters) extends Bri
       poked := addrs.map(i => crFile.io.mcr.activeWriteToAddress(i)).reduce(_ || _)
     })
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
 
       val name = getWName.toUpperCase
       def genOffsets(signals: Seq[String]): Unit = (signals.zipWithIndex) foreach {
         case (name, idx) => sb.append(genConstStatic(name, UInt32(idx)))}
 
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genComment("Pokeable target inputs"))
       sb.append(genMacro("POKE_SIZE", UInt64(hPort.ins.size)))
       genOffsets(hPort.ins.unzip._1)

--- a/sim/midas/src/main/scala/midas/widgets/PlusArgsBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PlusArgsBridge.scala
@@ -183,10 +183,10 @@ class PlusArgsBridgeModule(params: PlusArgsBridgeParams)(implicit p: Parameters)
       assert(plusArgValueNext === plusArgValue)
     }
 
-    override def genHeader(base: BigInt, sb: StringBuilder) {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder) {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genStatic(s"${headerWidgetName}_name", CStrLit(params.name)))
       sb.append(genStatic(s"${headerWidgetName}_default", CStrLit(s"${params.default}")))
       sb.append(genStatic(s"${headerWidgetName}_docstring", CStrLit(params.docstring)))

--- a/sim/midas/src/main/scala/midas/widgets/PrintBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/PrintBridge.scala
@@ -185,10 +185,10 @@ class PrintBridgeModule(key: PrintBridgeParameters)(implicit p: Parameters)
     val argumentOffsets = printPort.printRecords.map(_._2.argumentOffsets().map(UInt32(_)))
     val formatStrings   = printPort.printRecords.map(_._2.formatString).map(CStrLit)
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genConstStatic(s"${headerWidgetName}_print_count", UInt32(printPort.printRecords.size)))
       sb.append(genConstStatic(s"${headerWidgetName}_token_bytes", UInt32(pow2Bits / 8)))
       sb.append(genConstStatic(s"${headerWidgetName}_idle_cycles_mask",

--- a/sim/midas/src/main/scala/midas/widgets/ResetPulseBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/ResetPulseBridge.scala
@@ -74,10 +74,10 @@ class ResetPulseBridgeModule(cfg: ResetPulseBridgeParameters)(implicit p: Parame
       remainingPulseLength := Mux(pulseComplete, 0.U, remainingPulseLength - 1.U)
     }
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genConstStatic(s"${headerWidgetName}_max_pulse_length", UInt32(cfg.maxPulseLength)))
       sb.append(genConstStatic(s"${headerWidgetName}_default_pulse_length", UInt32(cfg.defaultPulseLength)))
     }

--- a/sim/midas/src/main/scala/midas/widgets/TerminationBridge.scala
+++ b/sim/midas/src/main/scala/midas/widgets/TerminationBridge.scala
@@ -145,10 +145,10 @@ class TerminationBridgeModule(params: TerminationBridgeParams)(implicit p: Param
     //MMIO to indicate one of the target defined termination messages
     genROReg(terminationCode.bits, "out_terminationCode")
 
-    override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
       import CppGenerationUtils._
       val headerWidgetName = getWName.toUpperCase
-      super.genHeader(base, sb)
+      super.genHeader(base, memoryRegions, sb)
       sb.append(genConstStatic(s"${headerWidgetName}_message_count", UInt32((params.conditionInfo).size)))
       sb.append(genArray(s"${headerWidgetName}_message_type", (params.conditionInfo).map(x => UInt32(if(x.isErr) 1 else 0))))
       sb.append(genArray(s"${headerWidgetName}_message", (params.conditionInfo).map(x => CStrLit(x.message))))

--- a/sim/midas/src/main/scala/midas/widgets/UsesHostDRAM.scala
+++ b/sim/midas/src/main/scala/midas/widgets/UsesHostDRAM.scala
@@ -2,7 +2,6 @@
 
 package midas.widgets
 
-import midas.widgets.CppGenerationUtils._
 import freechips.rocketchip.amba.axi4.AXI4OutwardNode
 import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
 
@@ -32,10 +31,6 @@ import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
   */
 case class MemorySlaveConstraints(address: Seq[AddressSet], supportsRead: TransferSizes, supportsWrite: TransferSizes)
 
-object GetMemoryRegionOffsetConstName {
-  def apply(memoryRegionName: String) = s"${memoryRegionName}_offset"
-}
-
 /**
   * A common trait for referring collateral in the generated header.
   *
@@ -51,7 +46,6 @@ trait HostDramHeaderConsts {
    *
    */
   def memoryRegionName: String
-  def offsetConstName = GetMemoryRegionOffsetConstName(memoryRegionName)
 }
 
 /**
@@ -69,13 +63,6 @@ trait UsesHostDRAM extends HostDramHeaderConsts {
     * See [[MemorySlaveConstraints]] for more explanation.
     */
   def memorySlaveConstraints: MemorySlaveConstraints
-}
-
-private[midas] case class HostMemoryMapping(memoryRegionName: String, hostOffset: BigInt) extends HostDramHeaderConsts {
-  def serializeToHeader(sb: StringBuilder): Unit = {
-    sb.append(genComment(s"Host FPGA memory mapping for region: ${memoryRegionName}"))
-    sb.append(genConstStatic(offsetConstName, Int64(hostOffset)))
-  }
 }
 
 private[midas] object BytesOfDRAMRequired {

--- a/sim/midas/src/main/scala/midas/widgets/Widget.scala
+++ b/sim/midas/src/main/scala/midas/widgets/Widget.scala
@@ -190,7 +190,14 @@ abstract class WidgetImp(wrapper: Widget) extends LazyModuleImp(wrapper) {
     crFile
   }
 
-  def genHeader(base: BigInt, sb: StringBuilder): Unit = {
+  /** Emits a header snippet for this widget.
+    * @param base
+    *    The base address of the MMIO region allocated to the widget.
+    * @param memoryRegions
+    *    A mapping of names to allocated FPGA-DRAM regions. This is one mechanism
+    *    for establishing side-channels between two otherwise unconnected bridges or widgets.
+    */
+  def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
     wrapper.headerComment(sb)
     crRegistry.genHeader(wrapper.getWName.toUpperCase, base, sb)
     crRegistry.genArrayHeader(wrapper.getWName.toUpperCase, base, sb)
@@ -276,8 +283,8 @@ trait HasWidgets {
     * Iterates through each bridge, generating the header fragment. Must be
     * called after bridge address assignment is complete.
     */
-  def genHeader(sb: StringBuilder): Unit = {
-    widgets foreach ((w: Widget) => w.module.genHeader(addrMap(w.getWName).start, sb))
+  def genWidgetHeaders(sb: StringBuilder, memoryRegions: Map[String, BigInt]): Unit = {
+    widgets foreach ((w: Widget) => w.module.genHeader(addrMap(w.getWName).start, memoryRegions, sb))
   }
 
   def printWidgets: Unit = {


### PR DESCRIPTION
Instead of emitting a constant and referencing it by name in the header for a bridge constructor, the memory mapping is passed alongside the base offset for MMIO for bridge header emission to reference.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
