### PR TITLE
Removed auxiliary functions from simif_t

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/serial.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/serial.cc
@@ -1,10 +1,12 @@
 // See LICENSE for license details
 
 #include "serial.h"
+#include "bridges/loadmem.h"
 #include "core/simif.h"
 #include "fesvr/firesim_tsi.h"
 
 #include <cassert>
+#include <gmp.h>
 
 char serial_t::KIND;
 

--- a/sim/midas/src/main/cc/bridges/clock.cc
+++ b/sim/midas/src/main/cc/bridges/clock.cc
@@ -1,7 +1,6 @@
 // See LICENSE for license details.
 
 #include "clock.h"
-
 #include "core/simif.h"
 
 char clockmodule_t::KIND;

--- a/sim/midas/src/main/cc/bridges/heartbeat.cc
+++ b/sim/midas/src/main/cc/bridges/heartbeat.cc
@@ -1,14 +1,16 @@
 
 #include "heartbeat.h"
+#include "bridges/clock.h"
+#include "core/simif.h"
 
 #include <cinttypes>
 
-#include "core/simif.h"
-
 char heartbeat_t::KIND;
 
-heartbeat_t::heartbeat_t(simif_t &sim, const std::vector<std::string> &args)
-    : bridge_driver_t(sim, &KIND) {
+heartbeat_t::heartbeat_t(simif_t &sim,
+                         clockmodule_t &clock,
+                         const std::vector<std::string> &args)
+    : bridge_driver_t(sim, &KIND), clock(clock) {
   auto interval_arg = std::string("+heartbeat-polling-interval=");
   for (const auto &arg : args) {
     if (arg.find(interval_arg) == 0) {
@@ -29,7 +31,7 @@ heartbeat_t::heartbeat_t(simif_t &sim, const std::vector<std::string> &args)
 void heartbeat_t::tick() {
   if (trip_count == polling_interval) {
     trip_count = 0;
-    uint64_t current_cycle = simif.actual_tcycle();
+    uint64_t current_cycle = clock.tcycle();
     has_timed_out |= current_cycle == last_cycle;
 
     time_t current_time;

--- a/sim/midas/src/main/cc/bridges/heartbeat.h
+++ b/sim/midas/src/main/cc/bridges/heartbeat.h
@@ -1,9 +1,11 @@
 #ifndef __HEARTBEAT_H
 #define __HEARTBEAT_H
 
+#include "core/bridge_driver.h"
+
 #include <fstream>
 
-#include "core/bridge_driver.h"
+class clockmodule_t;
 
 // Periodically checks that the target is advancing by polling an FPGA-hosted
 // cycle count, which it writes out to a file.  The causes of an apparently
@@ -19,7 +21,9 @@ public:
   /// The identifier for the bridge type used for casts.
   static char KIND;
 
-  heartbeat_t(simif_t &sim, const std::vector<std::string> &args);
+  heartbeat_t(simif_t &sim,
+              clockmodule_t &clock,
+              const std::vector<std::string> &args);
 
   void init() override {}
   void tick() override;
@@ -28,6 +32,7 @@ public:
   void finish() override {}
 
 private:
+  clockmodule_t &clock;
   std::ofstream log;
   time_t start_time;
 

--- a/sim/midas/src/main/cc/bridges/master.cc
+++ b/sim/midas/src/main/cc/bridges/master.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "master.h"
 #include "core/simif.h"
 
 char master_t::KIND;

--- a/sim/midas/src/main/cc/core/simif.cc
+++ b/sim/midas/src/main/cc/core/simif.cc
@@ -3,25 +3,10 @@
 #include "simif.h"
 #include "core/config.h"
 #include "core/simulation.h"
-#include "core/stream_engine.h"
 
 #include <iostream>
 
-simif_t::simif_t(const TargetConfig &config,
-                 const std::vector<std::string> &args)
-    : config(config), args(args), registry() {
-  for (auto &arg : args) {
-    if (arg.find("+fastloadmem") == 0) {
-      fastloadmem = true;
-    }
-    if (arg.find("+loadmem=") == 0) {
-      load_mem_path = arg.c_str() + 9;
-    }
-    if (arg.find("+zero-out-dram") == 0) {
-      do_zero_out_dram = true;
-    }
-  }
-}
+simif_t::simif_t(const TargetConfig &config) : config(config) {}
 
 simif_t::~simif_t() = default;
 
@@ -35,31 +20,6 @@ FPGAManagedStreamIO &simif_t::get_fpga_managed_stream_io() {
   abort();
 }
 
-void simif_t::target_init() {
-  auto &master = registry.get_widget<master_t>();
-  auto &loadmem = registry.get_widget<loadmem_t>();
-
-  // Do any post-constructor initialization required before requesting MMIO
-  while (!master.is_init_done())
-    ;
-
-  if (auto *stream = registry.get_stream_engine()) {
-    stream->init();
-  }
-
-  if (do_zero_out_dram) {
-    fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few seconds...\n");
-    loadmem.zero_out_dram();
-  }
-
-  if (!fastloadmem && !load_mem_path.empty()) {
-    loadmem.load_mem_from_file(load_mem_path);
-  }
-}
-
 std::string_view simif_t::get_target_name() const { return config.target_name; }
 
-int simif_t::run(simulation_t &sim) {
-  target_init();
-  return sim.execute_simulation_flow();
-}
+int simif_t::run(simulation_t &sim) { return sim.execute_simulation_flow(); }

--- a/sim/midas/src/main/cc/core/simif.h
+++ b/sim/midas/src/main/cc/core/simif.h
@@ -13,9 +13,6 @@
 
 #include <map>
 
-#include "bridges/clock.h"
-#include "bridges/loadmem.h"
-#include "bridges/master.h"
 #include "core/timing.h"
 #include "core/widget_registry.h"
 
@@ -25,37 +22,23 @@ class CPUManagedStreamIO;
 class FPGAManagedStreamIO;
 class TargetConfig;
 
-/** \class simif_t
+/**
+ * FireSim's main simulation class.
  *
- *  @brief FireSim's main simulation class.
  *
- *  Historically this god class wrapped all of the features presented by FireSim
- *  / MIDAS-derived simulators. Critically, it declares an interface for
- *  interacting with the host-FPGA, which consist of methods for implementing
- *  32b MMIO (read, write), and latency-insensitive bridge streams (push, pull).
- *  Concrete subclasses of simif_t must be written for metasimulation and each
- *  supported host plaform. See simif_f1_t for an example.
- *  simif_t also provides a few core functions that are tied to bridges and
- *  widgets that must be present in all simulators:
- *
- *  - To track simulation time, it provides methods to interact with the
- *    ClockBridge. This bridge is solely responsible for defining a schedule of
- *    clock edges to simulate, and must be instantiated in all targets. See
- *    actual_tcycle() and hcycle().  Utilities to report performance are based
- *    off these measures of time.
- *
- *  - To read and write into FPGA DRAM, the LoadMem widget provides a
- *    low-bandwidth side channel via MMIO. See read_mem, write_mem,
- *    zero_out_dram.
+ * It declares an interface for interacting with the host FPGA or simulator,
+ * which consist of methods for implementing 32b MMIO (read, write), and
+ * latency-insensitive bridge streams (push, pull). Concrete subclasses of
+ * simif_t must be written for metasimulation and each supported host plaform.
+ * See simif_f1_t for an example.
  */
 class simif_t {
 public:
-  simif_t(const TargetConfig &config, const std::vector<std::string> &args);
+  simif_t(const TargetConfig &config);
+
   virtual ~simif_t();
 
 public:
-  /** Bridge / Widget MMIO methods */
-
   /**
    * @brief 32b MMIO write, issued over the simulation control bus (AXI4-lite).
    *
@@ -87,34 +70,10 @@ public:
    */
   virtual FPGAManagedStreamIO &get_fpga_managed_stream_io();
 
-  // End host-platform interface.
-
-  /**
-   * Provides the current target cycle of the fastest clock.
-   *
-   * The target cycle is based on the number of clock tokens enqueued
-   * (will report a larger number).
-   */
-  uint64_t actual_tcycle() {
-    return registry.get_widget<clockmodule_t>().tcycle();
-  }
-
-  /**
-   * Provides the current host cycle.
-   */
-  uint64_t actual_hcycle() {
-    return registry.get_widget<clockmodule_t>().hcycle();
-  }
-
   /**
    * Return the name of the simulated target.
    */
   std::string_view get_target_name() const;
-
-  /**
-   * Return a reference to the registry which owns all widgets.
-   */
-  widget_registry_t &get_registry() { return registry; }
 
   /**
    * Runs the simulation in the context of the driver.
@@ -126,34 +85,9 @@ public:
 
 protected:
   /**
-   * Sets up the target and blocks until it is initialized.
-   */
-  void target_init();
-
-protected:
-  /**
    * Target configuration.
    */
   const TargetConfig &config;
-
-  /**
-   * Saved command-line arguments.
-   */
-  std::vector<std::string> args;
-
-  /**
-   * Helper holding references to all bridges.
-   */
-  widget_registry_t registry;
-
-  /**
-   * Path to load DRAM contents from.
-   */
-  std::string load_mem_path;
-
-  bool fastloadmem = false;
-  // If set, will write all zeros to fpga dram before commencing simulation
-  bool do_zero_out_dram = false;
 };
 
 #endif // __SIMIF_H

--- a/sim/midas/src/main/cc/emul/simif_emul.h
+++ b/sim/midas/src/main/cc/emul/simif_emul.h
@@ -143,6 +143,11 @@ protected:
   uint64_t memsize;
 
   /**
+   * If +fastloadmem and +loadmem are set, memories are loaded from this file.
+   */
+  std::string load_mem_path;
+
+  /**
    * Advances the simulation by a random number of ticks.
    *
    * The number of ticks is bounded by `maximum_host_delay`.

--- a/sim/midas/src/main/cc/simif_f1.cc
+++ b/sim/midas/src/main/cc/simif_f1.cc
@@ -44,7 +44,7 @@ private:
 
 simif_f1_t::simif_f1_t(const TargetConfig &config,
                        const std::vector<std::string> &args)
-    : simif_t(config, args) {
+    : simif_t(config) {
   slot_id = -1;
 
   for (auto &arg : args) {

--- a/sim/midas/src/main/cc/simif_f1_xsim.cc
+++ b/sim/midas/src/main/cc/simif_f1_xsim.cc
@@ -41,7 +41,7 @@ private:
 
 simif_f1_xsim_t::simif_f1_xsim_t(const TargetConfig &config,
                                  const std::vector<std::string> &args)
-    : simif_t(config, args) {
+    : simif_t(config) {
   mkfifo(driver_to_xsim, 0666);
   fprintf(stderr, "opening driver to xsim\n");
   driver_to_xsim_fd = open(driver_to_xsim, O_WRONLY);

--- a/sim/midas/src/main/cc/simif_vitis.cc
+++ b/sim/midas/src/main/cc/simif_vitis.cc
@@ -55,7 +55,7 @@ constexpr uint64_t u250_dram_expected_offset = 0x4000000000L;
 
 simif_vitis_t::simif_vitis_t(const TargetConfig &config,
                              const std::vector<std::string> &args)
-    : simif_t(config, args) {
+    : simif_t(config) {
   slotid = -1;
   binary_file = "";
 

--- a/sim/src/main/cc/bridges/BridgeHarness.cc
+++ b/sim/src/main/cc/bridges/BridgeHarness.cc
@@ -6,14 +6,15 @@
 #include "bridges/uart.h"
 #include "core/bridge_driver.h"
 
-BridgeHarness::BridgeHarness(const std::vector<std::string> &args, simif_t &sim)
-    : simulation_t(sim, args),
-      peek_poke(sim.get_registry().get_widget<peek_poke_t>()) {}
+BridgeHarness::BridgeHarness(widget_registry_t &registry,
+                             const std::vector<std::string> &args)
+    : simulation_t(registry, args),
+      peek_poke(registry.get_widget<peek_poke_t>()) {}
 
 BridgeHarness::~BridgeHarness() = default;
 
 void BridgeHarness::simulation_init() {
-  for (auto &bridge : sim.get_registry().get_all_bridges()) {
+  for (auto &bridge : registry.get_all_bridges()) {
     bridge->init();
   }
 }
@@ -28,7 +29,7 @@ int BridgeHarness::simulation_run() {
   // Tick until all requests are serviced.
   peek_poke.step(get_step_limit(), /*blocking=*/false);
   for (unsigned i = 0; i < get_tick_limit() && !peek_poke.is_done(); ++i) {
-    for (auto &bridge : sim.get_registry().get_all_bridges()) {
+    for (auto &bridge : registry.get_all_bridges()) {
       bridge->tick();
     }
   }
@@ -38,7 +39,7 @@ int BridgeHarness::simulation_run() {
 }
 
 void BridgeHarness::simulation_finish() {
-  for (auto &bridge : sim.get_registry().get_all_bridges()) {
+  for (auto &bridge : registry.get_all_bridges()) {
     bridge->finish();
   }
 }

--- a/sim/src/main/cc/bridges/BridgeHarness.h
+++ b/sim/src/main/cc/bridges/BridgeHarness.h
@@ -17,7 +17,8 @@ class bridge_driver_t;
  */
 class BridgeHarness : public simulation_t {
 public:
-  BridgeHarness(const std::vector<std::string> &args, simif_t &sim);
+  BridgeHarness(widget_registry_t &registry,
+                const std::vector<std::string> &args);
 
   ~BridgeHarness() override;
 
@@ -35,7 +36,9 @@ private:
 
 #define TEST_MAIN(CLASS_NAME)                                                  \
   std::unique_ptr<simulation_t> create_simulation(                             \
-      const std::vector<std::string> &args, simif_t &sim) {                    \
-    return std::make_unique<CLASS_NAME>(args, sim);                            \
+      simif_t &simif,                                                          \
+      widget_registry_t &registry,                                             \
+      const std::vector<std::string> &args) {                                  \
+    return std::make_unique<CLASS_NAME>(registry, args);                       \
   }
 #endif // MIDAEXAMPLES_BRIDGEHARNESS_H

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "bridges/clock.h"
 #include "bridges/fased_memory_timing_model.h"
 #include "bridges/fpga_model.h"
 #include "bridges/peek_poke.h"
@@ -11,7 +12,9 @@
 
 class fasedtests_top_t : public systematic_scheduler_t, public simulation_t {
 public:
-  fasedtests_top_t(const std::vector<std::string> &args, simif_t &sim);
+  fasedtests_top_t(simif_t &simif,
+                   widget_registry_t &registry,
+                   const std::vector<std::string> &args);
   ~fasedtests_top_t() override = default;
 
   void simulation_init() override;
@@ -37,10 +40,12 @@ private:
   int exit_code();
 };
 
-fasedtests_top_t::fasedtests_top_t(const std::vector<std::string> &args,
-                                   simif_t &sim)
-    : simulation_t(sim, args),
-      peek_poke(sim.get_registry().get_widget<peek_poke_t>()) {
+fasedtests_top_t::fasedtests_top_t(simif_t &simif,
+                                   widget_registry_t &registry,
+                                   const std::vector<std::string> &args)
+    : simulation_t(registry, args),
+      peek_poke(registry.get_widget<peek_poke_t>()) {
+
   max_cycles = -1;
   profile_interval = max_cycles;
 
@@ -53,31 +58,32 @@ fasedtests_top_t::fasedtests_top_t(const std::vector<std::string> &args,
     }
   }
 
-  auto *model = sim.get_registry().get_all_models()[0];
-  sim.get_registry().add_widget(
-      new test_harness_bridge_t(sim,
-                                sim.get_registry().get_widget<peek_poke_t>(),
+  auto *model = registry.get_all_models()[0];
+  registry.add_widget(
+      new test_harness_bridge_t(simif,
+                                registry.get_widget<peek_poke_t>(),
+                                registry.get_widget<master_t>(),
                                 model->get_addr_map(),
                                 args));
 }
 
 bool fasedtests_top_t::simulation_complete() {
   bool is_complete = false;
-  for (auto &e : sim.get_registry().get_all_bridges()) {
+  for (auto &e : registry.get_all_bridges()) {
     is_complete |= e->terminate();
   }
   return is_complete;
 }
 
 uint64_t fasedtests_top_t::profile_models() {
-  for (auto &mod : sim.get_registry().get_all_models()) {
+  for (auto &mod : registry.get_all_models()) {
     mod->profile();
   }
   return profile_interval;
 }
 
 int fasedtests_top_t::exit_code() {
-  for (auto &e : sim.get_registry().get_all_bridges()) {
+  for (auto &e : registry.get_all_bridges()) {
     if (e->exit_code())
       return e->exit_code();
   }
@@ -90,10 +96,10 @@ void fasedtests_top_t::simulation_init() {
     register_task([this]() { return this->profile_models(); }, 0);
   }
 
-  for (auto *bridge : sim.get_registry().get_all_bridges()) {
+  for (auto *bridge : registry.get_all_bridges()) {
     bridge->init();
   }
-  for (auto *model : sim.get_registry().get_all_models()) {
+  for (auto *model : registry.get_all_models()) {
     model->init();
   }
 }
@@ -103,7 +109,7 @@ int fasedtests_top_t::simulation_run() {
     run_scheduled_tasks();
     peek_poke.step(get_largest_stepsize(), false);
     while (!peek_poke.is_done() && !simulation_complete()) {
-      for (auto &e : sim.get_registry().get_all_bridges())
+      for (auto &e : registry.get_all_bridges())
         e->tick();
     }
   }
@@ -112,15 +118,17 @@ int fasedtests_top_t::simulation_run() {
 }
 
 void fasedtests_top_t::simulation_finish() {
-  for (auto *bridge : sim.get_registry().get_all_bridges()) {
+  for (auto *bridge : registry.get_all_bridges()) {
     bridge->finish();
   }
-  for (auto *model : sim.get_registry().get_all_models()) {
+  for (auto *model : registry.get_all_models()) {
     model->finish();
   }
 }
 
 std::unique_ptr<simulation_t>
-create_simulation(const std::vector<std::string> &args, simif_t &sim) {
-  return std::make_unique<fasedtests_top_t>(args, sim);
+create_simulation(simif_t &simif,
+                  widget_registry_t &registry,
+                  const std::vector<std::string> &args) {
+  return std::make_unique<fasedtests_top_t>(simif, registry, args);
 }

--- a/sim/src/main/cc/fasedtests/test_harness_bridge.h
+++ b/sim/src/main/cc/fasedtests/test_harness_bridge.h
@@ -5,6 +5,7 @@
 
 #include <unordered_map>
 
+#include "bridges/master.h"
 #include "bridges/peek_poke.h"
 #include "core/address_map.h"
 #include "core/bridge_driver.h"
@@ -14,6 +15,7 @@ private:
   int error = 0;
   bool done = false;
   peek_poke_t &peek_poke;
+  master_t &master;
   const AddressMap addr_map;
   std::unordered_map<std::string, uint32_t> expected_uarchevent_values;
 
@@ -26,6 +28,7 @@ public:
    */
   test_harness_bridge_t(simif_t &simif,
                         peek_poke_t &peek_poke,
+                        master_t &master,
                         const AddressMap &addr_map,
                         const std::vector<std::string> &args);
   ~test_harness_bridge_t() override = default;

--- a/sim/src/main/cc/midasexamples/TestHarness.h
+++ b/sim/src/main/cc/midasexamples/TestHarness.h
@@ -20,7 +20,9 @@
  */
 class TestHarness : public simulation_t {
 public:
-  TestHarness(const std::vector<std::string> &args, simif_t &sim);
+  TestHarness(widget_registry_t &registry,
+              const std::vector<std::string> &args,
+              std::string_view target_name);
 
   ~TestHarness() override;
 
@@ -48,7 +50,7 @@ public:
 
   /**
    * Returns an upper bound for the cycle reached by the target
-   * If using blocking steps, this will be ~equivalent to actual_tcycle()
+   * If using blocking steps, this will be ~equivalent to the clock tcycle()
    */
   uint64_t cycles() { return t; };
 
@@ -63,7 +65,7 @@ public:
    */
   template <typename T>
   std::vector<T *> get_bridges() {
-    return sim.get_registry().get_bridges<T>();
+    return registry.get_bridges<T>();
   }
 
   /**
@@ -71,11 +73,12 @@ public:
    */
   template <typename T>
   T &get_bridge() {
-    return sim.get_registry().get_widget<T>();
+    return registry.get_widget<T>();
   }
 
 protected:
   peek_poke_t &peek_poke;
+  std::string_view target_name;
 
   /// Random number generator for tests, using a fixed default seed.
   uint64_t random_seed = 0;
@@ -90,7 +93,10 @@ protected:
 
 #define TEST_MAIN(CLASS_NAME)                                                  \
   std::unique_ptr<simulation_t> create_simulation(                             \
-      const std::vector<std::string> &args, simif_t &sim) {                    \
-    return std::make_unique<CLASS_NAME>(args, sim);                            \
+      simif_t &simif,                                                          \
+      widget_registry_t &registry,                                             \
+      const std::vector<std::string> &args) {                                  \
+    return std::make_unique<CLASS_NAME>(                                       \
+        registry, args, simif.get_target_name());                              \
   }
 #endif // MIDAEXAMPLES_TESTHARNESS_H

--- a/sim/src/main/cc/midasexamples/TestMultiSRAM.cc
+++ b/sim/src/main/cc/midasexamples/TestMultiSRAM.cc
@@ -2,8 +2,10 @@
 
 class TestMultiSRAM final : public MultiRegfileTest {
 public:
-  TestMultiSRAM(const std::vector<std::string> &args, simif_t &simif)
-      : MultiRegfileTest(args, simif) {
+  TestMultiSRAM(widget_registry_t &registry,
+                const std::vector<std::string> &args,
+                std::string_view target_name)
+      : MultiRegfileTest(registry, args, target_name) {
     write_first = false;
   }
 };

--- a/sim/src/main/cc/midasexamples/TestPlusArgsModule.cc
+++ b/sim/src/main/cc/midasexamples/TestPlusArgsModule.cc
@@ -41,10 +41,14 @@ public:
   /**
    * Constructor.
    *
+   * @param [in] registry Reference to the widget registry holding bridges.
    * @param [in] args The argument list from main
    */
-  TestPlusArgsModule(const std::vector<std::string> &args, simif_t &simif)
-      : TestHarness(args, simif), plusargsinator(get_bridge<plusargs_t>()) {
+  TestPlusArgsModule(widget_registry_t &registry,
+                     const std::vector<std::string> &args,
+                     std::string_view target_name)
+      : TestHarness(registry, args, target_name),
+        plusargsinator(get_bridge<plusargs_t>()) {
     parse_key(args);
   }
 


### PR DESCRIPTION
`simif_t` is now solely an interface to the backend running the simulation (vcs, f1, ...).  Moved logic which depends on bridges to `simulation_t`. Additionally, bridges no longer have access to the registry. Any widgets they depend on must be provided in the constructor.

In the future, the `run` method of `simif_t` should be moved to a separate interface to decouple it from the IO mechanism implementations.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
