### PR TITLE
Update doc of always_expand_run_farm for rename

### DIFF
--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -622,13 +622,13 @@ you should not change it unless you are done with your current Run Farm.
 
 Per AWS restrictions, this tag can be no longer than 255 characters.
 
-``always_expand_runfarm``
+``always_expand_run_farm``
 """""""""""""""""""""""""
-When ``yes`` (the default behavior when not given) the number of instances
+When ``true`` (the default behavior when not given) the number of instances
 of each type (see ``f1.16xlarges`` etc. below)  are launched every time you
 run ``launchrunfarm``.
 
-When ``no``, ``launchrunfarm`` looks for already existing instances that
+When ``false``, ``launchrunfarm`` looks for already existing instances that
 match ``run_farm_tag`` and treat ``f1.16xlarges`` (and other 'instance-type'
 values below) as a total count.
 

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -623,7 +623,7 @@ you should not change it unless you are done with your current Run Farm.
 Per AWS restrictions, this tag can be no longer than 255 characters.
 
 ``always_expand_run_farm``
-"""""""""""""""""""""""""
+""""""""""""""""""""""""""
 When ``true`` (the default behavior when not given) the number of instances
 of each type (see ``f1.16xlarges`` etc. below)  are launched every time you
 run ``launchrunfarm``.


### PR DESCRIPTION
At some point @abejgonzalez renamed the option from `always_expand_runfarm` to `always_expand_run_farm` because that is more "readable".

This just updates the docs so that they align with the code.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

doc only change

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

only changes documentation

### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [X] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
