### PR TITLE
Do not materialize memory connections if the target does not use them

### DIFF
--- a/sim/midas/src/main/cc/core/simulation.cc
+++ b/sim/midas/src/main/cc/core/simulation.cc
@@ -125,13 +125,20 @@ void simulation_t::wait_for_init() {
 }
 
 void simulation_t::init_dram() {
-  auto &loadmem = registry.get_widget<loadmem_t>();
-  if (do_zero_out_dram) {
-    fprintf(stderr, "Zeroing out FPGA DRAM. This will take a few seconds...\n");
-    loadmem.zero_out_dram();
-  }
+  if (auto *loadmem = registry.get_widget_opt<loadmem_t>()) {
+    if (do_zero_out_dram) {
+      fprintf(stderr,
+              "Zeroing out FPGA DRAM. This will take a few seconds...\n");
+      loadmem->zero_out_dram();
+    }
 
-  if (!load_mem_path.empty()) {
-    loadmem.load_mem_from_file(load_mem_path);
+    if (!load_mem_path.empty()) {
+      loadmem->load_mem_from_file(load_mem_path);
+    }
+  } else {
+    if (do_zero_out_dram || !load_mem_path.empty()) {
+      fprintf(stderr,
+              "Skipping memory initialization: target does not use DRAM\n");
+    }
   }
 }

--- a/sim/midas/src/main/cc/core/widget_registry.h
+++ b/sim/midas/src/main/cc/core/widget_registry.h
@@ -56,10 +56,23 @@ public:
    */
   template <typename T>
   T &get_widget() {
+    auto *widget = get_widget_opt<T>();
+    assert(widget && "cannot find widget");
+    return *widget;
+  }
+
+  /**
+   * Return a widget of a particular kind, if it has a single instance.
+   *
+   * @tparam T Type of the widget to fetch
+   * @return Pointer to the widget instance.
+   */
+  template <typename T>
+  T *get_widget_opt() {
     auto it = widgets.find(&T::KIND);
-    assert(it != widgets.end() && "no bridges registered");
-    assert(it->second.size() == 1 && "multiple bridges registered");
-    return *static_cast<T *>(it->second[0].get());
+    if (it == widgets.end() || it->second.size() != 1)
+      return nullptr;
+    return static_cast<T *>(it->second[0].get());
   }
 
   /**

--- a/sim/midas/src/main/cc/emul/simif_emul.cc
+++ b/sim/midas/src/main/cc/emul/simif_emul.cc
@@ -190,8 +190,10 @@ simif_emul_t::FPGAManagedStreamIOImpl::FPGAManagedStreamIOImpl(
 }
 
 void simif_emul_t::load_mems(const char *fname) {
-  slave[0]->load_mem(0, fname);
   // TODO: allow file to be split across slaves
+  if (!slave.empty()) {
+    slave[0]->load_mem(0, fname);
+  }
 }
 
 int simif_emul_t::end() {

--- a/sim/midas/src/main/scala/midas/core/FPGATop.scala
+++ b/sim/midas/src/main/scala/midas/core/FPGATop.scala
@@ -147,95 +147,96 @@ class FPGATop(implicit p: Parameters) extends LazyModule with HasWidgets {
     regionTuples.toSeq.sortBy(r => (BytesOfDRAMRequired(r._2), r._1.head.memoryRegionName)).reverse
 
   // Allocate memory regions using a base-and-bounds scheme
-  val dramOffsetsRev     = sortedRegionTuples.foldLeft(Seq(BigInt(0)))({ case (offsets, (bridgeSeq, addresses)) =>
+  val dramOffsetsRev       = sortedRegionTuples.foldLeft(Seq(BigInt(0)))({ case (offsets, (bridgeSeq, addresses)) =>
     val requestedCapacity = BytesOfDRAMRequired(addresses)
     val pageAligned4k     = ((requestedCapacity + 4095) >> 12) << 12
     (offsets.head + pageAligned4k) +: offsets
   })
-  val totalDRAMAllocated = dramOffsetsRev.head
-  val dramOffsets        = dramOffsetsRev.tail.reverse
-  val availableDRAM      = p(HostMemNumChannels) * p(HostMemChannelKey).size
+  val totalDRAMAllocated   = dramOffsetsRev.head
+  val dramOffsets          = dramOffsetsRev.tail.reverse
+  val dramBytesPerChannel  = p(HostMemChannelKey).size
+  val availableDRAM        = p(HostMemNumChannels) * dramBytesPerChannel
   require(
     totalDRAMAllocated <= availableDRAM,
     s"Total requested DRAM of ${totalDRAMAllocated}B, exceeds host capacity of ${availableDRAM}B",
   )
+  val dramChannelsRequired = (totalDRAMAllocated + dramBytesPerChannel - 1) / dramBytesPerChannel
 
-  val loadMem          = addWidget(new LoadMemWidget(totalDRAMAllocated))
-  // Host DRAM handling
-  val memChannelParams = p(HostMemChannelKey)
-  // Define multiple single-channel nodes, instead of one multichannel node to more easily
-  // bind a subset to the XBAR.
-  val memAXI4Nodes     = Seq.tabulate(p(HostMemNumChannels)) { channel =>
-    val device = new MemoryDevice
-    val base   = channel * memChannelParams.size
-    AXI4SlaveNode(
-      Seq(
-        AXI4SlavePortParameters(
-          slaves    = Seq(
-            AXI4SlaveParameters(
-              address       = Seq(AddressSet(base, memChannelParams.size - 1)),
-              resources     = device.reg,
-              regionType    = RegionType.UNCACHED, // cacheable
-              executable    = false,
-              supportsWrite = TransferSizes(1, memChannelParams.maxXferBytes),
-              supportsRead  = TransferSizes(1, memChannelParams.maxXferBytes),
-              interleavedId = Some(0),
+  // If the target needs DRAM, build the required channels.
+  val (targetMemoryRegions, memAXI4Nodes): (Map[String, BigInt], Seq[AXI4SlaveNode]) =
+    if (dramChannelsRequired == 0) { (Map(), Seq()) }
+    else {
+      // In keeping with the Nasti implementation, we put all channels on a single XBar.
+      val xbar = AXI4Xbar()
+
+      val memChannelParams = p(HostMemChannelKey)
+
+      // Define multiple single-channel nodes, instead of one multichannel node to more easily
+      // bind a subset to the XBAR.
+      val memAXI4Nodes = Seq.tabulate(p(HostMemNumChannels)) { channel =>
+        val device = new MemoryDevice
+        val base   = channel * memChannelParams.size
+        AXI4SlaveNode(
+          Seq(
+            AXI4SlavePortParameters(
+              slaves    = Seq(
+                AXI4SlaveParameters(
+                  address       = Seq(AddressSet(base, memChannelParams.size - 1)),
+                  resources     = device.reg,
+                  regionType    = RegionType.UNCACHED, // cacheable
+                  executable    = false,
+                  supportsWrite = TransferSizes(1, memChannelParams.maxXferBytes),
+                  supportsRead  = TransferSizes(1, memChannelParams.maxXferBytes),
+                  interleavedId = Some(0),
+                )
+              ), // slave does not interleave read responses
+              beatBytes = memChannelParams.beatBytes,
             )
-          ), // slave does not interleave read responses
-          beatBytes = memChannelParams.beatBytes,
+          )
         )
-      )
-    )
-  }
+      }
 
-  // In keeping with the Nasti implementation, we put all channels on a single XBar.
-  val xbar = AXI4Xbar()
-
-  private def bindActiveHostChannel(channelNode: AXI4SlaveNode): Unit = p(HostMemIdSpaceKey) match {
-    case Some(AXI4IdSpaceConstraint(idBits, maxFlight)) =>
-      (channelNode := AXI4Buffer()
-        := AXI4UserYanker(Some(maxFlight))
-        := AXI4IdIndexer(idBits)
-        := AXI4Buffer()
-        := xbar)
-    case None                                           =>
-      (channelNode := AXI4Buffer()
-        := xbar)
-  }
-
-  // Connect only as many channels as needed by bridges requesting host DRAM.
-  // Always connect one channel because:
-  // 1) It is still assumed in some places, see loadmem
-  // 2) Almost all simulators we've built to date require at least one channel
-  // 3) In F1, the first DRAM channel cannot be omitted.
-  val dramChannelsRequired =
-    math.max(1, math.ceil(totalDRAMAllocated.toDouble / p(HostMemChannelKey).size.toLong).toInt)
-  for ((node, idx) <- memAXI4Nodes.zipWithIndex) {
-    if (idx < dramChannelsRequired) {
-      bindActiveHostChannel(node)
-    } else {
-      node := AXI4TieOff()
-    }
-  }
-
-  xbar := loadMem.toHostMemory
-  val targetMemoryRegions = Map(
-    sortedRegionTuples
-      .zip(dramOffsets)
-      .map({ case ((bridgeSeq, addresses), hostBaseAddr) =>
-        val regionName         = bridgeSeq.head.memoryRegionName
-        val virtualBaseAddr    = addresses.map(_.base).min
-        val offset             = hostBaseAddr - virtualBaseAddr
-        val preTranslationPort = (xbar
-          :=* AXI4Buffer()
-          :=* AXI4AddressTranslation(offset, addresses, regionName))
-        bridgeSeq.foreach { bridge =>
-          (preTranslationPort := AXI4Deinterleaver(bridge.memorySlaveConstraints.supportsRead.max)
-            := bridge.memoryMasterNode)
+      // Connect only as many channels as needed by bridges requesting host DRAM.
+      for ((node, idx) <- memAXI4Nodes.zipWithIndex) {
+        if (idx < dramChannelsRequired) {
+          p(HostMemIdSpaceKey) match {
+            case Some(AXI4IdSpaceConstraint(idBits, maxFlight)) =>
+              (node := AXI4Buffer()
+                := AXI4UserYanker(Some(maxFlight))
+                := AXI4IdIndexer(idBits)
+                := AXI4Buffer()
+                := xbar)
+            case None                                           =>
+              (node := AXI4Buffer()
+                := xbar)
+          }
+        } else {
+          node := AXI4TieOff()
         }
-        regionName -> offset
-      }): _*
-  )
+      }
+
+      val loadMem = addWidget(new LoadMemWidget(totalDRAMAllocated))
+      xbar := loadMem.toHostMemory
+      val memoryRegions = Map(
+        sortedRegionTuples
+          .zip(dramOffsets)
+          .map({ case ((bridgeSeq, addresses), hostBaseAddr) =>
+            val regionName         = bridgeSeq.head.memoryRegionName
+            val virtualBaseAddr    = addresses.map(_.base).min
+            val offset             = hostBaseAddr - virtualBaseAddr
+            val preTranslationPort = (xbar
+              :=* AXI4Buffer()
+              :=* AXI4AddressTranslation(offset, addresses, regionName))
+            bridgeSeq.foreach { bridge =>
+              (preTranslationPort := AXI4Deinterleaver(bridge.memorySlaveConstraints.supportsRead.max)
+                := bridge.memoryMasterNode)
+            }
+            regionName -> offset
+          }): _*
+      )
+
+      (memoryRegions, memAXI4Nodes)
+    }
 
   def printHostDRAMSummary(): Unit = {
     def toIECString(value: BigInt): String = {
@@ -367,7 +368,7 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
   HostClockSource.annotate(clock)
 
   val ctrl = IO(Flipped(WidgetMMIO()))
-  val mem  = IO(Vec(p(HostMemNumChannels), AXI4Bundle(p(HostMemChannelKey).axi4BundleParams)))
+  val mem  = IO(Vec(outer.memAXI4Nodes.length, AXI4Bundle(p(HostMemChannelKey).axi4BundleParams)))
 
   val cpu_managed_axi4 = outer.cpuManagedAXI4NodeTuple.map { case (node, params) =>
     val port = IO(Flipped(AXI4Bundle(params.axi4BundleParams)))
@@ -459,7 +460,7 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
     sb.append(",\n.mem = ")
     printConfig(confMem)
 
-    sb.append(s",\n.mem_num_channels = ${p(HostMemNumChannels)}")
+    sb.append(s",\n.mem_num_channels = ${outer.memAXI4Nodes.length}")
 
     sb.append(",\n.cpu_managed = ")
     confCPUManaged match {
@@ -502,8 +503,10 @@ class FPGATopImp(outer: FPGATop)(implicit p: Parameters) extends LazyModuleImp(o
       printMacro("FPGA_MANAGED_AXI4", "PRESENT", 1.toLong)
     }
 
-    for (idx <- 1 to p(HostMemNumChannels)) {
-      printMacro("MEM", s"HAS_CHANNEL${idx - 1}", 1.toLong)
+    if (outer.memAXI4Nodes.nonEmpty) {
+      for (idx <- 0 to outer.memAXI4Nodes.length) {
+        printMacro("MEM", s"HAS_CHANNEL${idx - 1}", 1.toLong)
+      }
     }
     printConfig("MEM", confMem)
   }

--- a/sim/midas/src/main/scala/midas/platform/F1Shim.scala
+++ b/sim/midas/src/main/scala/midas/platform/F1Shim.scala
@@ -6,9 +6,9 @@ import chisel3.util._
 import junctions._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy.LazyModuleImp
-import freechips.rocketchip.util.HeterogeneousBag
+import freechips.rocketchip.amba.axi4.AXI4Bundle
 
-import midas.core.CPUManagedAXI4Key
+import midas.core.{CPUManagedAXI4Key, HostMemChannelKey, HostMemNumChannels}
 import midas.widgets.{AXI4Printf, CtrlNastiKey}
 import midas.stage.GoldenGateOutputFileAnnotation
 
@@ -20,7 +20,7 @@ class F1Shim(implicit p: Parameters) extends PlatformShim {
     val io_dma    = IO(Flipped(new NastiIO()(p.alterPartial { case NastiKey =>
       NastiParameters(p(CPUManagedAXI4Key).get.axi4BundleParams)
     })))
-    val io_slave  = IO(HeterogeneousBag(top.module.mem.map(x => x.cloneType)))
+    val io_slave  = IO(Vec(p(HostMemNumChannels), AXI4Bundle(p(HostMemChannelKey).axi4BundleParams)))
 
     if (p(AXIDebugPrint)) {
       AXI4Printf(io_master, "master")
@@ -30,19 +30,31 @@ class F1Shim(implicit p: Parameters) extends PlatformShim {
 
     top.module.ctrl <> io_master
 
+    // Connect the CPU-managed stream engine if the target has one. Otherwise, cap off the connection.
     top.module.cpu_managed_axi4 match {
       case None       =>
         io_dma.aw.ready := false.B
         io_dma.ar.ready := false.B
         io_dma.w.ready  := false.B
         io_dma.r.valid  := false.B
-        io_dma.r.bits   := DontCare
+        io_dma.r.bits   := 0.U
         io_dma.b.valid  := false.B
-        io_dma.b.bits   := DontCare
+        io_dma.b.bits   := 0.U
       case Some(axi4) =>
         AXI4NastiAssigner.toAXI4(axi4, io_dma)
     }
 
+    // Using last-connect semantics, first cap off all channels and then connect the ones used.
+    for (slave <- io_slave) {
+      slave.aw.valid := false.B
+      slave.aw.bits  := 0.U
+      slave.ar.valid := false.B
+      slave.ar.bits  := 0.U
+      slave.w.valid  := false.B
+      slave.w.bits   := 0.U
+      slave.r.ready  := false.B
+      slave.b.ready  := false.B
+    }
     io_slave.zip(top.module.mem).foreach({ case (io, bundle) => io <> bundle })
 
     // Biancolin: It would be good to put in writing why ID is being reassigned...

--- a/sim/midas/src/main/scala/midas/platform/xilinx/AXI4Crossing.scala
+++ b/sim/midas/src/main/scala/midas/platform/xilinx/AXI4Crossing.scala
@@ -170,6 +170,39 @@ class XilinxAXI4Bundle(val bundleParams: AXI4BundleParameters, val isAXI4Lite: B
       }
     }
   }
+
+  def tieoffAsManager(): Unit = {
+    awid.foreach { _ := 0.U }
+    awaddr  := 0.U
+    awlen.foreach { _ := 0.U }
+    awsize.foreach { _ := 0.U }
+    awburst.foreach { _ := 0.U }
+    awlock.foreach { _ := 0.U }
+    awcache.foreach { _ := 0.U }
+    awprot  := 0.U
+    awqos.foreach { _ := 0.U }
+    awvalid := false.B
+
+    wdata  := 0.U
+    wstrb  := 0.U
+    wlast.foreach { _ := 0.U }
+    wvalid := false.B
+
+    bready := false.B
+
+    arid.foreach { _ := 0.U }
+    araddr  := 0.U
+    arlen.foreach { _ := 0.U }
+    arsize.foreach { _ := 0.U }
+    arburst.foreach { _ := 0.U }
+    arlock.foreach { _ := 0.U }
+    arcache.foreach { _ := 0.U }
+    arprot  := 0.U
+    arqos.foreach { _ := 0.U }
+    arvalid := false.B
+
+    rready := false.B
+  }
 }
 
 class AXI4ClockConverter(

--- a/sim/src/test/scala/midasexamples/MemorySuite.scala
+++ b/sim/src/test/scala/midasexamples/MemorySuite.scala
@@ -14,7 +14,8 @@ import freechips.rocketchip.config._
 import firesim.{BasePlatformConfig, TestSuiteCommon}
 
 abstract class LoadMemTest(
-  override val basePlatformConfig: BasePlatformConfig
+  override val basePlatformConfig: BasePlatformConfig,
+  val extraArgs:                   Seq[String] = Seq(),
 ) extends TutorialSuite("LoadMemModule", platformConfigs = Seq(classOf[NoSynthAsserts]))
     with Matchers {
 
@@ -59,7 +60,7 @@ abstract class LoadMemTest(
         run(
           backend,
           debug,
-          args = Seq(s"+n=${numLines} +loadmem=${input.getPath}", s"+test-dump-file=${output.getPath}"),
+          args = Seq(s"+n=${numLines} +loadmem=${input.getPath}", s"+test-dump-file=${output.getPath}") ++ extraArgs,
         ) == 0
       )
       val result = scala.io.Source.fromFile(output.getPath).mkString
@@ -71,8 +72,13 @@ abstract class LoadMemTest(
 class LoadMemF1Test    extends LoadMemTest(BaseConfigs.F1)
 class LoadMemVitisTest extends LoadMemTest(BaseConfigs.Vitis)
 
-class BridgeTests
+class FastLoadMemF1Test    extends LoadMemTest(BaseConfigs.F1, extraArgs = Seq("+fastloadmem"))
+class FastLoadMemVitisTest extends LoadMemTest(BaseConfigs.Vitis, extraArgs = Seq("+fastloadmem"))
+
+class MemoryCITests
     extends Suites(
       new LoadMemF1Test,
       new LoadMemVitisTest,
+      new FastLoadMemF1Test,
+      new FastLoadMemVitisTest,
     )

--- a/sim/src/test/scala/midasexamples/TutorialSuite.scala
+++ b/sim/src/test/scala/midasexamples/TutorialSuite.scala
@@ -56,6 +56,7 @@ class CIGroupA
       new AutoCounterCITests,
       new ResetPulseBridgeActiveHighTest,
       new ResetPulseBridgeActiveLowTest,
+      new MemoryCITests,
     )
 
 class CIGroupB


### PR DESCRIPTION
In line with the omission of managed stream engines and their associated connections to the top-level, this PR also eliminates unused memory connections. The top-level ports to the platform hardware are left unchanged. If no memories are used in the target, the `LoadMem` widget is omitted.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

#1430 

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

The port mappings are not affected.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
