### PR TITLE
Added a test for memory accesses and LoadMemWidget

### DIFF
--- a/sim/midas/src/main/cc/bridges/loadmem.cc
+++ b/sim/midas/src/main/cc/bridges/loadmem.cc
@@ -20,13 +20,14 @@ loadmem_t::loadmem_t(simif_t &simif,
 }
 
 void loadmem_t::load_mem_from_file(const std::string &filename) {
-  fprintf(stdout, "[loadmem] start loading\n");
+  const size_t chunk = mem_conf.data_bits / 4;
+
+  fprintf(stdout, "[loadmem] start loading, chunk = %ld\n", chunk);
   std::ifstream file(filename.c_str());
   if (!file) {
     fprintf(stderr, "Cannot open %s\n", filename.c_str());
     exit(EXIT_FAILURE);
   }
-  const size_t chunk = mem_conf.data_bits / 4;
   size_t addr = 0;
   std::string line;
   mpz_t data;

--- a/sim/midas/src/main/cc/core/simulation.cc
+++ b/sim/midas/src/main/cc/core/simulation.cc
@@ -86,6 +86,8 @@ int simulation_t::execute_simulation_flow() {
     stream->init();
   }
 
+  init_dram();
+
   simulation_init();
 
   record_start_times();

--- a/sim/src/main/cc/midasexamples/TestLoadMemModule.cc
+++ b/sim/src/main/cc/midasexamples/TestLoadMemModule.cc
@@ -1,0 +1,70 @@
+// See LICENSE for license details.
+
+#include "TestHarness.h"
+
+class TestLoadMemModule final : public TestHarness {
+public:
+  static constexpr unsigned timeout = 128;
+
+  FILE *output = stdout;
+  uint32_t n = 128;
+
+  TestLoadMemModule(widget_registry_t &registry,
+                    const std::vector<std::string> &args,
+                    std::string_view target_name)
+      : TestHarness(registry, args, target_name) {
+    constexpr std::string_view test_dump_key = "+test-dump-file=";
+    constexpr std::string_view n_key = "+n=";
+
+    for (const auto &arg : args) {
+      if (arg.find(test_dump_key) == 0) {
+        output = fopen(arg.substr(test_dump_key.length()).c_str(), "w");
+        continue;
+      }
+      if (arg.find(n_key) == 0) {
+        n = atoi(arg.substr(n_key.length()).c_str());
+        continue;
+      }
+    }
+  }
+
+  ~TestLoadMemModule() override {
+    if (output != stdout)
+      fclose(output);
+  }
+
+  void run_test() override {
+    // Reset the DUT.
+    peek_poke.poke("reset", 1, /*blocking=*/true);
+    peek_poke.step(1, /*blocking=*/true);
+    peek_poke.poke("reset", 0, /*blocking=*/true);
+    peek_poke.step(1, /*blocking=*/true);
+
+    // Run through an address range and print the value.
+    for (uint32_t addr = 0; addr < n; ++addr) {
+      peek_poke.step(1000, false);
+      peek_poke.poke("addr", addr, false);
+
+      // The address change triggers a read. Wait for the
+      // done flag to indicate its completion.
+      bool done = false;
+      for (unsigned i = 0; i < timeout; ++i) {
+        if (peek_poke.peek("done", true)) {
+          done = true;
+          break;
+        }
+      }
+      if (!done) {
+        fprintf(stderr, "Cannot read value at %x\n", addr);
+        exit(1);
+      }
+
+      // Read the value and print it to the output file.
+      uint32_t lo = peek_poke.peek("data_lo", true);
+      uint32_t hi = peek_poke.peek("data_hi", true);
+      fprintf(output, "%08x%08x\n", hi, lo);
+    }
+  }
+};
+
+TEST_MAIN(TestLoadMemModule)

--- a/sim/src/main/scala/midasexamples/LoadMemModule.scala
+++ b/sim/src/main/scala/midasexamples/LoadMemModule.scala
@@ -1,0 +1,159 @@
+// See LICENSE for license details.
+
+package firesim.midasexamples
+
+import chisel3._
+
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy.AddressSet
+
+import junctions.NastiParameters
+import midas.models.{AXI4EdgeSummary, BaseParams, CompleteConfig, FASEDBridge, LatencyPipeConfig}
+import midas.widgets.{PeekPokeBridge, RationalClockBridge}
+
+class ReaderIO extends Bundle {
+  val addr    = Input(UInt(16.W))
+  val data_lo = Output(UInt(32.W))
+  val data_hi = Output(UInt(32.W))
+  val done    = Output(Bool())
+}
+
+class MemoryReader(implicit p: Parameters) extends LazyModule {
+  val node = TLClientNode(
+    Seq(
+      TLMasterPortParameters.v1(
+        Seq(
+          TLMasterParameters.v1(
+            name     = "MemoryReader",
+            sourceId = IdRange(0, 1),
+          )
+        )
+      )
+    )
+  )
+
+  lazy val module = new Impl
+  class Impl extends LazyModuleImp(this) {
+    val io = IO(new ReaderIO)
+
+    val (out, edge) = node.out(0)
+
+    val latchAddr  = RegInit(0xffff.U(16.W))
+    val latchValue = RegInit(0.U(64.W))
+    val pending    = RegInit(false.B)
+
+    // Kick off a request with the address on the IO port.
+    out.a.valid := !pending && latchAddr =/= io.addr
+
+    val (legal, bits) = edge.Get(0.U, io.addr << 3.U, 3.U)
+    out.a.bits := bits
+
+    when(out.a.fire) {
+      latchAddr := io.addr
+      pending   := true.B
+    }
+
+    // Latch the result of the latest memory read.
+    out.d.ready := pending
+    when(out.d.fire) {
+      latchValue := out.d.bits.data
+      pending    := false.B
+    }
+
+    // Tie off unused channels.
+    out.b.ready := true.B
+    out.c.valid := false.B
+    out.e.valid := false.B
+
+    // Wire outputs to the harness.
+    io.done    := !pending
+    io.data_lo := latchValue(31, 0)
+    io.data_hi := latchValue >> 32.U
+  }
+}
+
+class LoadMemDUT(implicit p: Parameters) extends LazyModule {
+  val addrBits        = 16
+  val maxTransferSize = 64
+  val beatBytes       = 8
+  val idBits          = 1
+  val nMemoryChannels = 1
+
+  val xbar = AXI4Xbar()
+
+  val slave = AXI4SlaveNode(Seq.tabulate(nMemoryChannels) { i =>
+    val base   = AddressSet.misaligned(0, (BigInt(1) << addrBits))
+    val filter = AddressSet(i * maxTransferSize, ~((nMemoryChannels - 1) * maxTransferSize))
+    AXI4SlavePortParameters(
+      slaves    = Seq(
+        AXI4SlaveParameters(
+          address       = base.flatMap(_.intersect(filter)),
+          regionType    = RegionType.UNCACHED,
+          executable    = true,
+          supportsWrite = TransferSizes(1, maxTransferSize),
+          supportsRead  = TransferSizes(1, maxTransferSize),
+          interleavedId = Some(0),
+        )
+      ),
+      beatBytes = beatBytes,
+    )
+  })
+
+  (slave
+    :*= AXI4Buffer()
+    :*= AXI4UserYanker()
+    :*= AXI4IdIndexer(idBits)
+    :*= xbar)
+
+  val reader = LazyModule(new MemoryReader)
+
+  (xbar := AXI4Deinterleaver(maxTransferSize)
+    := TLToAXI4()
+    := TLDelayer(0.1)
+    := TLBuffer(BufferParams.flow)
+    := TLDelayer(0.1)
+    := reader.node)
+
+  lazy val module = new Impl
+  class Impl extends LazyModuleImp(this) {
+    val io = IO(new ReaderIO)
+    io <> reader.module.io
+
+    for ((axi4, edge) <- slave.in) {
+      val nastiKey = NastiParameters(axi4.r.bits.data.getWidth, axi4.ar.bits.addr.getWidth, axi4.ar.bits.id.getWidth)
+      FASEDBridge(
+        clock,
+        axi4,
+        reset.asBool,
+        CompleteConfig(
+          new LatencyPipeConfig(
+            BaseParams(maxReads = 16, maxWrites = 16, beatCounters = true, llcKey = None)
+          ),
+          nastiKey,
+          Some(AXI4EdgeSummary(edge)),
+          Some("DefaultMemoryRegion"),
+        ),
+      )
+    }
+  }
+}
+
+class LoadMemModule(implicit val p: Parameters) extends RawModule {
+  val clock = RationalClockBridge().io.clocks.head
+  val reset = WireInit(false.B)
+
+  withClockAndReset(clock, reset) {
+    val dut = Module((LazyModule(new LoadMemDUT)).module)
+    PeekPokeBridge(
+      clock,
+      reset,
+      ("addr", dut.io.addr),
+      ("data_lo", dut.io.data_lo),
+      ("data_hi", dut.io.data_hi),
+      ("done", dut.io.done),
+    )
+  }
+}

--- a/sim/src/test/scala/midasexamples/MemorySuite.scala
+++ b/sim/src/test/scala/midasexamples/MemorySuite.scala
@@ -1,0 +1,117 @@
+//See LICENSE for license details.
+
+package firesim.midasexamples
+
+import java.io._
+
+import org.scalatest.Suites
+import org.scalatest.matchers.should._
+
+import freechips.rocketchip.config.Config
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config._
+
+import firesim.{BasePlatformConfig, TestSuiteCommon}
+
+abstract class LoadMemTest(
+  override val basePlatformConfig: BasePlatformConfig
+) extends TestSuiteCommon("midasexamples")
+    with Matchers {
+
+  override def targetConfigs   = "NoConfig"
+  override def targetName      = "LoadMemModule"
+  override def platformConfigs = Seq(classOf[NoSynthAsserts])
+
+  def run(
+    backend:  String,
+    debug:    Boolean      = false,
+    logFile:  Option[File] = None,
+    waveform: Option[File] = None,
+    args:     Seq[String]  = Nil,
+  ) = {
+    val makeArgs = Seq(
+      s"run-$backend%s".format(if (debug) "-debug" else ""),
+      "LOGFILE=%s".format(logFile.map(toStr).getOrElse("")),
+      "WAVEFORM=%s".format(waveform.map(toStr).getOrElse("")),
+      "ARGS=%s".format(args.mkString(" ")),
+    )
+    if (isCmdAvailable(backend)) {
+      make(makeArgs: _*)
+    } else 0
+  }
+
+  /** Helper to generate tests strings.
+    */
+  def getTestInput(length: Int): String = {
+    val gen   = new scala.util.Random(100)
+    val alpha = "0123456789abcdef"
+    Seq
+      .tabulate(length) { _ =>
+        (1 to 16).map(_ => alpha(gen.nextInt(alpha.length))).mkString
+      }
+      .mkString("\n")
+  }
+
+  /** Runs MIDAS-level simulation on the design.
+    *
+    * @param backend
+    *   Backend simulator: "verilator" or "vcs"
+    * @param debug
+    *   When true, captures waves from the simulation
+    */
+  def runTest(backend: String, debug: Boolean) {
+    // Generate a random string spanning 2 sectors with a fixed seed.
+    val numLines = 128
+    val data     = getTestInput(numLines)
+
+    // Create an input file.
+    val input       = File.createTempFile("input", ".txt")
+    //input.deleteOnExit()
+    val inputWriter = new BufferedWriter(new FileWriter(input))
+    inputWriter.write(data)
+    inputWriter.flush()
+    inputWriter.close()
+
+    // Pre-allocate space in the output.
+    val output       = File.createTempFile("output", ".txt")
+    //output.deleteOnExit()
+    val outputWriter = new BufferedWriter(new FileWriter(output))
+    for (i <- 1 to data.size) {
+      outputWriter.write('x')
+    }
+    outputWriter.flush()
+    outputWriter.close()
+
+    val runResult =
+      run(backend, debug, args = Seq(s"+n=${numLines} +loadmem=${input.getPath}", s"+test-dump-file=${output.getPath}"))
+    assert(runResult == 0)
+    val result    = scala.io.Source.fromFile(output.getPath).mkString
+    result should equal(data + "\n")
+  }
+
+  mkdirs()
+  behavior.of(s"$targetName")
+  elaborateAndCompile()
+  for (backend <- Seq("vcs", "verilator")) {
+    compileMlSimulator(backend)
+
+    val testEnvStr = s"pass in ${backend} MIDAS-level simulation"
+
+    if (isCmdAvailable(backend)) {
+      it should testEnvStr in {
+        runTest(backend, false)
+      }
+    } else {
+      ignore should testEnvStr in {}
+    }
+  }
+}
+
+class LoadMemF1Test    extends LoadMemTest(BaseConfigs.F1)
+class LoadMemVitisTest extends LoadMemTest(BaseConfigs.Vitis)
+
+class BridgeTests
+    extends Suites(
+      new LoadMemF1Test,
+      new LoadMemVitisTest,
+    )


### PR DESCRIPTION
This PR fixes the invocation to `LoadMem` and adds a test for it.

The test performs memory read accesses through a TileLink node which goes to DRAM through a trivial FASED bridge. Read requests from the driver are received through the `PeekPokeBridge` and are sent back to be printed to a file. The test harness compares the file passed to loadmem with the results produced by this bridge, which should read all data back.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
