### PR TITLE
VCS post-synthesis RTL simulators

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -53,6 +53,7 @@ include make/scala-build.mk
 
 include $(TARGET_PROJECT_MAKEFRAG)/build.mk
 include make/goldengate.mk
+include make/post-synth.mk
 
 include $(TARGET_PROJECT_MAKEFRAG)/driver.mk
 include make/library.mk

--- a/sim/make/goldengate.mk
+++ b/sim/make/goldengate.mk
@@ -9,6 +9,7 @@ header := $(GENERATED_DIR)/$(BASE_FILE_NAME).const.h
 
 # The midas-generated simulator RTL which will be baked into the FPGA shell project
 simulator_verilog := $(GENERATED_DIR)/$(BASE_FILE_NAME).sv
+simulator_xdc := $(GENERATED_DIR)/$(BASE_FILE_NAME).synthesis.xdc
 
 # Pre-simulation-mapping annotations which includes all Bridge Annotations
 # extracted used to generate new runtime configurations.
@@ -21,7 +22,7 @@ compile: $(simulator_verilog)
 # empty recipe to help make understand multiple targets come from single recipe invocation
 # without using the new (4.3) '&:' grouped targets see https://stackoverflow.com/a/41710495
 .SECONDARY: $(simulator_verilog).intermediate
-$(simulator_verilog) $(header) $(fame_annos): $(simulator_verilog).intermediate ;
+$(simulator_verilog) $(simulator_xdc) $(header) $(fame_annos): $(simulator_verilog).intermediate ;
 
 # Disable FIRRTL 1.4 deduplication because it creates multiple failures
 # Run the 1.3 version instead (checked-in). If dedup must be completely disabled,

--- a/sim/make/post-synth.mk
+++ b/sim/make/post-synth.mk
@@ -1,0 +1,24 @@
+# See LICENSE for license details.
+
+STRATEGY ?= BASIC
+FREQUENCY ?= 30
+
+
+################################################################################
+# Post-synthesis RTL generation
+################################################################################
+
+POST_SYNTH_RTL := $(GENERATED_DIR)/verilog.sv
+POST_SYNTH_XDC := $(GENERATED_DIR)/$(BASE_FILE_NAME).post-synth.xdc
+
+$(POST_SYNTH_XDC): $(simulator_xdc)
+	sed 's#firesim_top/##g' $(simulator_xdc) > $(POST_SYNTH_XDC)
+
+$(POST_SYNTH_RTL): $(simulator_verilog) $(POST_SYNTH_XDC) scripts/synth_fpga.tcl
+	 cd $(GENERATED_DIR) && time vivado \
+			-mode batch -nojournal \
+			-source $(firesim_base_dir)/scripts/synth_fpga.tcl \
+			-tclargs $(STRATEGY) $(FREQUENCY) $@ $(POST_SYNTH_XDC) $(simulator_verilog)
+
+.PHONY: post-synth-rtl
+post-synth-rtl: $(POST_SYNTH_RTL)

--- a/sim/make/vcs.mk
+++ b/sim/make/vcs.mk
@@ -1,29 +1,49 @@
 # See LICENSE for license details.
 
-##############################
-# VCS MIDAS-Level Simulators #
-##############################
+################################################################################
+# VCS MIDAS-Level Simulators
+################################################################################
 
 VCS_CXXOPTS ?= -O2
 
 vcs = $(GENERATED_DIR)/$(DESIGN)
 vcs_debug = $(GENERATED_DIR)/$(DESIGN)-debug
+vcs_post_synth = $(GENERATED_DIR)/$(DESIGN)-post-synth
+vcs_post_synth_debug = $(GENERATED_DIR)/$(DESIGN)-post-synth-debug
 
-$(vcs) $(vcs_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VCS_CXXOPTS) -I$(VCS_HOME)/include -D RTLSIM
+$(vcs) $(vcs_post_synth) $(vcs_debug) $(vcs_post_synth_debug): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(VCS_CXXOPTS) -I$(VCS_HOME)/include -D RTLSIM
 # VCS can mangle the ordering of libraries and object files at link time such
 # that some valid dependencies are pruned when --as-needed is set.
 # Conservatively set --no-as-needed in case --as-needed is defined in LDFLAGS.
-$(vcs) $(vcs_debug): export LDFLAGS := $(LDFLAGS) -Wl,--no-as-needed $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
+$(vcs) $(vcs_post_synth) $(vcs_debug) $(vcs_post_synth_debug): export LDFLAGS := $(LDFLAGS) -Wl,--no-as-needed $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN'
 
-$(vcs): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
-	$(MAKE) -C $(simif_dir) vcs PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" TOP_DIR=$(chipyard_dir)
+vcs_driver_deps := $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 
-$(vcs_debug): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h) $(simulator_verilog)
-	$(MAKE) -C $(simif_dir) vcs-debug PLATFORM=$(PLATFORM) DRIVER_NAME=$(DESIGN) GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
-	GEN_DIR=$(GENERATED_DIR) DRIVER="$(DRIVER_CC)" TOP_DIR=$(chipyard_dir)
+define make_vcs
+	$(MAKE) -C $(simif_dir) $(1) \
+		PLATFORM=$(PLATFORM) \
+		DRIVER_NAME=$(DESIGN) \
+		GEN_FILE_BASENAME=$(BASE_FILE_NAME) \
+		GEN_DIR=$(GENERATED_DIR) \
+		DRIVER="$(DRIVER_CC)" \
+		TOP_DIR=$(chipyard_dir) \
+		DESIGN_V=$(2)
+endef
 
-.PHONY: vcs vcs-debug
+$(vcs): $(vcs_driver_deps) $(simulator_verilog)
+	$(call make_vcs, vcs,$(simulator_verilog))
+
+$(vcs_debug): $(vcs_driver_deps) $(simulator_verilog)
+	$(call make_vcs, vcs-debug,$(simulator_verilog))
+
+$(vcs_post_synth): $(vcs_driver_deps) $(POST_SYNTH_RTL)
+	$(call make_vcs, vcs-post-synth,$(POST_SYNTH_RTL))
+
+$(vcs_post_synth_debug): $(vcs_driver_deps) $(POST_SYNTH_RTL)
+	$(call make_vcs, vcs-post-synth-debug,$(POST_SYNTH_RTL))
+
+.PHONY: vcs vcs-debug vcs-post-synth  vcs-post-synth-f1-debug
 vcs: $(vcs)
 vcs-debug: $(vcs_debug)
-
+vcs-post-synth: $(vcs_post_synth)
+vcs-post-synth-debug: $(vcs_post_synth_debug)

--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -24,7 +24,7 @@ CLOCK_PERIOD ?= 1.0
 override CXXFLAGS += -Wall -I$(midas_dir) -I$(GEN_DIR)
 override LDFLAGS += -L$(GEN_DIR) -lstdc++ -lpthread -lgmp
 
-design_v  := $(GEN_DIR)/$(GEN_FILE_BASENAME).sv
+DESIGN_V  ?= $(GEN_DIR)/$(GEN_FILE_BASENAME).sv
 design_h  := $(GEN_DIR)/$(GEN_FILE_BASENAME).const.h
 design_vh := $(GEN_DIR)/$(GEN_FILE_BASENAME).const.vh
 driver_h = $(foreach t, $(DRIVER), $(wildcard $(dir $(t))/*.h))
@@ -32,28 +32,38 @@ driver_h = $(foreach t, $(DRIVER), $(wildcard $(dir $(t))/*.h))
 bridge_h := $(wildcard $(bridge_dir)/*.h) $(wildcard $(core_dir)/*.h)
 bridge_cc := $(wildcard $(bridge_dir)/*.cc) $(wildcard $(core_dir)/*.cc)
 bridge_o := $(patsubst $(midas_dir)/%.cc, $(GEN_DIR)/%.o, $(bridge_cc))
-$(bridge_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h) $(bridge_h)
+$(bridge_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(bridge_h)
 	mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -c -o $@ $< -include $(word 2, $^)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 platform_files := simif_$(MAIN) main
 platform_cc := $(addprefix $(midas_dir)/, $(addsuffix .cc, $(platform_files)))
 platform_o := $(addprefix $(GEN_DIR)/, $(addsuffix .o, $(platform_files)))
 
-$(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h)
+$(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc
 	mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) -c -o $@ $< -include $(word 2, $^)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
-$(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(design_h) $(DRIVER) $(driver_h) $(platform_o) $(bridge_o)
+$(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(DRIVER) $(driver_h) $(platform_o) $(bridge_o)
 	mkdir -p $(OUT_DIR)
-	$(CXX) $(CXXFLAGS) -include $< \
-	-o $@ $(DRIVER) $(platform_o) $(bridge_o) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o $@ $(DRIVER) $(platform_o) $(bridge_o) $(LDFLAGS)
 
 .PHONY: driver
 driver: $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
 
 # Sources for building MIDAS-level simulators. Must be defined before sources VCS/Verilator Makefrags
 override CXXFLAGS += -std=c++17 -include $(design_h)
+# Force verilator to obey our -std=c++17 from CXXFLAGS if it thinks it needs to add a -std argument to the compiler
+# by default, it will capture a -std argument during it's build using heuristics to try and match
+# the system-package for SystemC.
+# 1. we don't use SystemC
+# 2. the heuristics Verilator uses to capture -std at configure are incorrect for us
+# 3. Verilator output compiles and links for us fine with std=c++17
+# VERILATOR_FLAGS could do this with
+#   VERILATOR_FLAGS += -MAKEFLAGS CFG_CXXFLAGS_STD_NEWEST=
+# but we don't pass --build to it, we invoke the make build ourselves
+# see also https://github.com/verilator/verilator/issues/3588
+VERILATOR_MAKEFLAGS += CFG_CXXFLAGS_STD_NEWEST=
 
 # Models of FPGA primitives that are used in host-level sim, but not in FPGATop
 sim_fpga_resource_models := $(v_dir)/BUFGCE.v
@@ -62,7 +72,7 @@ emul_dir   := $(midas_dir)/emul
 emul_h     := $(driver_h) $(bridge_h) $(emul_dir)/simif_emul.h $(emul_dir)/mmio.h $(emul_dir)/mm.h
 # This includes c sources and static libraries
 emul_cc    := $(DRIVER) $(bridge_cc) $(emul_dir)/simif_emul.cc $(emul_dir)/mmio.cc $(emul_dir)/mm.cc $(emul_dir)/dpi.cc $(midas_dir)/main.cc
-emul_v     := $(design_vh) $(design_v) $(sim_fpga_resource_models)
+emul_v     := $(design_vh) $(DESIGN_V) $(sim_fpga_resource_models)
 
 verilator_conf := rtlsim/ml-verilator-conf.vlt
 verilator_wrapper_v := $(v_dir)/top.sv
@@ -70,8 +80,12 @@ verilator_harness := $(midas_dir)/simif_emul_verilator.cc
 top_module := emul
 include rtlsim/Makefrag-verilator
 
+# tell make not to look for implicit rules for verilator sourcefiles (helps --debug=i output)
+$(verilator_harness): ;
+
 verilator: $(OUT_DIR)/V$(DRIVER_NAME)
 verilator-debug: $(OUT_DIR)/V$(DRIVER_NAME)-debug
+.PHONY: verilator verilator-debug
 
 # Add an extra wrapper source for VCS simulators
 vcs_wrapper_v := $(v_dir)/top.sv
@@ -80,7 +94,11 @@ TB := emul
 VCS_FLAGS := -e vcs_main
 include rtlsim/Makefrag-vcs
 
+$(vcs_harness): ;
+
 vcs: $(OUT_DIR)/$(DRIVER_NAME)
 vcs-debug: $(OUT_DIR)/$(DRIVER_NAME)-debug
+vcs-post-synth: $(OUT_DIR)/$(DRIVER_NAME)-post-synth
+vcs-post-synth-debug: $(OUT_DIR)/$(DRIVER_NAME)-post-synth-debug
 
-.PHONY: verilator verilator-debug vcs vcs-debug
+.PHONY: vcs vcs-debug vcs-post-synth vcs-post-synth-debug

--- a/sim/midas/src/main/cc/rtlsim/Makefrag-vcs
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-vcs
@@ -16,8 +16,10 @@
 # aforementioned sources. This should removed once we remove the global
 # -include of the generated header.
 VCS ?= vcs -full64
-override VCS_FLAGS := -quiet -timescale=1ns/1ps +v2k +rad +vcs+initreg+random +vcs+lic+wait \
-	-notice -line +lint=all,noVCDE,noONGS,noUI -quiet -debug_acc+pp+dmptf -debug_region+cell+encrypt +no_notifier -cpp $(CXX) \
+vcs_flags := \
+	$(VCS_FLAGS) \
+	-quiet -timescale=1ps/1ps +v2k +rad +vcs+initreg+random +vcs+lic+wait \
+	-notice -line -quiet -debug_acc+pp+dmptf -debug_region+cell+encrypt +no_notifier -cpp $(CXX) \
 	-top $(TB) \
 	-Mdir=$(GEN_DIR)/$(DRIVER_NAME)-debug.csrc \
 	+vc+list \
@@ -26,25 +28,58 @@ override VCS_FLAGS := -quiet -timescale=1ns/1ps +v2k +rad +vcs+initreg+random +v
 	-sverilog \
 	-assert svaext \
 	+define+CLOCK_PERIOD=$(CLOCK_PERIOD) \
+	+define+RANDOMIZE_MEM_INIT \
+	+define+RANDOMIZE_REG_INIT \
 	+define+RANDOMIZE_GARBAGE_ASSIGN \
 	+define+RANDOMIZE_INVALID_ASSIGN \
 	+define+STOP_COND=!$(TB).reset \
 	+define+PRINTF_COND=!$(TB).reset \
-	$(VCS_FLAGS)
+	+define+RANDOM=32\'b0 \
+	$(vcs_flags)
 
 vcs_v := $(emul_v) $(vcs_wrapper_v)
 vcs_cc := $(emul_cc) $(vcs_harness)
+
+################################################################################
+
+vcs_rtl_flags := \
+	$(vcs_flags) \
+	+lint=all,noVCDE,noONGS,noUI
 
 $(OUT_DIR)/$(DRIVER_NAME): $(vcs_v) $(vcs_cc) $(emul_h)
 	mkdir -p $(OUT_DIR)
 	rm -rf $(GEN_DIR)/$(DRIVER_NAME).csrc
 	rm -rf $(OUT_DIR)/$(DRIVER_NAME).daidir
-	$(VCS) $(VCS_FLAGS) \
-	-o $@ $(vcs_v) $(vcs_cc)
+	$(VCS) $(vcs_rtl_flags) -o $@ $(vcs_v) $(vcs_cc)
 
 $(OUT_DIR)/$(DRIVER_NAME)-debug: $(vcs_v) $(vcs_cc) $(emul_h)
 	mkdir -p $(OUT_DIR)
 	rm -rf $(GEN_DIR)/$(DRIVER_NAME)-debug.csrc
 	rm -rf $(OUT_DIR)/$(DRIVER_NAME)-debug.daidir
-	$(VCS) $(VCS_FLAGS) +define+DEBUG \
-	-o $@ $(vcs_v) $(vcs_cc)
+	$(VCS) $(vcs_rtl_flags) +define+DEBUG -o $@ $(vcs_v) $(vcs_cc)
+
+################################################################################
+
+vcs_post_synth_flags := \
+	$(vcs_flags) \
+	+lint=none +warn=none \
+	-y ${XILINX_VIVADO}/data/verilog/src/unisims \
+	-y ${XILINX_VIVADO}/data/verilog/src/unimacro \
+	-y ${XILINX_VIVADO}/data/verilog/src/retarget \
+	-y ${XILINX_VIVADO}/ids_lite/ISE/verilog/src/XilinxCoreLib \
+	+incdir+${XILINX_VIVADO}/verilog/src \
+	+libext+.v \
+	${XILINX_VIVADO}/data/verilog/src/glbl.v \
+	-top glbl
+
+$(OUT_DIR)/$(DRIVER_NAME)-post-synth: $(vcs_v) $(vcs_cc) $(emul_h)
+	mkdir -p $(OUT_DIR)
+	rm -rf $(GEN_DIR)/$(DRIVER_NAME)-post-synth.csrc
+	rm -rf $(OUT_DIR)/$(DRIVER_NAME)-post-synth.daidir
+	$(VCS) $(vcs_post_synth_flags) -o $@ $(vcs_v) $(vcs_cc)
+
+$(OUT_DIR)/$(DRIVER_NAME)-post-synth-debug: $(vcs_v) $(vcs_cc) $(emul_h)
+	mkdir -p $(OUT_DIR)
+	rm -rf $(GEN_DIR)/$(DRIVER_NAME)-post-synth-debug.csrc
+	rm -rf $(OUT_DIR)/$(DRIVER_NAME)-post-synth-debug.daidir
+	$(VCS) $(vcs_post_synth_flags) +define+DEBUG -o $@ $(vcs_v) $(vcs_cc)

--- a/sim/scripts/synth_fpga.tcl
+++ b/sim/scripts/synth_fpga.tcl
@@ -1,0 +1,120 @@
+# See LICENSE for license details.
+
+################################################################################
+# This file can be used to synthesize the `FPGATop` module of a design. It
+# emulates the strategy & frequency that the AWS flows might use.
+################################################################################
+
+################################################################################
+# Command-line Arguments
+################################################################################
+
+set strategy                [lindex $argv  0]
+set desired_host_frequency  [lindex $argv  1]
+set output                  [lindex $argv  2]
+set firesim_xdc             [lindex $argv  3]
+set firesim_sv              [lindex $argv  4]
+
+set device_type         "xcvu9p-flgb2104-2-i"
+set uram_option         2
+
+################################################################################
+# Read design files
+################################################################################
+
+if {$uram_option != 2} {
+  set_param synth.elaboration.rodinMoreOptions {rt::set_parameter disableOregPackingUram true}
+  set_param physynth.ultraRAMOptOutput false
+}
+
+# Maintain DONT TOUCH functionality for 2020.2 onwards
+if {[string match *2020.2* [version -short]] || [string match *2021.* [version -short]]} {
+  set_param project.replaceDontTouchWithKeepHierarchySoft false
+}
+
+switch $uram_option {
+    "2" {
+        set synth_uram_option "-max_uram_cascade_height 2"
+        set uramHeight 2
+    }
+    "3" {
+        set synth_uram_option "-max_uram_cascade_height 3"
+        set uramHeight 3
+    }
+    "4" {
+        set synth_uram_option "-max_uram_cascade_height 1"
+        set uramHeight 4
+    }
+    default {
+        set synth_uram_option "-max_uram_cascade_height 1"
+        set uramHeight 4
+    }
+}
+
+switch $strategy {
+    "BASIC" {
+        puts "BASIC strategy."
+        set synth_options "-keep_equivalent_registers $synth_uram_option -retiming"
+        set synth_directive "default"
+    }
+    "AREA" {
+        puts "AREA strategy."
+        set synth_options "$synth_uram_option -retiming"
+        set synth_directive "AreaOptimized_high"
+    }
+    "EXPLORE" {
+        puts "EXPLORE strategy."
+        set synth_options "-keep_equivalent_registers -flatten_hierarchy rebuilt $synth_uram_option -retiming"
+        set synth_directive "default"
+    }
+    "NORETIMING" {
+        puts "NORETIMING strategy."
+        set synth_options "-no_lc -shreg_min_size 5 -fsm_extraction one_hot -resource_sharing auto $synth_uram_option"
+        set synth_directive "default"
+    }
+    "TIMING" {
+        puts "TIMING strategy."
+        set synth_options "-no_lc -shreg_min_size 5 -fsm_extraction one_hot -resource_sharing auto $synth_uram_option -retiming"
+        set synth_directive "default"
+    }
+    "CONGESTION" {
+        puts "CONGESTION strategy."
+        set synth_options "-no_lc -shreg_min_size 10 -control_set_opt_threshold 16 $synth_uram_option -retiming"
+        set synth_directive "AlternateRoutability"
+    }
+    "DEFAULT" {
+        puts "DEFAULT strategy."
+        set synth_options "-keep_equivalent_registers -flatten_hierarchy rebuilt $synth_uram_option -retiming"
+        set synth_directive "default"
+    }
+    default {
+        puts "$strategy is NOT a valid strategy."
+        exit 1
+    }
+}
+
+################################################################################
+# Read design files
+################################################################################
+
+read_verilog -sv [list $firesim_sv]
+read_xdc [list $firesim_xdc]
+
+################################################################################
+# CL Synthesis
+################################################################################
+
+update_compile_order -fileset sources_1
+
+eval [concat synth_design -top FPGATop -verilog_define XSDB_SLV_DIS -part $device_type -mode out_of_context $synth_options -directive $synth_directive]
+set failval [catch {exec grep "FAIL" failfast.csv}]
+if { $failval==0 } {
+  puts "Synthesis failed"
+  exit 1
+}
+
+write_checkpoint -force $output.dcp
+write_verilog -force -mode design $output
+report_utilization -hierarchical -hierarchical_percentages -file $output.rpt
+
+close_project


### PR DESCRIPTION
This PR adds make rules to get the post-synth RTL out of vivado and build a VCS simulator out of it. On VCS, a 150ns startup delay is hard-wired on all simulation modes to yield identical waveforms. The delay is required to initialize vivado gate-level libraries.

Running `make vcs-post-synth` and `make vcs-post-synth-debug` builds the simulators.

<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
