### PR TITLE
pickup fab-classic#77 by bumping to 1.19.2

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,4 +1,4 @@
-fab-classic==1.19.1
+fab-classic==1.19.2
 boto3==1.20.21
 pytz
 pyyaml

--- a/conda-reqs.conda-lock.yml
+++ b/conda-reqs.conda-lock.yml
@@ -5123,14 +5123,14 @@ package:
     paramiko-ng: '*'
     six: '>=1.10.0'
   hash:
-    sha256: 7fe3dfd0d9d5d0dd7e650b42fc7d62ec5d643ac4275a77f483ec2b57f19c3e58
+    sha256: 8edfd97ff58ca616cdd6e77bc42d3f71d27842197f13771c77cf0b553f3b4311
   manager: pip
   name: fab-classic
   optional: false
   platform: linux-64
   source: null
-  url: https://files.pythonhosted.org/packages/86/f4/c301effc438788c184bbd0c08a586135f325581e6c4cf9f1d40229f9894b/fab_classic-1.19.1-py2.py3-none-any.whl
-  version: 1.19.1
+  url: https://files.pythonhosted.org/packages/6b/0f/efc537eebfd2a2c470250c0ac8bd8a05ffc13d95a7fb22021367890d7c46/fab_classic-1.19.2-py2.py3-none-any.whl
+  version: 1.19.2
 - category: main
   dependencies:
     asttokens: '>=2,<3'

--- a/conda-reqs.yaml
+++ b/conda-reqs.yaml
@@ -125,7 +125,7 @@ dependencies:
     - types-pytz
     - pip
     - pip:
-        - fab-classic==1.19.1
+        - fab-classic==1.19.2
         - mypy-boto3-ec2==1.21.9
         - sure==2.0.0
         - pylddwrap==1.2.1


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

fab-classic has logic to react to paramiko `SSHException` raised when server load is too high.  In this case, fab-classic should retry the connection until it gets to `env.connection_attempts` (see https://github.com/firesim/firesim/blob/0755382dae22e5be1e933a3e888bcadc1a7354c9/deploy/firesim#L437) and then raise `NetworkError`.

The logic in fab-classic 1.19.1 does not correctly match the paramiko exception message in all the required cases and incorrectly stops retrying the connection before reaching `env.connection_attempts` (it falls down a path where it aborts because the code thinks it should be querying the user for a password).

This fix makes the firesim manager more robust in environments where the server networking performance is struggling to keep up.

We may further want to catch `NetworkError` when in the `runworkload` monitoring loop so that hosts could be marked `???` for as long as we're unable to connect to them, rather than causing the monitoring loop to die so that the user is responsible for manually monitoring their workload and collecting results.  I leave that for a future PR.

#### Related PRs / Issues

<!-- List any related issues here -->

fab-classic#77 fixing fab-classic#76

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

No impact

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

No impact.

### Contributor Checklist
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you add Scaladoc/docstring/doxygen to every public function/method? **n/a**
- [X] Did you add at least one test demonstrating the PR? **n/a**
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you state the UI / API impact?
- [X] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [X] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [X] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [X] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
