### PR TITLE
Add ci:persist-prior-workflows tag to allow prior workflow to run until completion

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -41,6 +41,12 @@ Currently, the only way to access any running instance that is created from the 
 
 If the instance is stopped, then you must request a AWS IAM user account from the FireSim developers to access the EC2 console and restart the instance.
 
+Prior CI Jobs for Pull Requests
+------------------------------
+
+The default behavior is that a new commit to a PR will cancel any existing workflows that are still running. This is to save resources and is done by the `cancel-prior-workflows` job. If you wish to 
+allow all prior workflows to keep running, add the `ci:persist-prior-workflows` tag to your PR. Please use this tag sparingly, and with caution.
+
 GitHub Secrets
 --------------
 * **AWS_ACCESS_KEY_ID**: Passed to `aws configure` on CI containers + manager instances

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -28,6 +28,7 @@ env:
   LANGUAGE: "en_US:en"
   LC_ALL: "en_US.UTF-8"
   CI_LABEL_DEBUG: ${{ contains(github.event.pull_request.labels.*.name, 'ci:debug') }}
+  CI_LABEL_PERSIST: ${{ contains(github.event.pull_request.labels.*.name, 'ci:persist-prior-workflows') }}
 
 jobs:
   cancel-prior-workflows:
@@ -35,6 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel previous workflow runs
+        if: ${{ (env.CI_LABEL_PERSIST != 'true') }}
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}

--- a/sim/src/test/scala/bridges/TracerVSuite.scala
+++ b/sim/src/test/scala/bridges/TracerVSuite.scala
@@ -60,5 +60,5 @@ class TracerVF1TestCount1 extends TracerVTestBase(BaseConfigs.F1, 1);
 // This test is disabled until FireSim issue #1428 is resolved
 // class TracerVF1TestCount5 extends TracerVTestBase(BaseConfigs.F1, 5, Some(3), Some("FF0000001C")); // in hex
 class TracerVF1TestCount6 extends TracerVTestBase(BaseConfigs.F1, 6, Some(2), Some("3000")); // in hex
-class TracerVF1TestCount7 extends TracerVTestBase(BaseConfigs.F1, 7, Some(1), Some("8"));    // in decimala DELME These changes should not be merged
+class TracerVF1TestCount7 extends TracerVTestBase(BaseConfigs.F1, 7, Some(1), Some("9"));    // in decimala
 class TracerVVitisTest    extends TracerVTestBase(BaseConfigs.Vitis, 7);

--- a/sim/src/test/scala/bridges/TracerVSuite.scala
+++ b/sim/src/test/scala/bridges/TracerVSuite.scala
@@ -60,5 +60,5 @@ class TracerVF1TestCount1 extends TracerVTestBase(BaseConfigs.F1, 1);
 // This test is disabled until FireSim issue #1428 is resolved
 // class TracerVF1TestCount5 extends TracerVTestBase(BaseConfigs.F1, 5, Some(3), Some("FF0000001C")); // in hex
 class TracerVF1TestCount6 extends TracerVTestBase(BaseConfigs.F1, 6, Some(2), Some("3000")); // in hex
-class TracerVF1TestCount7 extends TracerVTestBase(BaseConfigs.F1, 7, Some(1), Some("9"));    // in decimala
+class TracerVF1TestCount7 extends TracerVTestBase(BaseConfigs.F1, 7, Some(1), Some("8"));    // in decimala DELME These changes should not be merged
 class TracerVVitisTest    extends TracerVTestBase(BaseConfigs.Vitis, 7);


### PR DESCRIPTION
This is a CI only change that adds a new tag `ci:persist-prior-workflows`. When present, this tag will NOT run the `cancel-prior-workflows` job.
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact
Developers will have a new tool that makes debugging CI issues easier.

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
No change.
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
