### PR TITLE
Add uartlog checking to Linux boots in CI

### DIFF
--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -17,7 +17,7 @@ def run_linux_poweroff_externally_provisioned():
 
     with prefix(f"cd {manager_fsim_dir} && source sourceme-f1-manager.sh"):
 
-        def run_w_timeout(workload_path, workload, timeout):
+        def run_w_timeout(workload_path, workload, timeout, num_passes):
             """ Run workload with a specific timeout
 
             :arg: workload_path (str) - workload abs path
@@ -84,9 +84,16 @@ def run_linux_poweroff_externally_provisioned():
                     print(f"Workload {workload} failed.")
                     sys.exit(rc)
                 else:
-                    print(f"Workload {workload} successful.")
+                    print(f"Workload run {workload} successful. Checking uartlogs...")
 
-        run_w_timeout(f"{manager_fsim_dir}/deploy/workloads", "linux-poweroff-all-no-nic.yaml", "45m")
+                    # verify that linux booted and the pass printout was given
+                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "*** PASSED ***" $LAST_DIR/*/uartlog; fi""")
+                    out_count = out.count('\n')
+                    assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
+
+                    print(f"Workload run {workload} successful.")
+
+        run_w_timeout(f"{manager_fsim_dir}/deploy/workloads", "linux-poweroff-all-no-nic.yaml", "45m", 2)
 
 if __name__ == "__main__":
     set_fabric_firesim_pem()


### PR DESCRIPTION
Very much overdue, but this adds a check for the `*** PASSED ***` string in the `uartlog` of simulations to ensure that Linux properly booted and finished. 

I noticed that the Vitis system booting Linux was broken due to some PR between current main and merging the `scala213` (RC bump) PR but it wasn't caught in CI (since the `uartlogs` were never checked). **This PR is expected to fail on booting Linux with Vitis**. That issue will be resolved in a future PR.

- [ ] Verify functionality of NIC simulation. Since the simulation tears down immediately when it detects that a node is finished, I assume that there should only be 1 simulation boot success signal. Is this correct?

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
