### PR TITLE
Add `build_farm_tag` field to AWS EC2 build farm recipe

### DIFF
--- a/.github/scripts/workflow-monitor.py
+++ b/.github/scripts/workflow-monitor.py
@@ -62,15 +62,18 @@ def main(platform: Platform, issue_id: int):
 
                 # check that select instances are terminated on time
                 platform_lib.check_and_terminate_run_farm_instances(45, ci_env['GITHUB_RUN_ID'], issue_id)
+                platform_lib.check_and_terminate_build_farm_instances(12, ci_env['GITHUB_RUN_ID'], issue_id)
 
                 if state_status in ['completed']:
                     if state_concl in TERMINATE_STATES:
                         platform_lib.check_and_terminate_run_farm_instances(0, ci_env['GITHUB_RUN_ID'], issue_id)
+                        platform_lib.check_and_terminate_build_farm_instances(0, ci_env['GITHUB_RUN_ID'], issue_id)
                         platform_lib.terminate_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
                         return
                     elif state_concl in STOP_STATES:
-                        # if we stop then we should terminate the run farm instances
+                        # if we stop then we should terminate the run/build farm instances
                         platform_lib.check_and_terminate_run_farm_instances(0, ci_env['GITHUB_RUN_ID'], issue_id)
+                        platform_lib.check_and_terminate_build_farm_instances(0, ci_env['GITHUB_RUN_ID'], issue_id)
                         platform_lib.stop_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
                         return
                     elif state_concl not in NOP_STATES:
@@ -93,6 +96,7 @@ def main(platform: Platform, issue_id: int):
         issue_post(ci_env['PERSONAL_ACCESS_TOKEN'], issue_id, post_str)
 
         platform_lib.check_and_terminate_run_farm_instances(0, ci_env['GITHUB_RUN_ID'], issue_id)
+        platform_lib.check_and_terminate_build_farm_instances(0, ci_env['GITHUB_RUN_ID'], issue_id)
         platform_lib.terminate_instances(ci_env['PERSONAL_ACCESS_TOKEN'], ci_env['GITHUB_RUN_ID'])
 
         post_str = f"Instances for CI run {ci_env['GITHUB_RUN_ID']} were supposedly terminated. Verify termination manually.\n"

--- a/deploy/build-farm-recipes/aws_ec2.yaml
+++ b/deploy/build-farm-recipes/aws_ec2.yaml
@@ -19,6 +19,8 @@
 build_farm_type: AWSEC2
 args:
     # managerinit arg start
+    # tag to apply to build farm hosts
+    build_farm_tag: mainbuildfarm
     # instance type to use per build
     instance_type: z1d.2xlarge
     # instance market to use per build (ondemand, spot)

--- a/deploy/buildtools/buildfarm.py
+++ b/deploy/buildtools/buildfarm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import abc
 import pprint
+import os
 
 from awstools.awstools import aws_resource_names, launch_instances, wait_on_instance_launches, get_instance_ids_for_instances, terminate_instances
 

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -802,6 +802,17 @@ Here is an example of this configuration file:
 .. literalinclude:: /../deploy/build-farm-recipes/aws_ec2.yaml
    :language: yaml
 
+``build_farm_tag``
+""""""""""""""""
+
+Use ``build_farm_tag`` to differentiate between different Build Farms in FireSim.
+Having multiple ``config_build.yaml`` files with different ``build_farm_tag``
+values allows you to run many groups of builds at once from the same manager instance.
+The instances launched by the ``buildbitstream`` command will be tagged with
+this value.
+
+Per AWS restrictions, this tag can be no longer than 255 characters.
+
 ``instance_type``
 """"""""""""""""""
 

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -805,11 +805,10 @@ Here is an example of this configuration file:
 ``build_farm_tag``
 """"""""""""""""
 
-Use ``build_farm_tag`` to differentiate between different Build Farms in FireSim.
-Having multiple ``config_build.yaml`` files with different ``build_farm_tag``
-values allows you to run many groups of builds at once from the same manager instance.
+Use ``build_farm_tag`` to differentiate between different Build Farms used across **multiple FireSim repositories**.
 The instances launched by the ``buildbitstream`` command will be tagged with
 this value.
+Mainly for CI use.
 
 Per AWS restrictions, this tag can be no longer than 255 characters.
 

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -803,7 +803,7 @@ Here is an example of this configuration file:
    :language: yaml
 
 ``build_farm_tag``
-""""""""""""""""
+""""""""""""""""""
 
 Use ``build_farm_tag`` to differentiate between different Build Farms used across **multiple FireSim repositories**.
 The instances launched by the ``buildbitstream`` command will be tagged with

--- a/docs/Advanced-Usage/Manager/Manager-Environment-Variables.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Environment-Variables.rst
@@ -20,4 +20,4 @@ This is useful for separating run farms between multiple copies of FireSim.
 --------------------------
 
 This environment variable is used to prefix all Build Farm tags with some prefix in the AWS EC2 case.
-This is useful for separating build farms between multiple copies of FireSim.
+This is mainly for CI use only.

--- a/docs/Advanced-Usage/Manager/Manager-Environment-Variables.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Environment-Variables.rst
@@ -14,9 +14,10 @@ by the manager.
 This environment variable is used to prefix all Run Farm tags with some prefix in the AWS EC2 case.
 This is useful for separating run farms between multiple copies of FireSim.
 
-This is set in ``sourceme-f1-manager.sh``, so you can change it and commit it
-(e.g. if you're maintaining a branch for special runs). It can be unset or set
-to the empty string.
+.. _buildfarm-prefix:
 
+``FIRESIM_BUILDFARM_PREFIX``
+--------------------------
 
-
+This environment variable is used to prefix all Build Farm tags with some prefix in the AWS EC2 case.
+This is useful for separating build farms between multiple copies of FireSim.

--- a/docs/Advanced-Usage/Manager/Manager-Environment-Variables.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Environment-Variables.rst
@@ -17,7 +17,7 @@ This is useful for separating run farms between multiple copies of FireSim.
 .. _buildfarm-prefix:
 
 ``FIRESIM_BUILDFARM_PREFIX``
---------------------------
+----------------------------
 
 This environment variable is used to prefix all Build Farm tags with some prefix in the AWS EC2 case.
 This is mainly for CI use only.


### PR DESCRIPTION
Adds a new `build_farm_tag` field to the AWS EC2 build farm recipe that follows the same conventions as the `run_farm_tag` for the AWS EC2 run farm recipe (i.e. also has an environment variable that can prefix to it). This also adds an unused CI check to verify that build instances are terminated after 12 or 14 hours (this will be used in a future CI `buildbitstream` PR). I believe that this is a cleaner solution to https://github.com/firesim/firesim/pull/1016 (one of the prior `buildbitstream` CI PR blockages).

- New `build_farm_tag` for AWS EC2 build farms (includes `FIRESIM_BUILDFARM_PREFIX` env. variable and `buildfarmprefix` AWS resource variable check's that can further append to the tag)
- CI to verify that build instances are shutdown after 12 or 14 hours.

#### Related PRs / Issues

#1016

#### UI / API Impact

New `build_farm_tag` for AWS EC2 build farms (includes `FIRESIM_BUILDFARM_PREFIX` env. variable and `buildfarmprefix` AWS resource variable check's that can further append to the tag)

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
