### PR TITLE
TracerV standard csv output include all valid instructions

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.cc
@@ -274,8 +274,6 @@ void tracerv_t::serialize(
                     OUTBUF[i + 0],
                     q,
                     OUTBUF[i + q + 1] & (~valid_mask));
-          } else {
-            break;
           }
         }
       }


### PR DESCRIPTION
TracerV standard CSV output did include to few instructions. There was a break instruction in the for loop which iterates over the traced instructions of one cycle and broke the loop once a not valid instruction is encountered. 
Sounds reasonable but the BOOM only proceeds to the next instruction group once the current group is fully committed. 

That means for a 4-wide boom one can have one cycle the first instruction committing and the next cycle the next 3 instructions of the group committing for which the first instruction would be invalid (as already committed). TracerV would output the first instruction and cycle normally, but fully skip the next cycle.