### PR TITLE
Revert to UInt64 for offsetConst in SerialBridge

### DIFF
--- a/sim/firesim-lib/src/main/scala/bridges/SerialBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/SerialBridge.scala
@@ -100,7 +100,7 @@ class SerialBridgeModule(serialBridgeParams: SerialBridgeParams)(implicit p: Par
           "serial",
           Seq(
               CppBoolean(serialBridgeParams.memoryRegionNameOpt.isDefined),
-              UInt32(offsetConst)
+              UInt64(offsetConst)
           ),
           hasLoadMem = true
       )


### PR DESCRIPTION
PR #1398 broke FireSim Rocket supernode builds. You can see here that the `mem_host_offset` is 64b wide: https://github.com/firesim/firesim/pull/1398/files#diff-098225fbdae21ed16399652d570908e98dc7918a7e98ccf118c689e41c3f0c3bL19. However, here you can see that the constructor generates a `UInt32` instead of originally a 64b int: https://github.com/firesim/firesim/pull/1398/files#diff-ba1d4635003f304c25f2a454cd7882c077b1ac291d846afd39dbc65003f35f65R103. This PR fixes this issue.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
