### PR TITLE
Fix uartlog checking in CI for Linux boot

### DIFF
--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -87,8 +87,11 @@ def run_linux_poweroff_externally_provisioned():
                     print(f"Workload run {workload} successful. Checking uartlogs...")
 
                     # verify that linux booted and the pass printout was given
-                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "*** PASSED ***" $LAST_DIR/*/uartlog; fi""")
-                    out_count = out.count('\n') - 1
+                    match_key = "*** PASSED ***"
+                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/uartlog; fi""")
+                    out_split = [e for e in out.split('\n') if match_key in e]
+                    print(f"DEBUG: out_split = {out_split}")
+                    out_count = len(out_split)
                     assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
 
                     print(f"Workload run {workload} successful.")

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -57,8 +57,11 @@ def run_linux_poweroff_vitis():
                     print(f"Workload run {workload} successful. Checking uartlogs...")
 
                     # verify that linux booted and the pass printout was given
-                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "*** PASSED ***" $LAST_DIR/*/uartlog; fi""")
-                    out_count = out.count('\n') - 1
+                    match_key = "*** PASSED ***"
+                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/uartlog; fi""")
+                    out_split = [e for e in out.split('\n') if match_key in e]
+                    print(f"DEBUG: out_split = {out_split}")
+                    out_count = len(out_split)
                     assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
 
                     print(f"Workload run {workload} successful.")

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -48,8 +48,11 @@ def run_linux_poweroff():
                     print(f"Workload run {workload} successful. Checking uartlogs...")
 
                     # verify that linux booted and the pass printout was given
-                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "*** PASSED ***" $LAST_DIR/*/uartlog; fi""")
-                    out_count = out.count('\n') - 1
+                    match_key = "*** PASSED ***"
+                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/uartlog; fi""")
+                    out_split = [e for e in out.split('\n') if match_key in e]
+                    print(f"DEBUG: out_split = {out_split}")
+                    out_count = len(out_split)
                     assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
 
                     print(f"Workload run {workload} successful.")

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -53,7 +53,7 @@ def run_linux_poweroff():
                     out_split = [e for e in out.split('\n') if match_key in e]
                     print(f"DEBUG: out_split = {out_split}")
                     out_count = len(out_split)
-                    assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
+                    assert out_count >= num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
 
                     print(f"Workload run {workload} successful.")
 


### PR DESCRIPTION
This fixes the uartlog checking for Linux boots by properly splitting the returned grep lines and measuring the output lines that still have `*** PASSED ***` in them.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
