### PR TITLE
Bump Verilator to 5.006

### DIFF
--- a/conda-reqs/conda-reqs.conda-lock.yml
+++ b/conda-reqs/conda-reqs.conda-lock.yml
@@ -19,7 +19,7 @@ metadata:
   - url: nodefaults
     used_env_vars: []
   content_hash:
-    linux-64: caf706f5c6b553daef8b247d2f4aa9eadd988e2ebc403b0ea9c010d0c4163e89
+    linux-64: 7b05d81c2506f26cb3c3e4bd874be25c42dc64e96aa7d3bec29963ad9b4e8a9c
   platforms:
   - linux-64
   sources:
@@ -2154,14 +2154,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: eca7396b6eaec18e000a4eaa1abfef94
-    sha256: 50d8ecfe84778f61150527972199c4bd4f77cb86519db6d0adc179b7842ed8bb
+    md5: 6f90f1dc834447823b11d155726fcb37
+    sha256: 6a6901f20c5b4d81aebd25a0645b3578ebb6a323f9fd7e87ee05ecbcfe19069e
   manager: conda
   name: filelock
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.9.1-pyhd8ed1ab_0.conda
-  version: 3.9.1
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.10.0-pyhd8ed1ab_0.conda
+  version: 3.10.0
 - category: main
   dependencies:
     expat: '>=2.5.0,<3.0a0'
@@ -2480,17 +2480,17 @@ package:
   version: 7.88.1
 - category: main
   dependencies:
-    gnutls: '>=3.7.6,<3.8.0a0'
+    gnutls: '>=3.7.8,<3.8.0a0'
     libgcc-ng: '>=12'
   hash:
-    md5: 78ff89df42ec0d4fe4355490d7843d9b
-    sha256: 780c82366caab4a741f2a4baa901a9b71fad6c2b8f1f64c168f10f61a939e9d4
+    md5: a946cb6b36807a772748b55f59089a08
+    sha256: 33ddfa3d91816ee44df405424ee2fedf5df5c02a1ffa1819aa4c956eedae4533
   manager: conda
   name: libmicrohttpd
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.75-h2603550_1.tar.bz2
-  version: 0.9.75
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.76-h87ba234_0.conda
+  version: 0.9.76
 - category: main
   dependencies:
     python: '>=3.4'
@@ -3238,18 +3238,19 @@ package:
     gxx_impl_linux-64: ''
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.12,<1.3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     make: ''
     perl: ''
+    python: ''
   hash:
-    md5: 41af6df1758bae89161daf268566384e
-    sha256: e2f2302d69c0d6928d95a1c699b5ef0b14e0243e78495734962c78136d2e6b9f
+    md5: 1a0130b3de431ee4dd26734a234a1cde
+    sha256: 12971e7e175a7dfb70d4afcf76e38d1ed21a979d49e215d439e7392de221a14d
   manager: conda
   name: verilator
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/verilator-4.226-he0ac6c6_1.tar.bz2
-  version: '4.226'
+  url: https://conda.anaconda.org/conda-forge/linux-64/verilator-5.006-h07cc95c_1.conda
+  version: '5.006'
 - category: main
   dependencies:
     gettext: '>=0.21.1,<1.0a0'
@@ -3635,14 +3636,14 @@ package:
     python_abi: 3.10.* *_cp310
     unicodedata2: '>=14.0.0'
   hash:
-    md5: c8a9099d7b381fa9860d4c68bbd7e7a3
-    sha256: 4a1bddf064521479280be397d422e7562673efb74868d0918ea590f9fa737ff0
+    md5: 3b354798e12b65fa8ebe1d189de6a507
+    sha256: 20b42570005cd3f6d961efa3ac1e389ef763a94224406a6f33121824390f5b71
   manager: conda
   name: fonttools
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.39.0-py310h1fa729e_0.conda
-  version: 4.39.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.39.2-py310h1fa729e_0.conda
+  version: 4.39.2
 - category: main
   dependencies:
     python: '>=3.4'
@@ -4890,14 +4891,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
   hash:
-    md5: 2f2dcca9573590c48aac9ec5cb5f8567
-    sha256: 2670863c3d5fd91f573f39050ba2c6c5803f77f88cdc88edf6ad44b35a72bfc8
+    md5: d06f5e49b8d79d996760ff5c67708609
+    sha256: d24f24e061121dd45eaf6efbf57440b57458fa363a272935faba39759d0d5fce
   manager: conda
   name: botocore
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.29.91-pyhd8ed1ab_0.conda
-  version: 1.29.91
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.29.92-pyhd8ed1ab_0.conda
+  version: 1.29.92
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -5158,7 +5159,7 @@ package:
   version: 5.1.1
 - category: main
   dependencies:
-    botocore: 1.29.91
+    botocore: 1.29.92
     colorama: '>=0.2.5,<0.4.5'
     docutils: '>=0.10,<0.17'
     python: '>=3.10,<3.11.0a0'
@@ -5167,14 +5168,14 @@ package:
     rsa: '>=3.1.2,<4.8'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 3faf9727eae30f6627e85e81c1bfaa72
-    sha256: f3efab5d78bd27e1a149ca9d31a384892684ba1f4b69c0689196afbe9e87811d
+    md5: 483cbb122f44d32d0f4d8c8f527aa38d
+    sha256: 0f33bb98a400786005d8042c354150b04f231e6329d2ba6341f68cbf5674c512
   manager: conda
   name: awscli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.27.91-py310hff52083_0.conda
-  version: 1.27.91
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.27.92-py310hff52083_0.conda
+  version: 1.27.92
 - category: main
   dependencies:
     azure-core: '>=1.24.0,<2.0.0'
@@ -5190,19 +5191,19 @@ package:
   version: 1.3.2
 - category: main
   dependencies:
-    botocore: '>=1.29.91,<1.30.0'
+    botocore: '>=1.29.92,<1.30.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.7'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: f0aba2f8fe2c2c7b3f78999262263ad3
-    sha256: 48d4ad5ef69596ee5de64ff6f698b571952a0a12208f8cdd925bd5c1bbce1c36
+    md5: fb2238965007f7899f6cb7617b8f2c08
+    sha256: 90defbc937014e83ff5153ec3249bcb7061d149f485e45c94145e147a86abfca
   manager: conda
   name: boto3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.26.91-pyhd8ed1ab_0.conda
-  version: 1.26.91
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.26.92-pyhd8ed1ab_0.conda
+  version: 1.26.92
 - category: main
   dependencies:
     cachecontrol: 0.12.11 pyhd8ed1ab_1
@@ -5376,14 +5377,14 @@ package:
     python: ''
     typing_extensions: ''
   hash:
-    md5: 84e24eeed37acfdf0dc0b79eaf63b785
-    sha256: 0df91414088feb5d051309b4c07d2e6ec002a6f31179bd8eaa1a4566bb65baea
+    md5: 530f871aa605e076280989939a624045
+    sha256: 44f96e1c189cc710232a99a39eda3a912ec75a2d11cad89bc29c1a742e44733d
   manager: conda
   name: boto3-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.26.91-pyhd8ed1ab_0.conda
-  version: 1.26.91
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.26.93-pyhd8ed1ab_0.conda
+  version: 1.26.93
 - category: main
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'
@@ -5487,14 +5488,14 @@ package:
     pyyaml: '>5.4'
     sarif-om: ~=1.0.4
   hash:
-    md5: b77c6c465ed0b1214bb464f5603c5b96
-    sha256: 453798fdb8af369b8c181de2598ab36c48202eb2861552b11198188e649dec3d
+    md5: 88dea77f70dbf54d3813ebd00265e333
+    sha256: bbd7d97781ef7ff134b3fcfd0308e85168f8a32da10c2343915f4f762bb25d70
   manager: conda
   name: cfn-lint
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-0.74.3-pyhd8ed1ab_0.conda
-  version: 0.74.3
+  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-0.75.0-pyhd8ed1ab_0.conda
+  version: 0.75.0
 - category: main
   dependencies:
     aws-xray-sdk: '!=0.96,>=0.93'

--- a/conda-reqs/firesim.yaml
+++ b/conda-reqs/firesim.yaml
@@ -83,9 +83,7 @@ dependencies:
     - graphviz
     - expect
     - dtc
-      # Pull in a newer build of verilator 4.226 that defaults to C++17 for verilation
-      # See https://github.com/verilator/verilator/issues/3588
-    - verilator==4.226=he0ac6c6_1
+    - verilator==5.006
     - screen
     - elfutils
     - libdwarf-dev==0.0.0.20190110_28_ga81397fc4 # from ucb-bar channel - using mainline libdwarf-feedstock

--- a/sim/make/cpp-lint.mk
+++ b/sim/make/cpp-lint.mk
@@ -26,7 +26,7 @@ clang_tidy_flags :=\
 	-I$(firesim_base_dir)/firesim-lib/src/main/cc \
 	-I$(firesim_base_dir)/src/main/cc/midasexamples \
 	-I$(testchipip_csrc_dir) \
-	-std=c++17 \
+	-std=c++20 \
 	-x c++
 
 # Checks the files in parallel without applying fixes.

--- a/sim/make/verilator.mk
+++ b/sim/make/verilator.mk
@@ -4,7 +4,7 @@
 # Verilator MIDAS-Level Simulators #
 ####################################
 
-VERILATOR_CXXOPTS ?= -O0
+VERILATOR_CXXOPTS ?= -O2
 VERILATOR_MAKEFLAGS ?= -j8 VM_PARALLEL_BUILDS=1
 
 verilator = $(GENERATED_DIR)/V$(DESIGN)

--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -52,18 +52,7 @@ $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM): $(DRIVER) $(driver_h) $(platform_o) $(bri
 driver: $(OUT_DIR)/$(DRIVER_NAME)-$(PLATFORM)
 
 # Sources for building MIDAS-level simulators. Must be defined before sources VCS/Verilator Makefrags
-override CXXFLAGS += -std=c++17 -include $(design_h)
-# Force verilator to obey our -std=c++17 from CXXFLAGS if it thinks it needs to add a -std argument to the compiler
-# by default, it will capture a -std argument during it's build using heuristics to try and match
-# the system-package for SystemC.
-# 1. we don't use SystemC
-# 2. the heuristics Verilator uses to capture -std at configure are incorrect for us
-# 3. Verilator output compiles and links for us fine with std=c++17
-# VERILATOR_FLAGS could do this with
-#   VERILATOR_FLAGS += -MAKEFLAGS CFG_CXXFLAGS_STD_NEWEST=
-# but we don't pass --build to it, we invoke the make build ourselves
-# see also https://github.com/verilator/verilator/issues/3588
-VERILATOR_MAKEFLAGS += CFG_CXXFLAGS_STD_NEWEST=
+override CXXFLAGS += -std=c++20 -include $(design_h)
 
 # Models of FPGA primitives that are used in host-level sim, but not in FPGATop
 sim_fpga_resource_models := $(v_dir)/BUFGCE.v

--- a/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
+++ b/sim/midas/src/main/cc/rtlsim/Makefrag-verilator
@@ -17,7 +17,7 @@
 #   (optional) verilator_conf: An verilator configuration file
 #   (optional) VERILATOR_FLAGS: extra flags depending on the target
 
-VERILATOR ?= verilator --cc --exe
+VERILATOR ?= verilator --cc --exe --timing
 verilator_v := $(emul_v) $(verilator_wrapper_v)
 verilator_cc := $(emul_cc) $(verilator_harness)
 
@@ -25,10 +25,15 @@ TIMESCALE_OPTS := $(shell verilator --version | perl -lne 'if (/(\d.\d+)/ && $$1
 override VERILATOR_FLAGS := \
 	$(TIMESCALE_OPTS) \
 	--top-module $(top_module) \
-	-Wno-STMTDLY \
 	-O3 \
+	-sv \
 	--output-split 10000 \
 	--output-split-cfuncs 100 \
+	-Wall \
+	-Wno-UNUSEDSIGNAL \
+	-Wno-DECLFILENAME \
+	-Wno-VARHIDDEN \
+	-Wno-UNDRIVEN \
 	-CFLAGS "$(CXXFLAGS) " \
 	-LDFLAGS "$(LDFLAGS) " \
 	$(VERILATOR_FLAGS)

--- a/sim/midas/src/main/verilog/BUFGCE.v
+++ b/sim/midas/src/main/verilog/BUFGCE.v
@@ -3,16 +3,8 @@ module BUFGCE(
   input      CE,
   output reg O
 );
-   reg       enable_latch;
-   always @(posedge I)
-     enable_latch <= CE;
-`ifdef VERILATOR
-   // Note: Verilator doesn't like procedural clock gates
-   // They cause combinational loop errors and UNOPT_FLAT
-   assign O = (I & enable_latch);
-`else
-   // Note: VCS doesn't like the Verilator clock gate
-   // Delays clock edge too much when CE is a register
+   /* verilator lint_off BLKSEQ */
+   // VCS/Verilator-v5 compatible clock gating
    // Blocking assignment makes behavior deterministic
    always @(posedge I or negedge I) begin
      if (CE)
@@ -20,5 +12,5 @@ module BUFGCE(
      else
        O = 1'h0;
    end
-`endif
+   /* verilator lint_on BLKSEQ */
 endmodule


### PR DESCRIPTION
Bumps Verilator to 5.006 (will combine with Chipyard's Verilator bump: https://github.com/ucb-bar/chipyard/pull/1398). A future PR will replace the C++ simulation top-level with a Verilog top-level (i.e. like what is done in Xcelium).

- Use C++20 across the board since Verilator `--timing` flag requires coroutine support provided in C++20
- Default to VCS's implementation of BUFGCE. The old implementation for Verilator would result in weird timing bugs starting from v5 (specifically for modules using the BUFGCE clock, register values would be not properly latched in).
- Bump to `O2` for C++ optimizations (`O2` should be sufficiently faster and still relatively bug-free)
- Add warning checks to Verilator (all the `-W...` args)
- Add support for SV constructs (since the files we use are `.sv`)

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
