### PR TITLE
Use FREQUENCY as a prereq in Vitis builds

### DIFF
--- a/platforms/vitis/cl_firesim/Makefile
+++ b/platforms/vitis/cl_firesim/Makefile
@@ -18,11 +18,13 @@ endif
 # taken from https://stackoverflow.com/questions/26145267/how-do-i-force-a-target-to-be-rebuilt-if-a-variable-is-set
 # variable argument to DEPENDABLE_VAR can be used as a prerequisite
 define DEPENDABLE_VAR
+
 .PHONY: phony
 $1: phony
-    @if [[ `cat $1 2>&1` != '$($1)' ]]; then \
-        echo -n $($1) > $1 ; \
-    fi
+	@if [[ `cat $1 2>&1` != '$($1)' ]]; then \
+		echo -n $($1) > $1 ; \
+	fi
+
 endef
 
 # Builds through vitis use the same tool (v++) for building xclbins destined

--- a/platforms/vitis/cl_firesim/Makefile
+++ b/platforms/vitis/cl_firesim/Makefile
@@ -2,7 +2,7 @@
 #
 # Assumptions:
 #   Host must be x86
-#   You have the Vitis 2020.2 + XRT tools installed
+#   You have the Vitis 2022.1 + XRT tools installed
 
 buildroot = $(abspath .)
 PROJECT_NAME := firesim
@@ -14,6 +14,16 @@ help::
 ifndef XILINX_VITIS
 	$(error XILINX_VITIS variable is not set, please set correctly and rerun)
 endif
+
+# taken from https://stackoverflow.com/questions/26145267/how-do-i-force-a-target-to-be-rebuilt-if-a-variable-is-set
+# variable argument to DEPENDABLE_VAR can be used as a prerequisite
+define DEPENDABLE_VAR
+.PHONY: phony
+$1: phony
+    @if [[ `cat $1 2>&1` != '$($1)' ]]; then \
+        echo -n $($1) > $1 ; \
+    fi
+endef
 
 # Builds through vitis use the same tool (v++) for building xclbins destined
 # for FPGA deployment and various simulation. This is controlled by the --target, -t flag
@@ -28,7 +38,7 @@ SIM_DIR        := $(buildroot)/simulation
 bitstream: TARGET = hw
 bitstream: VPP_TARGET_SPECIFIC_ARGS = --target $(TARGET) --config $(buildroot)/build-bitstream.cfg
 sim:       TARGET = hw_emu
-sim:       VPP_TARGET_SPECIFIC_ARGS = --target $(TARGET) --config $(buildroot)/simulation.cfg 
+sim:       VPP_TARGET_SPECIFIC_ARGS = --target $(TARGET) --config $(buildroot)/simulation.cfg
 run-sim:   TARGET = hw_emu
 run-sim:   VPP_TARGET_SPECIFIC_ARGS = --target $(TARGET) --config $(buildroot)/simulation.cfg
 
@@ -38,6 +48,9 @@ DEVICE ?= xilinx_u250_gen3x16_xdma_3_1_202020_1
 # Provide's the desired simulator frequency. This is generated from the clock
 # provided to the kernel using an internal MMCM.
 FREQUENCY ?= 90
+
+# declare FREQUENCY to be dependable
+$(eval $(call DEPENDABLE_VAR,FREQUENCY))
 
 # Selects a vitis config, by looking in build-strategies, for an equivalently
 # named cfg file.
@@ -134,7 +147,7 @@ $(sv_processed): $(sv_generated)
 
 ipgen_scripts = $(shell find design/ -iname "*.ipgen.tcl")
 
-%.xo: scripts/package_kernel.tcl scripts/gen_xo.tcl $(sv_processed) $(sv_defines) $(ipgen_scripts)
+%.xo: scripts/package_kernel.tcl scripts/gen_xo.tcl $(sv_processed) $(sv_defines) $(ipgen_scripts) FREQUENCY
 	mkdir -p $(@D)
 	# Move into the simulation or bitstream-build directory
 	cd $(@D)/..; $(VIVADO) -mode batch -source $(buildroot)/scripts/gen_xo.tcl \
@@ -203,4 +216,3 @@ run-sim: $(SIM_BINARY_CONTAINER) $(delivered_sim_inputs) $(emconfig)
 .PHONY: clean
 clean:
 	rm -rf $(SIM_DIR) $(BITSTREAM_DIR)
-


### PR DESCRIPTION
If you build a bitstream with a specific `FREQUENCY` given in the `config_build_recipe.yaml`, you will generate a `.xo` file using that frequency. However, if you update the recipe frequency without updating the build tuple, you will not regenerate the `.xo` file, hence keeping the same frequency until you do a `make clean` in the `cl_*` dir. This adds a new make function that allows you to add the `FREQUENCY` variable as a prereq., allowing it to regenerate the `.xo` file if changed.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
