### PR TITLE
Fix conda lockfile docs / make lockfile generation easier

### DIFF
--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -136,10 +136,9 @@ if [ "$IS_LIBRARY" = true ]; then
     fi
 else
     # note: lock file must end in .conda-lock.yml - see https://github.com/conda-incubator/conda-lock/issues/154
-    LOCKFILE="$RDIR/conda-reqs/conda-reqs.conda-lock.yml"
     if [ "$USE_PINNED_DEPS" = false ]; then
         # auto-gen the lockfile
-        conda-lock -f "$RDIR/conda-reqs/firesim.yaml" -f "$RDIR/conda-reqs/ci-shared.yaml" -p linux-64 --lockfile "$LOCKFILE"
+	./scripts/generate-conda-lockfile.sh
     fi
     conda-lock install -p $RDIR/.conda-env $LOCKFILE
     source $RDIR/.conda-env/etc/profile.d/conda.sh

--- a/build-setup-nolog.sh
+++ b/build-setup-nolog.sh
@@ -140,6 +140,7 @@ else
         # auto-gen the lockfile
 	./scripts/generate-conda-lockfile.sh
     fi
+    LOCKFILE="$(find $RDIR/conda-reqs/*.conda-lock.yml)"
     conda-lock install -p $RDIR/.conda-env $LOCKFILE
     source $RDIR/.conda-env/etc/profile.d/conda.sh
     conda activate $RDIR/.conda-env

--- a/docs/Developer-Docs/Managing-Conda-Lock-File.rst
+++ b/docs/Developer-Docs/Managing-Conda-Lock-File.rst
@@ -11,7 +11,7 @@ If developers want to update the requirements files, they should also update the
 There are two different methods:
 
 #. Running ``build-setup.sh --unpinned-deps``. This will update the lock file in place so that it can be committed and will re-setup the FireSim repository.
-#. Manually running ``conda-lock -f <conda requirements file> -f <conda requirements file> --lockfile <conda lock file>``
+#. Running ``./scripts/generate-conda-lockfile.sh``. This will update the lock file in place without setting up your directory.
 
 Caveats of the Conda Lock File and CI
 =====================================

--- a/scripts/generate-conda-lockfile.sh
+++ b/scripts/generate-conda-lockfile.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-REQS_DIR="$(pwd)/conda-reqs"
+CUR_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REQS_DIR="$CUR_DIR/../conda-reqs"
 if [ ! -d "$REQS_DIR" ]; then
   echo "$REQS_DIR does not exist, make sure you're calling this script from firesim/"
   exit 1

--- a/scripts/generate-conda-lockfile.sh
+++ b/scripts/generate-conda-lockfile.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+REQS_DIR="$(pwd)/conda-reqs"
+if [ ! -d "$REQS_DIR" ]; then
+  echo "$REQS_DIR does not exist, make sure you're calling this script from firesim/"
+  exit 1
+fi
+conda-lock -f "$REQS_DIR/firesim.yaml" -f "$REQS_DIR/ci-shared.yaml" -p linux-64 --lockfile "$REQS_DIR/conda-reqs.conda-lock.yml"


### PR DESCRIPTION
<!-- 
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Creates a callable script that is also used by build-setup.sh to generate the conda lockfile, which makes it easier to make changes to dependencies / move dependencies between ci-shared and general.
#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->
Only UI change is instead of manually running conda-lock, there is now a script that generates the lockfile.
#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [x] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
