### PR TITLE
Bump Conda to 22.11.1-4

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MACHINE_LAUNCH_DIR=/tmp
+export HOME="${HOME:-/root}"
 
 CONDA_INSTALL_PREFIX=/opt/conda
 CONDA_INSTALLER_VERSION=22.11.1-4
@@ -163,8 +164,8 @@ set -o pipefail
             conda_install_extra=""
             echo "::INFO:: installing conda to '$CONDA_INSTALL_PREFIX'"
         fi
-        # -b for non-interactive install, HOME overridden to ignore set -u errors
-        $SUDO HOME="/" ./install_conda.sh -b -p "$CONDA_INSTALL_PREFIX" $conda_install_extra
+        # -b for non-interactive install
+        $SUDO bash ./install_conda.sh -b -p "$CONDA_INSTALL_PREFIX" $conda_install_extra
         rm ./install_conda.sh
 
         # see https://conda-forge.org/docs/user/tipsandtricks.html#multiple-channels

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -3,7 +3,7 @@
 MACHINE_LAUNCH_DIR=/tmp
 
 CONDA_INSTALL_PREFIX=/opt/conda
-CONDA_INSTALLER_VERSION=4.12.0-0
+CONDA_INSTALLER_VERSION=22.11.1-4
 CONDA_INSTALLER="https://github.com/conda-forge/miniforge/releases/download/${CONDA_INSTALLER_VERSION}/Miniforge3-${CONDA_INSTALLER_VERSION}-Linux-x86_64.sh"
 CONDA_CMD="conda" # some installers install mamba or micromamba
 CONDA_ENV_NAME="firesim"
@@ -186,7 +186,7 @@ set -o pipefail
         # see https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
         $SUDO "$CONDA_EXE" install $DRY_RUN_OPTION -y -n base conda-libmamba-solver
         # Use the fast solver by default
-        "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --set experimental_solver libmamba
+        "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --set solver libmamba
 
         conda_init_extra_args=()
         if [[ "$INSTALL_TYPE" == system ]]; then

--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -163,8 +163,8 @@ set -o pipefail
             conda_install_extra=""
             echo "::INFO:: installing conda to '$CONDA_INSTALL_PREFIX'"
         fi
-        # -b for non-interactive install
-        $SUDO bash ./install_conda.sh -b -p "$CONDA_INSTALL_PREFIX" $conda_install_extra
+        # -b for non-interactive install, HOME overridden to ignore set -u errors
+        $SUDO HOME="/" ./install_conda.sh -b -p "$CONDA_INSTALL_PREFIX" $conda_install_extra
         rm ./install_conda.sh
 
         # see https://conda-forge.org/docs/user/tipsandtricks.html#multiple-channels


### PR DESCRIPTION
Bump Conda to fix `experimental_solver` flag removal. If `HOME` is unset, then set it to `/root`

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
