### PR TITLE
Dedup CI uartlog checking | Add more checks

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -1,4 +1,4 @@
-from fabric.api import env, run # type: ignore
+from fabric.api import env # type: ignore
 import requests
 
 from typing import Dict

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -1,4 +1,4 @@
-from fabric.api import env # type: ignore
+from fabric.api import env, run # type: ignore
 import requests
 
 from typing import Dict
@@ -36,3 +36,10 @@ def get_platform_lib(platform: Platform) -> PlatformLib:
         raise Exception(f"Azure not yet supported")
     else:
         raise Exception(f"Invalid platform: '{platform}'")
+
+def search_match_in_last_workloads_output_file(file_name: str = "uartlog", match_key: str = "*** PASSED ***") -> int:
+    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/{file_name}; fi""")
+    out_split = [e for e in out.split('\n') if match_key in e]
+    out_count = len(out_split)
+    print(f"Found {out_count} '{match_key}' strings in {file_name}")
+    return out_count

--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from fabric.api import prefix, settings, run, execute # type: ignore
 
-from common import manager_fsim_dir, set_fabric_firesim_pem
+from common import manager_fsim_dir, set_fabric_firesim_pem, search_match_in_last_workloads_output_file
 from ci_variables import ci_env
 sys.path.append(ci_env['GITHUB_WORKSPACE'] + "/deploy")
 from awstools.awstools import get_instances_with_filter, get_private_ips_for_instances
@@ -84,15 +84,24 @@ def run_linux_poweroff_externally_provisioned():
                     print(f"Workload {workload} failed.")
                     sys.exit(rc)
                 else:
-                    print(f"Workload run {workload} successful. Checking uartlogs...")
+                    print(f"Workload run {workload} successful. Checking workload files...")
 
-                    # verify that linux booted and the pass printout was given
-                    match_key = "*** PASSED ***"
-                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/uartlog; fi""")
-                    out_split = [e for e in out.split('\n') if match_key in e]
-                    print(f"DEBUG: out_split = {out_split}")
-                    out_count = len(out_split)
-                    assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
+                    file_name = 'uartlog'
+
+                    # first driver completed successfully
+                    match_key = '*** PASSED ***'
+                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+
+                    # verify login was reached (i.e. linux booted)
+                    match_key = 'buildroot login:'
+                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+
+                    # verify reaching poweroff
+                    match_key = 'Power down'
+                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
 
                     print(f"Workload run {workload} successful.")
 

--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -87,22 +87,18 @@ def run_linux_poweroff_externally_provisioned():
                 else:
                     print(f"Workload run {workload} successful. Checking workload files...")
 
-                    file_name = 'uartlog'
+                    def check(match_key, file_name = 'uartlog'):
+                        out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                        assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
 
                     # first driver completed successfully
-                    match_key = '*** PASSED ***'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+                    check('*** PASSED ***')
 
                     # verify login was reached (i.e. linux booted)
-                    match_key = 'buildroot login:'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+                    check('buildroot login:')
 
                     # verify reaching poweroff
-                    match_key = 'Power down'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+                    check('Power down')
 
                     print(f"Workload run {workload} successful.")
 

--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from fabric.api import prefix, settings, run, execute # type: ignore
 
-from common import manager_fsim_dir, set_fabric_firesim_pem, search_match_in_last_workloads_output_file
+from common import manager_fsim_dir, set_fabric_firesim_pem
+from utils import search_match_in_last_workloads_output_file
 from ci_variables import ci_env
 sys.path.append(ci_env['GITHUB_WORKSPACE'] + "/deploy")
 from awstools.awstools import get_instances_with_filter, get_private_ips_for_instances

--- a/.github/scripts/run-linux-poweroff-externally-provisioned.py
+++ b/.github/scripts/run-linux-poweroff-externally-provisioned.py
@@ -95,7 +95,7 @@ def run_linux_poweroff_externally_provisioned():
                     check('*** PASSED ***')
 
                     # verify login was reached (i.e. linux booted)
-                    check('buildroot login:')
+                    check('launching firemarshal workload')
 
                     # verify reaching poweroff
                     check('Power down')

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -59,22 +59,18 @@ def run_linux_poweroff_vitis():
                 else:
                     print(f"Workload run {workload} successful. Checking workload files...")
 
-                    file_name = 'uartlog'
+                    def check(match_key, file_name = 'uartlog'):
+                        out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                        assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
 
                     # first driver completed successfully
-                    match_key = '*** PASSED ***'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+                    check('*** PASSED ***')
 
                     # verify login was reached (i.e. linux booted)
-                    match_key = 'buildroot login:'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+                    check('buildroot login:')
 
                     # verify reaching poweroff
-                    match_key = 'Power down'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+                    check('Power down')
 
                     print(f"Workload run {workload} successful.")
 

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -4,6 +4,7 @@ import sys
 from fabric.api import prefix, run, settings, execute # type: ignore
 
 from ci_variables import ci_env
+from common import search_match_in_last_workloads_output_file
 
 def run_linux_poweroff_vitis():
     """ Runs Base Vitis Build """
@@ -56,15 +57,24 @@ def run_linux_poweroff_vitis():
                     print(f"Workload {workload} failed.")
                     sys.exit(rc)
                 else:
-                    print(f"Workload run {workload} successful. Checking uartlogs...")
+                    print(f"Workload run {workload} successful. Checking workload files...")
 
-                    # verify that linux booted and the pass printout was given
-                    match_key = "*** PASSED ***"
-                    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/uartlog; fi""")
-                    out_split = [e for e in out.split('\n') if match_key in e]
-                    print(f"DEBUG: out_split = {out_split}")
-                    out_count = len(out_split)
-                    assert out_count == num_passes, f"Uartlog is malformed for some runs: *** PASSED *** found {out_count} times (!= {num_passes}). Something went wrong."
+                    file_name = 'uartlog'
+
+                    # first driver completed successfully
+                    match_key = '*** PASSED ***'
+                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+
+                    # verify login was reached (i.e. linux booted)
+                    match_key = 'buildroot login:'
+                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
+
+                    # verify reaching poweroff
+                    match_key = 'Power down'
+                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                    assert out_count == num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
 
                     print(f"Workload run {workload} successful.")
 

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -67,7 +67,7 @@ def run_linux_poweroff_vitis():
                     check('*** PASSED ***')
 
                     # verify login was reached (i.e. linux booted)
-                    check('buildroot login:')
+                    check('launching firemarshal workload')
 
                     # verify reaching poweroff
                     check('Power down')

--- a/.github/scripts/run-linux-poweroff-vitis.py
+++ b/.github/scripts/run-linux-poweroff-vitis.py
@@ -4,7 +4,7 @@ import sys
 from fabric.api import prefix, run, settings, execute # type: ignore
 
 from ci_variables import ci_env
-from common import search_match_in_last_workloads_output_file
+from utils import search_match_in_last_workloads_output_file
 
 def run_linux_poweroff_vitis():
     """ Runs Base Vitis Build """

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 from fabric.api import prefix, settings, run, execute # type: ignore
 
-from common import manager_fsim_dir, set_fabric_firesim_pem, search_match_in_last_workloads_output_file
+from common import manager_fsim_dir, set_fabric_firesim_pem
+from utils import search_match_in_last_workloads_output_file
 from ci_variables import ci_env
 
 def run_linux_poweroff():

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -48,23 +48,18 @@ def run_linux_poweroff():
                 else:
                     print(f"Workload run {workload} successful. Checking workload files...")
 
-                    file_name = 'uartlog'
+                    def check(match_key, file_name = 'uartlog'):
+                        out_count = search_match_in_last_workloads_output_file(file_name, match_key)
+                        assert out_count >= num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (!= {num_passes}). Something went wrong."
 
                     # first driver completed successfully
-                    match_key = '*** PASSED ***'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count >= num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (< {num_passes}). Something went wrong."
+                    check('*** PASSED ***')
 
                     # verify login was reached (i.e. linux booted)
-                    match_key = 'buildroot login:'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count >= num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (< {num_passes}). Something went wrong."
+                    check('buildroot login:')
 
                     # verify reaching poweroff
-                    match_key = 'Power down'
-                    out_count = search_match_in_last_workloads_output_file(file_name, match_key)
-                    assert out_count >= num_passes, f"Workload {file_name} files are malformed: '{match_key}' found {out_count} times (< {num_passes}). Something went wrong."
-
+                    check('Power down')
 
                     print(f"Workload run {workload} successful.")
 

--- a/.github/scripts/run-linux-poweroff.py
+++ b/.github/scripts/run-linux-poweroff.py
@@ -56,7 +56,7 @@ def run_linux_poweroff():
                     check('*** PASSED ***')
 
                     # verify login was reached (i.e. linux booted)
-                    check('buildroot login:')
+                    check('launching firemarshal workload')
 
                     # verify reaching poweroff
                     check('Power down')

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -1,41 +1,4 @@
-from fabric.api import env, run # type: ignore
-import requests
-
-from typing import Dict
-
-from platform_lib import PlatformLib, AWSPlatformLib, AzurePlatformLib, Platform
-from ci_variables import ci_env
-from github_common import deregister_runners
-
-# Remote paths
-manager_home_dir = "/home/centos"
-manager_fsim_pem = manager_home_dir + "/firesim.pem"
-manager_fsim_dir = ci_env['MANAGER_FIRESIM_LOCATION']
-manager_marshal_dir = manager_fsim_dir + "/sw/firesim-software"
-manager_ci_dir = manager_fsim_dir + "/.github/scripts"
-
-# Common fabric settings
-env.output_prefix = False
-env.abort_on_prompts = True
-env.timeout = 100
-env.connection_attempts = 10
-env.disable_known_hosts = True
-env.keepalive = 60 # keep long SSH connections running
-
-def set_fabric_firesim_pem() -> None:
-    env.key_filename = manager_fsim_pem
-
-aws_platform_lib = AWSPlatformLib(deregister_runners)
-#azure_platform_lib = AzurePlatformLib(deregister_runners)
-
-def get_platform_lib(platform: Platform) -> PlatformLib:
-    if platform == Platform.AWS:
-        return aws_platform_lib
-    elif platform == Platform.AZURE:
-        #return azure_platform_lib
-        raise Exception(f"Azure not yet supported")
-    else:
-        raise Exception(f"Invalid platform: '{platform}'")
+from fabric.api import run # type: ignore
 
 def search_match_in_last_workloads_output_file(file_name: str = "uartlog", match_key: str = "*** PASSED ***") -> int:
     out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/{file_name}; fi""")

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -1,7 +1,7 @@
 from fabric.api import run # type: ignore
 
 def search_match_in_last_workloads_output_file(file_name: str = "uartlog", match_key: str = "*** PASSED ***") -> int:
-    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/{file_name}; fi""")
+    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/{file_name} || true; fi""")
     out_split = [e for e in out.split('\n') if match_key in e]
     out_count = len(out_split)
     print(f"Found {out_count} '{match_key}' strings in {file_name}")

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -36,3 +36,10 @@ def get_platform_lib(platform: Platform) -> PlatformLib:
         raise Exception(f"Azure not yet supported")
     else:
         raise Exception(f"Invalid platform: '{platform}'")
+
+def search_match_in_last_workloads_output_file(file_name: str = "uartlog", match_key: str = "*** PASSED ***") -> int:
+    out = run(f"""cd deploy/results-workload/ && LAST_DIR=$(ls | tail -n1) && if [ -d "$LAST_DIR" ]; then grep -n "{match_key}" $LAST_DIR/*/{file_name}; fi""")
+    out_split = [e for e in out.split('\n') if match_key in e]
+    out_count = len(out_split)
+    print(f"Found {out_count} '{match_key}' strings in {file_name}")
+    return out_count


### PR DESCRIPTION
Previously if there was a failure in Linux boot, that caused the system to "properly" shutdown, the FireSim driver would still print `*** PASSED***` since the target executed faithfully (see https://github.com/firesim/firesim/actions/runs/4564478489/jobs/8058662908#step:3:9173). This behavior was not checked by the CI (which only checked the `*** PASSED ***` string). Instead, we want to verify that we are able to get to the login prompt, and properly shut down. This PR fixes these checks while also deduping some of the logic to check misc. workload files.

- This PR should fail (expected since the current CI is broken) until #1487 is merged.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config.ini interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
