### PR TITLE
Create separate security group for build/run farm instances that is only accessible from within the firesim VPC

### DIFF
--- a/.github/scripts/launch-manager-instance.py
+++ b/.github/scripts/launch-manager-instance.py
@@ -30,7 +30,8 @@ def main():
         '--int_behavior', 'terminate',
         '--block_devices', str([{'DeviceName':'/dev/sda1','Ebs':{'VolumeSize':300,'VolumeType':'gp2'}}]),
         '--tags', str(aws_platform_lib.get_manager_tag_dict(ci_env['GITHUB_SHA'], ci_env['GITHUB_RUN_ID'])),
-        '--user_data_file', ci_env['GITHUB_WORKSPACE'] + "/scripts/machine-launch-script.sh"
+        '--user_data_file', ci_env['GITHUB_WORKSPACE'] + "/scripts/machine-launch-script.sh",
+        "--use_manager_security_group"
     ])
 
     print("Instance ready.")

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -229,7 +229,9 @@ def farm_security_group_setup() -> None:
 
     if len(firesimsecuritygroup) > 1:
         rootLogger.critical(f"Too many security groups named {securitygroupname}. Exiting.")
+        assert False
     elif len(firesimsecuritygroup) == 1:
+        rootLogger.debug(f"Security group {securitygroupname} already exists. Skipping setup.")
         return
 
     # at this point, we do not have the required security group, so create it

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -752,17 +752,17 @@ def main(args: List[str]) -> int:
 
     if parsed_args.command == "launch":
         insts = launch_instances(
-            parsed_args.inst_type,
-            parsed_args.inst_amt,
-            parsed_args.market,
-            parsed_args.int_behavior,
-            parsed_args.spot_max_price,
-            parsed_args.block_devices,
-            parsed_args.tags,
-            parsed_args.random_subnet,
-            parsed_args.user_data_file,
-            parsed_args.ami_id,
-            parsed_args.use_manager_security_group)
+            instancetype=parsed_args.inst_type,
+            count=parsed_args.inst_amt,
+            instancemarket=parsed_args.market,
+            spotinterruptionbehavior=parsed_args.int_behavior,
+            spotmaxprice=parsed_args.spot_max_price,
+            blockdevices=parsed_args.block_devices,
+            tags=parsed_args.tags,
+            randomsubnet=parsed_args.random_subnet,
+            user_data_file=parsed_args.user_data_file,
+            ami_id=parsed_args.ami_id,
+            use_manager_security_group=parsed_args.use_manager_security_group)
         instids = get_instance_ids_for_instances(insts)
         print("Instance IDs: {}".format(instids))
         wait_on_instance_launches(insts)

--- a/deploy/tests/awstools/test_awstools.py
+++ b/deploy/tests/awstools/test_awstools.py
@@ -111,11 +111,12 @@ class TestLaunchInstances(object):
     def test_invalid_instance_type_fails(self):
         # local imports of code-under-test ensure moto has mocks
         # registered before any possible calls out to AWS
-        from awstools.awstools import launch_instances, run_block_device_dict
+        from awstools.awstools import launch_instances, run_block_device_dict, farm_security_group_setup
 
         # launch_instances requires vpc setup as done by firesim/scripts/setup_firesim.py
         from awstools.aws_setup import aws_setup
         aws_setup()
+        farm_security_group_setup()
 
         with pytest.raises(Exception):
             instances = launch_instances('INVALID_TYPE', 1,
@@ -129,11 +130,12 @@ class TestLaunchInstances(object):
 
         # local imports of code-under-test ensure moto has mocks
         # registered before any possible calls out to AWS
-        from awstools.awstools import launch_instances, run_block_device_dict
+        from awstools.awstools import launch_instances, run_block_device_dict, farm_security_group_setup
 
         # launch_instances requires vpc setup as done by firesim/scripts/setup_firesim.py
         from awstools.aws_setup import aws_setup
         aws_setup()
+        farm_security_group_setup()
 
         instances = launch_instances('f1.2xlarge', 1,
                                      instancemarket="ondemand", spotinterruptionbehavior=None, spotmaxprice=None,
@@ -183,11 +185,12 @@ class TestLaunchInstances(object):
 
         # local imports of code-under-test ensure moto has mocks
         # registered before any possible calls out to AWS
-        from awstools.awstools import launch_instances, run_block_device_dict, get_instances_by_tag_type
+        from awstools.awstools import launch_instances, run_block_device_dict, get_instances_by_tag_type, farm_security_group_setup
 
         # launch_instances requires vpc setup as done by firesim/scripts/setup_firesim.py
         from awstools.aws_setup import aws_setup
         aws_setup()
+        farm_security_group_setup()
 
         tag1 = {'fsimcluster': 'testcluster'}
         type = 'f1.2xlarge'
@@ -254,11 +257,12 @@ class TestLaunchInstances(object):
 
         # local imports of code-under-test ensure moto has mocks
         # registered before any possible calls out to AWS
-        from awstools.awstools import launch_instances, run_block_device_dict
+        from awstools.awstools import launch_instances, run_block_device_dict, farm_security_group_setup
 
         # launch_instances requires vpc setup as done by firesim/scripts/setup_firesim.py
         from awstools.aws_setup import aws_setup
         aws_setup()
+        farm_security_group_setup()
 
         type = 'f1.2xlarge'
 
@@ -294,11 +298,12 @@ class TestLaunchInstances(object):
 
         # local imports of code-under-test ensure moto has mocks
         # registered before any possible calls out to AWS
-        from awstools.awstools import launch_instances, run_block_device_dict
+        from awstools.awstools import launch_instances, run_block_device_dict, farm_security_group_setup
 
         # launch_instances requires vpc setup as done by firesim/scripts/setup_firesim.py
         from awstools.aws_setup import aws_setup
         aws_setup()
+        farm_security_group_setup()
 
         type = 'f1.2xlarge'
 
@@ -314,11 +319,12 @@ class TestLaunchInstances(object):
 
         # local imports of code-under-test ensure moto has mocks
         # registered before any possible calls out to AWS
-        from awstools.awstools import launch_instances, run_block_device_dict
+        from awstools.awstools import launch_instances, run_block_device_dict, farm_security_group_setup
 
         # launch_instances requires vpc setup as done by firesim/scripts/setup_firesim.py
         from awstools.aws_setup import aws_setup
         aws_setup()
+        farm_security_group_setup()
 
         type = 'f1.2xlarge'
 

--- a/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -33,7 +33,7 @@ To launch a manager instance, follow these steps:
 #. In the *Name* field, give the instance a recognizable name, for example ``firesim-manager-1``. This is purely for your own convenience and can also be left blank.
 #. In the *Application and OS Images* search box, search for
    ``FPGA Developer AMI - 1.12.1-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and
-   select the AMI that appears under the ***Community AMIs*** tab (there
+   select the AMI that appears under the **Community AMIs** tab (there
    should be only one). **DO NOT USE ANY OTHER VERSION.** For example, **do not** use `FPGA Developer AMI` from the *AWS Marketplace AMIs* tab, as you will likely get an incorrect version of the AMI.
 #. In the *Instance Type* drop-down, select the instance type of
    your choosing. A good choice is a ``c5.4xlarge`` (16 cores, 32 GiB) or a ``z1d.2xlarge`` (8 cores, 64 GiB).
@@ -43,7 +43,7 @@ To launch a manager instance, follow these steps:
    #. Under *VPC - required*, select the ``firesim`` VPC. Any subnet within the ``firesim`` VPC is fine.
    #. Under *Firewall (security groups)*, click *Select existing security
       group* and in the *Common security groups* dropdown that appears, select the ``firesim`` security group that was automatically
-      created for you earlier.
+      created for you earlier. Do **NOT** select the ``for-farms-only-firesim`` security group that might also be in the list (it is also fine if this group does not appear in your list).
 
 #. In the *Configure storage* section, increase the size of the root
    volume to at least 300GB. The default of 85GB can quickly become too small as


### PR DESCRIPTION
The new setup is:
* `firesim` security group is the same as before, used for managers
* `for-farms-only-firesim` security group is created in `firesim managerinit` if it does not already exist in the user's account. This is created with ingress allowed only from within the VPC.

This means all users will get naturally updated to the new setup the first time they run firesim managerinit with a version of firesim with this PR merged in. Old firesim installations/managers will continue to work as normal.

The CI setup should also get upgraded naturally via this process.

Added a clarifying note to the manager setup docs that `for-farms-only-firesim` should not be used for managers. First-time users will not have this security group when they create their first manager instance anyway.

#### Related PRs / Issues

N/A

#### UI / API Impact

We always instructed accessing build/run farm instances from the manager, so no change. Users will get an extra message the first time they run firesim managerinit on an aws account stating that this new security group is being created.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
