### PR TITLE
Manager support for custom TARGET_PROJECT

### DIFF
--- a/deploy/runtools/firesim_topology_with_passes.py
+++ b/deploy/runtools/firesim_topology_with_passes.py
@@ -316,8 +316,8 @@ class FireSimTopologyWithPasses:
             RuntimeHWConfig object then keep it the same.
             2) If a node's hardware config is none, give it the default
             hardware config.
-            3) In either case, call get_deploytriplet_for_config() once to
-            make the API call and cache the result for the deploytriplet.
+            3) In either case, call get_deployquadruplet_for_config() once to
+            make the API call and cache the result for the deployquadruplet.
         """
         servers = self.firesimtopol.get_dfs_order_servers()
 
@@ -331,7 +331,7 @@ class FireSimTopologyWithPasses:
                 hw_cfg = runtimehwconfig_lookup_fn(self.defaulthwconfig)
             elif isinstance(hw_cfg, str):
                 hw_cfg = runtimehwconfig_lookup_fn(hw_cfg)
-            hw_cfg.get_deploytriplet_for_config()
+            hw_cfg.get_deployquadruplet_for_config()
             server.set_server_hardware_config(hw_cfg)
 
     def pass_apply_default_params(self) -> None:

--- a/deploy/sample-backup-configs/sample_config_build_recipes.yaml
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.yaml
@@ -12,7 +12,7 @@
 #    DESIGN: <>
 #    TARGET_CONFIG: <>
 #    PLATFORM_CONFIG: Config
-#    deploy_triplet: null
+#    deploy_quadruplet: null
 #    # NOTE: these platform_config_args are for F1 only
 #    # they should be set to null if using another platform
 #    platform_config_args:
@@ -30,10 +30,11 @@
 # Quad-core, Rocket-based recipes
 # REQUIRED FOR TUTORIALS
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.QuadRocketConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 90
         build_strategy: TIMING
@@ -44,10 +45,11 @@ firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
 # NB: This has a faster host-clock frequency than the NIC-based design, because
 # its uncore runs at half rate relative to the tile.
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.QuadRocketConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 140
         build_strategy: TIMING
@@ -58,10 +60,11 @@ firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
 # Single-core, BOOM-based recipes
 # REQUIRED FOR TUTORIALS
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.LargeBoomConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 65
         build_strategy: TIMING
@@ -72,10 +75,11 @@ firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
 # NB: This has a faster host-clock frequency than the NIC-based design, because
 # its uncore runs at half rate relative to the tile.
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 65
         build_strategy: TIMING
@@ -85,10 +89,11 @@ firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
 
 # Single-core, CVA6-based recipes
 firesim_cva6_singlecore_no_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 90
         build_strategy: TIMING
@@ -98,10 +103,11 @@ firesim_cva6_singlecore_no_nic_l2_llc4mb_ddr3:
 
 # Single-core, Rocket-based recipes with Gemmini
 firesim_rocket_singlecore_gemmini_no_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 110
         build_strategy: TIMING
@@ -111,10 +117,11 @@ firesim_rocket_singlecore_gemmini_no_nic_l2_llc4mb_ddr3:
 
 # RAM Optimizations enabled by adding _MCRams PLATFORM_CONFIG string
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3_ramopts:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomConfig
     PLATFORM_CONFIG: WithAutoILA_MCRams_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 90
         build_strategy: TIMING
@@ -124,10 +131,11 @@ firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3_ramopts:
 
 # Supernode configurations -- multiple instances of an SoC in a single simulator
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_SupernodeFireSimRocketConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 85
         build_strategy: TIMING
@@ -141,7 +149,7 @@ midasexamples_gcd:
     DESIGN: GCD
     TARGET_CONFIG: NoConfig
     PLATFORM_CONFIG: DefaultF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 75
         build_strategy: TIMING
@@ -151,10 +159,11 @@ midasexamples_gcd:
 
 # Additional Tutorial Config
 firesim_rocket_singlecore_no_nic_l2_lbp:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.RocketConfig
     PLATFORM_CONFIG: BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 90
         build_strategy: TIMING
@@ -164,10 +173,11 @@ firesim_rocket_singlecore_no_nic_l2_lbp:
 
 # Additional Tutorial Config
 firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
     PLATFORM_CONFIG: BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 65
         build_strategy: TIMING
@@ -177,10 +187,11 @@ firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
 
 # Additional Tutorial Config
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
     PLATFORM_CONFIG: BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 65
         build_strategy: TIMING
@@ -190,10 +201,11 @@ firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
 
 # Additional Tutorial Config
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: DDR3FRFCFSLLC4MB_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketPrintfConfig
     PLATFORM_CONFIG: WithPrintfSynthesis_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 30
         build_strategy: TIMING
@@ -203,10 +215,11 @@ firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
 
 # Additional Vitis/XRT-only Config
 vitis_firesim_rocket_singlecore_no_nic:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocketMMIOOnlyConfig
     PLATFORM_CONFIG: BaseVitisConfig
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 140
         build_strategy: TIMING
@@ -217,10 +230,11 @@ vitis_firesim_rocket_singlecore_no_nic:
 # Additional Tutorial Config
 # Additional Vitis/XRT-only Config
 vitis_firesim_gemmini_rocket_singlecore_no_nic:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLeanGemminiRocketMMIOOnlyConfig
     PLATFORM_CONFIG: BaseVitisConfig
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 30
         build_strategy: TIMING
@@ -230,10 +244,11 @@ vitis_firesim_gemmini_rocket_singlecore_no_nic:
 
 # Additional Tutorial Config
 firesim_gemmini_rocket_singlecore_no_nic:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLeanGemminiRocketConfig
     PLATFORM_CONFIG: BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 30 # AJG: conservative for now, later sweep for higher frequency
         build_strategy: TIMING
@@ -243,10 +258,11 @@ firesim_gemmini_rocket_singlecore_no_nic:
 
 # Additional Tutorial Config
 firesim_gemmini_printf_rocket_singlecore_no_nic:
+    TARGET_PROJECT: firesim
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLeanGemminiPrintfRocketConfig
     PLATFORM_CONFIG: WithPrintfSynthesis_BaseF1Config
-    deploy_triplet: null
+    deploy_quadruplet: null
     platform_config_args:
         fpga_frequency: 10 # AJG: conservative for now, later sweep for higher frequency
         build_strategy: TIMING

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -1,7 +1,7 @@
 # Hardware config database for FireSim Simulation Manager
 # See https://docs.fires.im/en/stable/Advanced-Usage/Manager/Manager-Configuration-Files.html for documentation of all of these params.
 
-# Hardware configs represent a combination of an agfi, a deploytriplet override
+# Hardware configs represent a combination of an agfi, a deployquadruplet override
 # (if needed), and a custom runtime config (if needed)
 
 # The AGFIs provided below are public and available to all users.
@@ -12,54 +12,54 @@
 # DOCREF START: Example HWDB Entry
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
     agfi: agfi-0ac731f61d3f31817
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
     agfi: agfi-0a60b1241fe70aad8
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
     agfi: agfi-0c82dc422cf6408a9
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
     agfi: agfi-09a9331f468822063
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
     agfi: agfi-074d5fb88949da9e3
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_no_nic_l2_lbp:
     agfi: agfi-0bd3e59a6291be8d8
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
     agfi: agfi-0a3aa8485fc964a28
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
     agfi: agfi-037fd4a1261e58c73
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
     agfi: agfi-037978a7a54662358
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_gemmini_printf_rocket_singlecore_no_nic:
     agfi: agfi-03d8cc99122d5fb41
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 firesim_gemmini_rocket_singlecore_no_nic:
     agfi: agfi-09127fbc65317005a
-    deploy_triplet_override: null
+    deploy_quadruplet_override: null
     custom_runtime_config: null
 vitis_firesim_rocket_singlecore_no_nic:
     xclbin: https://firesim-ci-vitis-xclbins.s3.us-west-2.amazonaws.com/vitis_firesim_rocket_singlecore_no_nic_c12936.xclbin
-    deploy_triplet_override: FireSim-FireSimRocketMMIOOnlyConfig-BaseVitisConfig
+    deploy_quadruplet_override: firesim-FireSim-FireSimRocketMMIOOnlyConfig-BaseVitisConfig
     custom_runtime_config: null
 vitis_firesim_gemmini_rocket_singlecore_no_nic:
     xclbin: https://firesim-ci-vitis-xclbins.s3.us-west-2.amazonaws.com/vitis_firesim_gemmini_rocket_singlecore_no_nic_36bfe5.xclbin
-    deploy_triplet_override: FireSim-FireSimLeanGemminiRocketMMIOOnlyConfig-BaseVitisConfig
+    deploy_quadruplet_override: firesim-FireSim-FireSimLeanGemminiRocketMMIOOnlyConfig-BaseVitisConfig
     custom_runtime_config: null

--- a/deploy/tests/test_yaml_api.py
+++ b/deploy/tests/test_yaml_api.py
@@ -244,7 +244,7 @@ class TestConfigBuildAPI:
             testing_recipe_name:
                 DESIGN: TopModule
                 TARGET_CONFIG: Config
-                deploy_triplet: null
+                deploy_quadruplet: null
                 PLATFORM_CONFIG: Config
                 platform_config_args:
                     fpga_frequency: 123

--- a/docs/Advanced-Usage/Manager/AGFI-Tagging.rst
+++ b/docs/Advanced-Usage/Manager/AGFI-Tagging.rst
@@ -6,6 +6,7 @@ populated with metadata that helps the manager decide how to deploy
 a simulation. The important metadata is listed below, along with how each field
 is set and used:
 
-- ``firesim-buildtriplet``: This always reflects the triplet combination used to BUILD the AGFI.
-- ``firesim-deploytriplet``: This reflects the triplet combination that is used to DEPLOY the AGFI. By default, this is the same as ``firesim-buildtriplet``. In certain cases however, your users may not have access to a particular configuration, but a simpler configuration may be sufficient for building a compatible software driver (e.g. if you have proprietary RTL in your FPGA image that doesn't interface with the outside system). In this case, you can specify a custom deploytriplet at build time. If you do not do so, the manager will automatically set this to be the same as ``firesim-buildtriplet``.
+- ``firesim-buildquadruplet``: This always reflects the quadruplet combination used to BUILD the AGFI.
+- ``firesim-deployquadruplet``: This reflects the quadruplet combination that is used to DEPLOY the AGFI. By default, this is the same as ``firesim-buildquadruplet``. In certain cases however, your users may not have access to a particular configuration, but a simpler configuration may be sufficient for building a compatible software driver (e.g. if you have proprietary RTL in your FPGA image that doesn't interface with the outside system). In this case, you can specify a custom deployquadruplet at build time. If you do not do so, the manager will automatically set this to be the same as ``firesim-buildquadruplet``.
 - ``firesim-commit``: This is the commit hash of the version of FireSim used to build this AGFI. If the AGFI was created from a dirty copy of the FireSim repo, "-dirty" will be appended to the commit hash.
+

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -328,7 +328,7 @@ configuration in ``config_hwdb.yaml``. For example, to share the hardware config
     firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
         # this is a comment that describes my favorite configuration!
         agfi: agfi-0a6449b5894e96e53
-        deploy_triplet_override: null
+        deploy_quadruplet_override: null
         custom_runtime_config: null
 
 you would use:
@@ -420,16 +420,6 @@ platforms, but try to optimize for the same things. Strategies supported across 
 
 Names are derived AWS's strategy set.
 
-``deploy_triplet``
-""""""""""""""""""
-
-This allows you to override the ``deploytriplet`` stored with the AGFI.
-Otherwise, the ``DESIGN``/``TARGET_CONFIG``/``PLATFORM_CONFIG`` you specify
-above will be used. See the AGFI Tagging section for more details. Most likely,
-you should leave this set to ``null``. This is usually only used if you have
-proprietary RTL that you bake into an FPGA image, but don't want to share with
-users of the simulator.
-
 ``TARGET_PROJECT`` `(Optional)`
 """""""""""""""""""""""""""""""
 
@@ -439,6 +429,16 @@ in greater detail :ref:`here<generating-different-targets>`).  If
 Setting ``TARGET_PROJECT`` is required for building the MIDAS examples
 (``TARGET_PROJECT: midasexamples``) with the manager, or for building a
 user-provided target project.
+
+``deploy_quadruplet``
+""""""""""""""""""""""""""
+
+This allows you to override the ``deployquadruplet`` stored with the AGFI.
+Otherwise, the ``TARGET_PROJECT``/``DESIGN``/``TARGET_CONFIG``/``PLATFORM_CONFIG`` you specify
+above will be used. See the AGFI Tagging section for more details. Most likely,
+you should leave this set to ``null``. This is usually only used if you have
+proprietary RTL that you bake into an FPGA image, but don't want to share with
+users of the simulator.
 
 ``post_build_hook``
 """""""""""""""""""""""
@@ -491,7 +491,7 @@ Here is a sample of this configuration file:
 This file tracks hardware configurations that you can deploy as simulated nodes
 in FireSim. Each such configuration contains a name for easy reference in higher-level
 configurations, defined in the section header, an handle to a bitstream (an AGFI or ``xclbin`` path), which represents the
-FPGA image, a custom runtime config, if one is needed, and a deploy triplet
+FPGA image, a custom runtime config, if one is needed, and a deploy quadruplet
 override if one is necessary.
 
 When you build a new bitstream, you should put the default version of it in this
@@ -526,11 +526,11 @@ Indicates where the bitstream (FPGA Image) is located, may be one of:
   * A Uniform Resource Identifier (URI), (see :ref:`uri-path-support` for details)
   * A filesystem path available to the manager. Local paths are relative to the `deploy` folder.
 
-``deploy_triplet_override``
+``deploy_quadruplet_override``
 """""""""""""""""""""""""""""
 
 This is an advanced feature - under normal conditions, you should leave this set to ``null``, so that the
-manager uses the configuration triplet that is automatically stored with the
+manager uses the configuration quadruplet that is automatically stored with the
 bitstream metadata at build time. Advanced users can set this to a different
 value to build and use a different driver when deploying simulations. Since
 the driver depends on logic now hardwired into the
@@ -572,7 +572,7 @@ Add more hardware config sections, like ``NAME_GOES_HERE_2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can add as many of these entries to ``config_hwdb.yaml`` as you want, following the format
-discussed above (i.e. you provide ``agfi`` or ``xclbin``, ``deploy_triplet_override``, and ``custom_runtime_config``).
+discussed above (i.e. you provide ``agfi`` or ``xclbin``, ``deploy_quadruplet_override``, and ``custom_runtime_config``).
 
 .. _run-farm-recipe:
 

--- a/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Configuration-Files.rst
@@ -527,7 +527,7 @@ Indicates where the bitstream (FPGA Image) is located, may be one of:
   * A filesystem path available to the manager. Local paths are relative to the `deploy` folder.
 
 ``deploy_quadruplet_override``
-"""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 This is an advanced feature - under normal conditions, you should leave this set to ``null``, so that the
 manager uses the configuration quadruplet that is automatically stored with the

--- a/docs/Advanced-Usage/Manager/Manager-Tasks.rst
+++ b/docs/Advanced-Usage/Manager/Manager-Tasks.rst
@@ -318,7 +318,7 @@ is a rough outline of what the command does:
 - Constructs the internal representation of your simulation. This is a tree of
   components in the simulation (simulated server blades, switches)
 - For each type of server blade, rebuild the software simulation driver by querying
-  the bitstream metadata to get the build-triplet or using its override
+  the bitstream metadata to get the build-quadruplet or using its override
 - For each type of switch in the simulation, generate the switch model binary
 - For each host instance in the Run Farm, collect information about all the
   resources necessary to run a simulation on that host instance, then copy

--- a/docs/Advanced-Usage/Supernode.rst
+++ b/docs/Advanced-Usage/Supernode.rst
@@ -69,7 +69,7 @@ configurations.  For example:
     DESIGN: FireSim
     TARGET_CONFIG: SupernodeFireSimQuadRocketConfig
     PLATFORM_CONFIG: BaseF1Config
-    deploy_triplet: None
+    deploy_quadruplet: None
 
 
 We currently provide a single pre-built AGFI for supernode of 4 quad-core

--- a/docs/Advanced-Usage/Supernode.rst
+++ b/docs/Advanced-Usage/Supernode.rst
@@ -69,7 +69,7 @@ configurations.  For example:
     DESIGN: FireSim
     TARGET_CONFIG: SupernodeFireSimQuadRocketConfig
     PLATFORM_CONFIG: BaseF1Config
-    deploy_quadruplet: None
+    deploy_quadruplet: null
 
 
 We currently provide a single pre-built AGFI for supernode of 4 quad-core

--- a/docs/Golden-Gate/Resource-Optimizations.rst
+++ b/docs/Golden-Gate/Resource-Optimizations.rst
@@ -47,7 +47,7 @@ class to the platform configuration, as shown in the following example build rec
         DESIGN: FireSim
         TARGET_CONFIG: WithNIC_DDR3FRFCFSLLC4MB_FireSimLargeBoomConfig
         PLATFORM_CONFIG: MCRams_BaseF1Config
-        deploy_triplet: null
+        deploy_quadruplet: null
 
 
 Multi-Threading of Repeated Instances
@@ -71,7 +71,7 @@ example build recipe:
         DESIGN: FireSim
         TARGET_CONFIG: WithNIC_DDR3FRFCFSLLC4MB_FireSimQuadRocketConfig
         PLATFORM_CONFIG: MTModels_BaseF1Config
-        deploy_triplet: null
+        deploy_quadruplet: null
 
 This simulator configuration will rely on a single threaded model to simulate the four Rocket tiles.
 However, it will still produce bit- and cycle-identical results to any other platform configuration
@@ -89,4 +89,4 @@ partitioning.
         DESIGN: FireSim
         TARGET_CONFIG: MyMultiCoreBoomConfig
         PLATFORM_CONFIG: MTModels_MCRams_BaseF1Config
-        deploy_triplet: null
+        deploy_quadruplet: null

--- a/docs/Running-OnPrem-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
+++ b/docs/Running-OnPrem-Simulations-Tutorial/Running-a-Single-Node-Simulation.rst
@@ -148,7 +148,6 @@ You should expect output like the following:
 	FireSim Manager. Docs: https://docs.fires.im
 	Running: launchrunfarm
 
-	firesim_rocket_singlecore_no_nic is overriding a deploy triplet in your config_hwdb.yaml file. Make sure you understand why!
 	WARNING: Skipping launchrunfarm since run hosts are externally provisioned.
 	The full log of this run is:
 	.../firesim/deploy/logs/2023-03-06--00-20-37-launchrunfarm-24T0KOGRHBMSHAV5.log
@@ -173,7 +172,6 @@ For a complete run, you should expect output like the following:
 	$ firesim infrasetup                                                                                                                                                                                                        FireSim Manager. Docs: https://docs.fires.im
 	Running: infrasetup
 
-	firesim_rocket_singlecore_no_nic is overriding a deploy triplet in your config_hwdb.yaml file. Make sure you understand why!
 	Building FPGA software driver for FireSim-FireSimRocketConfig-BaseVitisConfig
 	...
 	[localhost] Checking if host instance is up...
@@ -211,7 +209,6 @@ nodes every 10s. When you do this, you will initially see output like:
 	FireSim Manager. Docs: https://docs.fires.im
 	Running: runworkload
 
-	firesim_rocket_singlecore_no_nic is overriding a deploy triplet in your config_hwdb.yaml file. Make sure you understand why!
 	Creating the directory: .../firesim/deploy/results-workload/2023-03-06--01-25-34-linux-uniform/
 	[localhost] Checking if host instance is up...
 	[localhost] Starting FPGA simulation for slot: 0.
@@ -403,7 +400,6 @@ Which should present you with the following:
 	FireSim Manager. Docs: https://docs.fires.im
 	Running: terminaterunfarm
 
-	firesim_rocket_singlecore_no_nic is overriding a deploy triplet in your config_hwdb.yaml file. Make sure you understand why!
 	WARNING: Skipping terminaterunfarm since run hosts are externally provisioned.
 	The full log of this run is:
 	.../firesim/deploy/logs/2023-03-06--01-34-45-terminaterunfarm-YFXAJCRGF8KF4LQ3.log


### PR DESCRIPTION
This PR updates the manager to support arbitrary `TARGET_PROJECT`s instead of only `firesim`. In effect, all mentions of `triplet`s (consisting of `(DESIGN, TARGET_CONFIG, PLATFORM_CONFIG)`) become `quadruplet`s (consisting of `(TARGET_PROJECT, DESIGN, TARGET_CONFIG, PLATFORM_CONFIG)`).

This adds support for all manager features except producing the command to run a simulation (this needs some more thinking). But building bitstreams/metasims and doing everything up to and including infrasetup (and then running the sim by hand on the run farm instance) works as expected.

This should be fully backwards compatible with existing AGFIs and config yaml files (see below).

This also adds a fix so that the manager doesn't complain about `deploy_quadruplet_override` (formerly `deploy_triplet_override`) being set for vitis bitstreams. FYI: @abejgonzalez 

Internally, you will notice that some mentions of "triplet" remain. These are because the make-system still relies on triplets for naming several things (e.g. directories in `sim/generated-src/f1/`). Updating this is punted to a future PR since this is only really a problem if you work with multiple different `quadruplet`s that have the same `triplet`, which is rare. This has no effect on functionality besides this case.

#### Related PRs / Issues

N/A

#### UI / API Impact

* Entries in `config_hwdb.yaml` now have a `deploy_quadruplet_override` key instead of `deploy_triplet_override`.
* Entries in `config_build_recipes.yaml` now have a `deploy_quadruplet` key instead of `deploy_triplet`.

For both, backwards compatibility is ensured like so:
1. The manager will print a warning if only `deploy_triplet_override` or `deploy_triplet` are defined, instructing the user to upgrade, but will otherwise work as usual.
2. The manager will error if both `deploy_triplet_override` and `deploy_quadruplet_override` are defined or both `deploy_triplet` and `deploy_quadruplet` are defined.
3. The manager will accept "triplet" values supplied for any of these keys and automatically assume `TARGET_PROJECT=firesim` for any triplet. Otherwise, quadruplets are expected and all defaults in config files and docs have been updated to quadruplets.

The serialized versions of triplets stored in AGFI descriptions (`firesim-buildtriplet` and `firesim-deploytriplet`) continue to be kept so that old managers can continue to use AGFIs generated with the version of the manager in this PR. For AGFIs tagged only with a triplet, the manager assumes `TARGET_PROJECT=firesim`. This version of the manager also adds `firesim-buildquadruplet` and `firesim-deployquadruplet` key/values on AGFIs for the new `TARGET_PROJECT` support. Old managers will ignore these keys silently.

I have tested:
* Existing AGFIs booting Linux
* Non-firesim TARGET_PROJECT AGFI build
* Non-firesim TARGET_PROJECT FPGA-run (infrasetup + run by hand on run farm)
* Non-firesim TARGET_PROJECT metasims (infrasetup + run by hand on run farm)

#### Verilog / AGFI Compatibility

See note above. No user facing changes. No need for AGFI re-gen.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
- [x] If applicable, did you apply the `ci:fpga-deploy` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
