### PR TITLE
update assert in timingmodel to allow BURST_FIXED w/len=0

### DIFF
--- a/sim/midas/src/main/scala/midas/models/dram/TimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/TimingModel.scala
@@ -109,11 +109,13 @@ abstract class TimingModel(val cfg: BaseConfig)(implicit val p: Parameters) exte
   pendingWReq.inc := tNasti.w.fire && tNasti.w.bits.last
   pendingWReq.dec := tNasti.b.fire
 
-  assert(!tNasti.ar.valid || (tNasti.ar.bits.burst === NastiConstants.BURST_INCR),
-    "Illegal ar request: memory model only supports incrementing bursts")
+  assert(!tNasti.ar.valid || (tNasti.ar.bits.burst === NastiConstants.BURST_INCR)
+    || ((tNasti.ar.bits.burst === NastiConstants.BURST_FIXED) && tNasti.ar.bits.len === 0.U),
+    "Illegal ar request: memory model only supports incrementing or fixed (len=0) bursts")
 
-  assert(!tNasti.aw.valid || (tNasti.aw.bits.burst === NastiConstants.BURST_INCR),
-    "Illegal aw request: memory model only supports incrementing bursts")
+  assert(!tNasti.aw.valid || (tNasti.aw.bits.burst === NastiConstants.BURST_INCR)
+    || ((tNasti.aw.bits.burst === NastiConstants.BURST_FIXED) && tNasti.aw.bits.len === 0.U),
+    "Illegal aw request: memory model only supports incrementing or fixed (len=0) bursts")
 
   // Release; returns responses to target
   val xactionRelease = Module(new AXI4Releaser)


### PR DESCRIPTION
see title

#### Related PRs / Issues

N/A

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

No regen necessary.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
