### PR TITLE
fix main.o build dependency on generated const.h

### DIFF
--- a/sim/midas/src/main/cc/Makefile
+++ b/sim/midas/src/main/cc/Makefile
@@ -40,7 +40,7 @@ platform_files := simif_$(MAIN) main
 platform_cc := $(addprefix $(midas_dir)/, $(addsuffix .cc, $(platform_files)))
 platform_o := $(addprefix $(GEN_DIR)/, $(addsuffix .o, $(platform_files)))
 
-$(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc
+$(platform_o): $(GEN_DIR)/%.o: $(midas_dir)/%.cc $(design_h)
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 


### PR DESCRIPTION
See title.

#### Related PRs / Issues

N/A

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
