### PR TITLE
Fix trigger system common case performance regression

### DIFF
--- a/.github/scripts/workflow-monitor.py
+++ b/.github/scripts/workflow-monitor.py
@@ -60,9 +60,9 @@ def main(platform: Platform, issue_id: int):
 
                 print(f"Workflow {ci_env['GITHUB_RUN_ID']} status: {state_status} {state_concl}")
 
-                # check that select instances are terminated on time
+                # check that select instances are terminated on time (45m for run farm insts, 12h for build farm insts)
                 platform_lib.check_and_terminate_run_farm_instances(45, ci_env['GITHUB_RUN_ID'], issue_id)
-                platform_lib.check_and_terminate_build_farm_instances(12, ci_env['GITHUB_RUN_ID'], issue_id)
+                platform_lib.check_and_terminate_build_farm_instances(12*60, ci_env['GITHUB_RUN_ID'], issue_id)
 
                 if state_status in ['completed']:
                     if state_concl in TERMINATE_STATES:

--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -139,7 +139,7 @@ jobs:
         if: ${{ (env.CI_LABEL_DEBUG != 'true') }}
         uses: ./.github/actions/setup-workflow-monitor
         with:
-          max-runtime-hours: 4
+          max-runtime-hours: 8
       - name: Initial Scala compilation
         uses: ./.github/actions/initial-scala-compile
       - name: Catch potentially orphaned manager

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -11,24 +11,24 @@
 
 # DOCREF START: Example HWDB Entry
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0ac731f61d3f31817
+    agfi: agfi-0b170c998292ab5a8
     deploy_quintuplet_override: null
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0a60b1241fe70aad8
+    agfi: agfi-04f514e82af7158d4
     deploy_quintuplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0c82dc422cf6408a9
+    agfi: agfi-0a9d2044e67a4f916
     deploy_quintuplet_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-09a9331f468822063
+    agfi: agfi-09b1570836eb1c55f
     deploy_quintuplet_override: null
     custom_runtime_config: null
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-074d5fb88949da9e3
+    agfi: agfi-0c7fdc93660655e43
     deploy_quintuplet_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_no_nic_l2_lbp:


### PR DESCRIPTION
Something in the trigger system is causing performance to be significantly reduced when tracerv is included but disabled at runtime (recent CI logs on F1 show 150 MHz FPGA freq -> 40 MHz effective freq).

This PR fixes this for the common case where the outcome of evaluating the trigger will not change during the course of the simulation. In this case, we will keep driving credit/debit tokens into the sim regardless of the normal trigger evaluation dependencies, since they don't matter.

Without this fix, having tracerv in a build but disabled at runtime is significantly reducing performance:

* F1, tracerv disabled at runtime: ~150 MHz FPGA freq -> 40 MHz effective freq
* VCU118, tracerv disabled at runtime: 50 MHz FPGA freq -> 15 MHz effective freq
* VCU118, tracerv enabled at runtime (logging to disk): 50 MHz FPGA freq -> 15 MHz effective freq
* VCU118, with this fix implemented, trigger always true, tracerv disabled at runtime: 50 MHz FPGA freq -> 45 MHz effective freq
* VCU118, with this fix implemented, trigger always true, tracerv enabled at runtime (logging to disk): 50 MHz FPGA freq -> 15 MHz effective freq

Waiting on buildbitstream CI to build F1 bitstreams to report F1 performance results.

#### Related PRs / Issues

N/A

#### UI / API Impact

No API change, only performance improvement in common cases.

#### Verilog / AGFI Compatibility

Does change verilog, but no compatibility issues.

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
