### PR TITLE
Misc. CI Cleanup - Local Cleanup Parallelism + Clobbered Buildbitstream PRs

### DIFF
--- a/.github/workflows/firesim-run-tests.yml
+++ b/.github/workflows/firesim-run-tests.yml
@@ -332,7 +332,7 @@ jobs:
           add-paths: "deploy/sample-backup-configs/sample_config_hwdb.yaml"
           commit-message: "Update AGFI(s) [ci skip]"
           body: "Update AGFI(s) for PR #${{ github.event.pull_request.number }}"
-          branch-suffix: short-commit-hash
+          branch-suffix: random
           title: "Update AGFI(s) for PR #${{ github.event.pull_request.number }} (`${{ github.head_ref }}`)"
 
   documentation-check:
@@ -491,13 +491,14 @@ jobs:
           add-paths: "deploy/sample-backup-configs/sample_config_hwdb.yaml"
           commit-message: "Update local bitstream(s) [ci skip]"
           body: "Update local bitstream(s) for PR #${{ github.event.pull_request.number }}"
-          branch-suffix: short-commit-hash
+          branch-suffix: random
           title: "Update local bitstream(s) for PR #${{ github.event.pull_request.number }} (`${{ github.head_ref }}`)"
 
   cleanup-local-fpga-repo:
     name: cleanup-local-fpga-repo
     needs: [run-parallel-vcs-metasims-and-vitis-driver, run-basic-linux-poweroff-vitis, run-vitis-check-docs-generated-components, run-local-fpga-buildbitstream]
-    runs-on: local-fpga
+    # uses a separate runner to cleanup (irrespective, of other jobs cancelled, running, etc)
+    runs-on: local-fpga-cleanup
     if: ${{ always() }}
     steps:
       - name: Delete repo copy


### PR DESCRIPTION
- Fixes issue where the local cleanup CI job would get "stuck" behind other queued jobs to `local-fpga`. Now we have x4 new runners that are strictly allocated for cleanup.
- Use a random branch suffix to avoid collisions between PRs

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
