### PR TITLE
FASED: overhaul occupancy histogram; added memory stats tests

### DIFF
--- a/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
+++ b/sim/firesim-lib/src/main/scala/configs/FASEDTargetConfigs.scala
@@ -77,9 +77,14 @@ class WithFuncModelLimits(maxReads: Int, maxWrites: Int) extends Config((site, h
   )
 })
 
-/*******************************************************************************
-* Complete Memory-Timing Model Configurations
-*******************************************************************************/
+/** Turns on all available model-agnostic instrumentation */
+class WithAllBaseInstrumentation
+    extends Config((site, here, up) => { case BaseParamsKey =>
+      up(BaseParamsKey, site).enableAllBaseInstrumentation()
+    })
+
+/** Complete Memory-Timing Model Configurations */
+
 // Latency Bandwidth Pipes
 class LBP32R32W extends Config(
   new WithFuncModelLimits(32,32) ++

--- a/sim/firesim-lib/src/test/scala/TestSuiteUtil.scala
+++ b/sim/firesim-lib/src/test/scala/TestSuiteUtil.scala
@@ -2,6 +2,7 @@ package firesim
 
 import java.io.File
 import scala.io.Source
+import collection.mutable
 
 object TestSuiteUtil {
 
@@ -42,5 +43,22 @@ object TestSuiteUtil {
     for ((a, b) <- bLines.zip(aLines)) {
       assert(a == b)
     }
+  }
+
+  /** Splits a CSV row in substrings, removing whitespace on either end */
+  def splitAtCommas(s: String) = s.split(",").map(_.trim)
+
+  def parseCSV(file: File): Map[String, Seq[String]] = {
+    val header :: valueRows = Source.fromFile(file).getLines.toList
+    val headerFields        = splitAtCommas(header)
+
+    val columns = Seq.fill(headerFields.size)(mutable.ArrayBuffer[String]())
+    for (row <- valueRows) {
+      val values = splitAtCommas(row)
+      assert(columns.size == values.size, s"CSV file ${file} must have a uniform number of values per row")
+      columns.zip(values).foreach { case (buffer, value) => buffer.append(value) }
+    }
+
+    Map(headerFields.zip(columns.map(_.toSeq)): _*)
   }
 }

--- a/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/sim/midas/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -69,9 +69,25 @@ case class BaseParams(
 
   // Number of xactions in flight in a given cycle. Bin N contains the range
   // (occupancyHistograms[N-1], occupancyHistograms[N]]
-  occupancyHistograms: Seq[Int] = Seq(0, 2, 4, 8),
-  addrRangeCounters: BigInt = BigInt(0)
-)
+  occupancyHistograms: Seq[Int] = Seq(0, 1, 4, 8, 16, 32, 48, 64),
+  addrRangeCounters:   BigInt   = BigInt(0),
+) {
+  occupancyHistograms.foldLeft(-1) { case (a: Int, b: Int) =>
+    require(a < b, "Occupancy histogram maximums must be strictly increasing")
+    b
+  }
+
+  def enableAllBaseInstrumentation(): BaseParams = this.copy(
+    detectAddressCollisions = true,
+    stallEventCounters      = true,
+    localHCycleCount        = true,
+    latencyHistograms       = true,
+    xactionCounters         = true,
+    beatCounters            = true,
+    targetCycleCounter      = true,
+  )
+}
+
 // A serializable summary of the diplomatic edge
 case class AXI4EdgeSummary(
   maxReadTransfer: Int,

--- a/sim/src/main/cc/fasedtests/fasedtests_top.cc
+++ b/sim/src/main/cc/fasedtests/fasedtests_top.cc
@@ -57,7 +57,7 @@ fasedtests_top_t::fasedtests_top_t(simif_t &simif,
 
   // Add functions you'd like to periodically invoke on a paused simulator here.
   if (profile_interval) {
-    register_task(0, [&] {
+    register_task(0, [&, profile_interval] {
       for (auto *mod : registry.get_bridges<FASEDMemoryTimingModel>()) {
         mod->profile();
       }

--- a/sim/src/main/scala/fasedtests/Config.scala
+++ b/sim/src/main/scala/fasedtests/Config.scala
@@ -93,6 +93,7 @@ class QuadChannel extends WithNMemoryChannels(4)
 class DefaultConfig extends Config(
   new WithoutTLMonitors ++
   new WithDefaultFuzzer ++
+  new WithAllBaseInstrumentation ++
   new WithDefaultMemPort ++
   new WithDefaultMemModel ++
   new Config((site, here, up) => {
@@ -101,14 +102,17 @@ class DefaultConfig extends Config(
 )
 
 class FCFSConfig extends Config(
+  new WithAllBaseInstrumentation ++
   new FCFS16GBQuadRank ++
   new DefaultConfig)
 
 class FRFCFSConfig extends Config(
+  new WithAllBaseInstrumentation ++
   new FRFCFS16GBQuadRank ++
   new DefaultConfig)
 
 class LLCDRAMConfig extends Config(
+  new WithAllBaseInstrumentation ++
   new FRFCFS16GBQuadRankLLC4MB ++
   new DefaultConfig)
 

--- a/sim/src/test/scala/midasexamples/AutoCounterSuite.scala
+++ b/sim/src/test/scala/midasexamples/AutoCounterSuite.scala
@@ -22,16 +22,6 @@ abstract class AutoCounterSuite(
     */
   def checkAutoCounterCSV(backend: String, filename: String, stdoutPrefix: String) {
     it should s"produce a csv file (${filename}) that matches in-circuit printf output" in {
-      val scrubWhitespace = raw"\s*(.*)\s*".r
-      def splitAtCommas(s: String) = {
-        s.split(",")
-          .map(scrubWhitespace.findFirstMatchIn(_).get.group(1))
-      }
-
-      def quotedSplitAtCommas(s: String) = {
-        s.split("\",\"")
-          .map(scrubWhitespace.findFirstMatchIn(_).get.group(1))
-      }
 
       val refLogFile = new File(outDir, s"/${targetName}.${backend}.out")
       val acFile     = new File(genDir, s"/${filename}")


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Fixes a bug where the larges bin would not increment. As part of fixing the bug, i've improved the generation scheme, and added some tests to ensure the memory_stats.csv file is sane.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
