### PR TITLE
automatically try newer hotfix versions of AMI in manager

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -48,7 +48,7 @@ def get_f1_ami_name() -> str:
     else:
         if cuser != "centos":
             print("Unknown $USER (expected centos/amzn). Defaulting to the Centos AWS EC2 AMI.")
-        return "FPGA Developer AMI - 1.12.1-40257ab5-6688-4c95-97d1-e251a40fd1fc"
+        return "FPGA Developer AMI - 1.12.2-40257ab5-6688-4c95-97d1-e251a40fd1fc"
 
 def get_incremented_f1_ami_name(ami_name: str, increment: int) -> str:
     """ For an ami_name of the format "STUFF - X.Y.Z-hash-stuff",

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -63,8 +63,8 @@ def get_incremented_f1_ami_name(ami_name: str, increment: int) -> str:
 
     version_number = list(map(int, split2[0].split(".")))
     version_number[-1] += increment
-    version_number = ".".join(map(str, version_number))
-    return prefix + version_number + suffix
+    version_number_str = ".".join(map(str, version_number))
+    return prefix + version_number_str + suffix
 
 class MockBoto3Instance:
     """ This is used for testing without actually launching instances. """

--- a/docs/Getting-Started-Guides/AWS-EC2-F1-Tutorial/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Getting-Started-Guides/AWS-EC2-F1-Tutorial/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -79,10 +79,11 @@ To launch a manager instance, follow these steps:
     you click ``Launch Instance``) getting stuck trying to "Subscribe" to the
     AMI even when the account is already subscribed. We have been able to
     bypass this issue by going to the FPGA Developer AMI page on AWS
-    Marketplace, clicking subscribe (even if already subscribed), and then
-    following the prompts about launching an instance until you get to the
-    point where you can select "Launch via EC2" in a dropdown. Once you click
-    continue on the page with "Launch via EC2", you will be brought back to
+    Marketplace, clicking subscribe (even if already subscribed), then clicking
+    "Continue to Configuration", then verify the correct AMI version and 
+    region are selected and click "Continue to Launch". Finally, change
+    the dropdown that says "Launch from Website" to "Launch through EC2" and
+    click "Launch". At this point, you will be brought back to
     the usual launch instance page, but the AMI will be pre-selected and you
     will be able to successfully launch at the end, after updating the rest
     of the options as noted above.

--- a/docs/Getting-Started-Guides/AWS-EC2-F1-Tutorial/Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/Getting-Started-Guides/AWS-EC2-F1-Tutorial/Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -35,6 +35,7 @@ To launch a manager instance, follow these steps:
    ``FPGA Developer AMI - 1.12.2-40257ab5-6688-4c95-97d1-e251a40fd1fc`` and
    select the AMI that appears under the **Community AMIs** tab (there
    should be only one). **DO NOT USE ANY OTHER VERSION.** For example, **do not** use `FPGA Developer AMI` from the *AWS Marketplace AMIs* tab, as you will likely get an incorrect version of the AMI.
+   If you find that there are no results for this search, you can try incrementing the last part of the version number in the search string, e.g., ``1.12.2 -> 1.12.3``. Other parts of the search term should be unchanged.
 #. In the *Instance Type* drop-down, select the instance type of
    your choosing. A good choice is a ``c5.4xlarge`` (16 cores, 32 GiB) or a ``z1d.2xlarge`` (8 cores, 64 GiB).
 #. In the *Key pair (login)* drop-down, select the ``firesim`` key pair we setup earlier.
@@ -71,6 +72,22 @@ To launch a manager instance, follow these steps:
    #. Selecting the wrong AMI.
 
 #. Click the orange *Launch Instance* button.
+
+
+.. warning::
+    Recently, some AWS users been having issues with the launch process (after
+    you click ``Launch Instance``) getting stuck trying to "Subscribe" to the
+    AMI even when the account is already subscribed. We have been able to
+    bypass this issue by going to the FPGA Developer AMI page on AWS
+    Marketplace, clicking subscribe (even if already subscribed), and then
+    following the prompts about launching an instance until you get to the
+    point where you can select "Launch via EC2" in a dropdown. Once you click
+    continue on the page with "Launch via EC2", you will be brought back to
+    the usual launch instance page, but the AMI will be pre-selected and you
+    will be able to successfully launch at the end, after updating the rest
+    of the options as noted above.
+
+
 
 Access your instance
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When AMI hotfix versions (Z in X.Y.Z) are removed, automatically try X.Y.Z+1 to X.Y.Z+9 in the manager.

These hotfix bumps have historically not required us to actually change anything else.

#### Related PRs / Issues

N/A

#### UI / API Impact

Auto-fix the problem where AMIs get silently removed, as long as a new hotfix version is released.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [x] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
