### PR TITLE
changed mmap to xdma_user instead of pci resource 

### DIFF
--- a/sim/midas/src/main/cc/simif_xilinx_alveo_u250.cc
+++ b/sim/midas/src/main/cc/simif_xilinx_alveo_u250.cc
@@ -246,27 +246,10 @@ void simif_xilinx_alveo_u250_t::fpga_setup(uint16_t domain_id,
   assert(ret >= 0);
   fpga_pci_check_file_id(sysfs_name, pci_device_id);
 
-  // open and memory map
-  snprintf(sysfs_name,
-           sizeof(sysfs_name),
-           "/sys/bus/pci/devices/" PCI_DEV_FMT "/resource%u",
-           domain_id,
-           bus_id,
-           device_id,
-           pf_id,
-           bar_id);
-
-  fd = open(sysfs_name, O_RDWR | O_SYNC);
-  assert(fd != -1);
-
-  bar0_base = mmap(0, bar0_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-  assert(bar0_base != MAP_FAILED);
-  close(fd);
-  fd = -1;
-
   // XDMA setup
   char device_file_name[256];
   char device_file_name2[256];
+  char user_file_name[256];
 
   ret = snprintf(sysfs_name,
                  sizeof(sysfs_name),
@@ -293,6 +276,17 @@ void simif_xilinx_alveo_u250_t::fpga_setup(uint16_t domain_id,
   }
 
   assert(xdma_id != -1);
+
+  // open and memory map
+  sprintf(user_file_name, "/dev/xdma%d_user", xdma_id);
+
+  fd = open(user_file_name, O_RDWR | O_SYNC);
+  assert(fd != -1);
+
+  bar0_base = mmap(0, bar0_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  assert(bar0_base != MAP_FAILED);
+  close(fd);
+  fd = -1;
 
   sprintf(device_file_name, "/dev/xdma%d_h2c_0", xdma_id);
   printf("Using xdma write queue: %s\n", device_file_name);


### PR DESCRIPTION
#### Related PRs / Issues

Recently, I tried to run firesim on Xilinx VCU118. And I am using Linux v5.4.246 for the Host and use the latest xdma and xvsec driver, which is v2023.1.3 from [Xilinx/dma_ip_drivers](https://github.com/Xilinx/dma_ip_drivers).

However, an error message shows `assert(bar0_base != MAP_FAILED);` failed in `sim/midas/src/main/cc/simif_xilinx_alveo_u250.cc`. I tried a simple C program to test mmap, then found that the user pcie bar can only be mapped when the xdma driver is not loaded.

After reviewing the xdma driver to see why it happens, I found that the xdma driver provides a way to the mmap user bar by mmap `/dev/xdma_user` char dev. So I change the code, and it works.


#### UI / API Impact

No change.

#### Verilog / AGFI Compatibility

No change.
