### PR TITLE
Restore all CI local builds + Gemmini U250-bare.

### DIFF
--- a/.github/scripts/run-agfi-buildbitstream.py
+++ b/.github/scripts/run-agfi-buildbitstream.py
@@ -66,6 +66,15 @@ def run_agfi_buildbitstream():
                     if match_agfi == True:
                         sys.exit("::ERROR:: Unable to find matching AGFI key for HWDB entry")
 
+            # strip newlines from end of file
+            with open(sample_hwdb_filename, "r+") as sample_hwdb_file:
+                content = sample_hwdb_file.read()
+                content = content.rstrip('\n')
+                sample_hwdb_file.seek(0)
+
+                sample_hwdb_file.write(content)
+                sample_hwdb_file.truncate()
+
             print(f"Printing {sample_hwdb_filename}...")
             run(f"cat {sample_hwdb_filename}")
 

--- a/.github/scripts/run-local-buildbitstreams.py
+++ b/.github/scripts/run-local-buildbitstreams.py
@@ -195,6 +195,15 @@ def run_local_buildbitstreams():
                     if match_bit == True:
                         sys.exit(f"::ERROR:: Unable to replace URL for {hwdb_entry_name} in {sample_hwdb_filename}")
 
+                # strip newlines from end of file
+                with open(sample_hwdb_filename, "r+") as sample_hwdb_file:
+                    content = sample_hwdb_file.read()
+                    content = content.rstrip('\n')
+                    sample_hwdb_file.seek(0)
+
+                    sample_hwdb_file.write(content)
+                    sample_hwdb_file.truncate()
+
             # could potentially use knight/ferry in the future (currently unused since they are currently overloaded)
             hosts = {
                 ("localhost", "vitis:2022.1"),
@@ -239,8 +248,16 @@ def run_local_buildbitstreams():
             # same order as in config_build.yaml
             # hwdb_entry_name, platform_name, buildtool:version
             batch_hwdbs_in = [
-                ("nitefury_firesim_rocket_singlecore_no_nic", "rhsresearch_nitefury_ii", "vitis:2022.1"),
+                ("vitis_firesim_rocket_singlecore_no_nic", "vitis", "vitis:2022.1"),
                 ("alveo_u250_firesim_rocket_singlecore_no_nic", "xilinx_alveo_u250", "vivado:2021.1"),
+                ("alveo_u250_firesim_gemmini_rocket_singlecore_no_nic", "xilinx_alveo_u250", "vivado:2021.1"),
+            ]
+
+            do_builds(batch_hwdbs_in)
+
+            batch_hwdbs_in = [
+                ("nitefury_firesim_rocket_singlecore_no_nic", "rhsresearch_nitefury_ii", "vitis:2022.1"),
+                ("alveo_u200_firesim_rocket_singlecore_no_nic", "xilinx_alveo_u200", "vivado:2021.1"),
                 ("alveo_u280_firesim_rocket_singlecore_no_nic", "xilinx_alveo_u280", "vivado:2021.1"),
                 ("xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic", "xilinx_vcu118", "vivado:2019.1"),
             ]

--- a/deploy/sample-backup-configs/sample_config_build.yaml
+++ b/deploy/sample-backup-configs/sample_config_build.yaml
@@ -41,13 +41,13 @@ builds_to_run:
 
     # Configs for Vitis/XRT
     # - vitis_firesim_rocket_singlecore_no_nic
-    # - vitis_firesim_gemmini_rocket_singlecore_no_nic
 
     # Config for RHSResearch Nitefury II
     # - nitefury_firesim_rocket_singlecore_no_nic
 
     # Configs for Xilinx Alveo U250/U280
     # - alveo_u250_firesim_rocket_singlecore_no_nic
+    # - alveo_u250_firesim_gemmini_rocket_singlecore_no_nic
     # - alveo_u200_firesim_rocket_singlecore_no_nic
     # - alveo_u280_firesim_rocket_singlecore_no_nic
 

--- a/deploy/sample-backup-configs/sample_config_build_recipes.yaml
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.yaml
@@ -242,22 +242,6 @@ vitis_firesim_rocket_singlecore_no_nic:
     bit_builder_recipe: bit-builder-recipes/vitis.yaml
 
 # Additional Tutorial Config
-# Additional Xilinx Vitis/XRT-only Config
-vitis_firesim_gemmini_rocket_singlecore_no_nic:
-    PLATFORM: vitis
-    TARGET_PROJECT: firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimLeanGemminiRocketMMIOOnlyConfig
-    PLATFORM_CONFIG: BaseVitisConfig
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 30
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/vitis.yaml
-
-# Additional Tutorial Config
 firesim_gemmini_rocket_singlecore_no_nic:
     PLATFORM: f1
     TARGET_PROJECT: firesim
@@ -296,7 +280,23 @@ alveo_u250_firesim_rocket_singlecore_no_nic:
     PLATFORM_CONFIG: BaseXilinxAlveoConfig
     deploy_quintuplet: null
     platform_config_args:
-        fpga_frequency: 15
+        fpga_frequency: 60
+        build_strategy: TIMING
+    post_build_hook: null
+    metasim_customruntimeconfig: null
+    bit_builder_recipe: bit-builder-recipes/xilinx_alveo_u250.yaml
+
+# Additional Tutorial Config
+# Additional Xilinx Alveo U250-only Config
+alveo_u250_firesim_gemmini_rocket_singlecore_no_nic:
+    PLATFORM: xilinx_alveo_u250
+    TARGET_PROJECT: firesim
+    DESIGN: FireSim
+    TARGET_CONFIG: FireSimLeanGemminiRocketConfig
+    PLATFORM_CONFIG: BaseXilinxAlveoConfig
+    deploy_quintuplet: null
+    platform_config_args:
+        fpga_frequency: 60
         build_strategy: TIMING
     post_build_hook: null
     metasim_customruntimeconfig: null
@@ -311,7 +311,7 @@ alveo_u280_firesim_rocket_singlecore_no_nic:
     PLATFORM_CONFIG: BaseXilinxAlveoConfig
     deploy_quintuplet: null
     platform_config_args:
-        fpga_frequency: 15
+        fpga_frequency: 60
         build_strategy: TIMING
     post_build_hook: null
     metasim_customruntimeconfig: null
@@ -326,7 +326,7 @@ alveo_u200_firesim_rocket_singlecore_no_nic:
     PLATFORM_CONFIG: BaseXilinxAlveoConfig
     deploy_quintuplet: null
     platform_config_args:
-        fpga_frequency: 15
+        fpga_frequency: 60
         build_strategy: TIMING
     post_build_hook: null
     metasim_customruntimeconfig: null

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -68,6 +68,10 @@ alveo_u250_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/ed04a2e3f5dc6b14ef0acfbb1b8ae4963bdacd3e/xilinx_alveo_u250/alveo_u250_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
+alveo_u250_firesim_gemmini_rocket_singlecore_no_nic:
+    bitstream_tar: REPLACE_THIS
+    deploy_quintuplet_override: null
+    custom_runtime_config: null
 alveo_u200_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/15490e0486604006b9f2f6a4188a7ec57ed06276/xilinx_alveo_u200/alveo_u200_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
@@ -85,8 +89,4 @@ nitefury_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/69531b76799f73a049ab2d9856b2ba00151872af/rhsresearch_nitefury_ii/nitefury_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
-
-
-
-
 


### PR DESCRIPTION
See title.

#### Related PRs / Issues

N/A

#### UI / API Impact

Pre-built bitstreams will be available for vitis U250 + bare-U250 Gemmini.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
