### PR TITLE
Additional VCU118 inital setup fixes

### DIFF
--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -685,6 +685,7 @@ class XilinxAlveoBitBuilder(BitBuilder):
         local_cl_dir = f"{local_results_dir}/{fpga_build_postfix}"
         bit_path = f"{local_cl_dir}/vivado_proj/firesim.bit"
         mcs_path = f"{local_cl_dir}/vivado_proj/firesim.mcs"
+        mcs_secondary_path = f"{local_cl_dir}/vivado_proj/firesim_secondary.mcs"
         tar_staging_path = f"{local_cl_dir}/{self.build_config.PLATFORM}"
         tar_name = "firesim.tar.gz"
 
@@ -695,6 +696,8 @@ class XilinxAlveoBitBuilder(BitBuilder):
         # store bitfile (and mcs if it exists)
         local(f"cp {bit_path} {tar_staging_path}")
         local(f"cp {mcs_path} {tar_staging_path}")
+        if self.build_config.PLATFORM == "xilinx_vcu118":
+            local(f"cp {mcs_secondary_path} {tar_staging_path}")
 
         # store metadata string
         local(f"""echo '{self.get_metadata_string()}' >> {tar_staging_path}/metadata""")

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -56,7 +56,7 @@ firesim_supernode_rocket_singlecore_nic_l2_lbp:
     deploy_quintuplet_override: null
     custom_runtime_config: null
 vitis_firesim_rocket_singlecore_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/23fc86bcade868b892f245a1d93de985e7ea10a8/vitis/vitis_firesim_rocket_singlecore_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/9697ea5f5f297e386c5c6f60ba5a71ee3020f93f/vitis/vitis_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
 vitis_firesim_gemmini_rocket_singlecore_no_nic:
@@ -64,26 +64,26 @@ vitis_firesim_gemmini_rocket_singlecore_no_nic:
     deploy_quintuplet_override: null
     custom_runtime_config: null
 alveo_u250_firesim_rocket_singlecore_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/e0fbdb133ace9ee73121fd2b5ac4ac6ebcd681e0/xilinx_alveo_u250/alveo_u250_firesim_rocket_singlecore_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/ac2cd0c123e1755a666d48709021d29abb440ab6/xilinx_alveo_u250/alveo_u250_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
 alveo_u250_firesim_gemmini_rocket_singlecore_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/709b988e36201250a60cdb46b66483565cc9a701/xilinx_alveo_u250/alveo_u250_firesim_gemmini_rocket_singlecore_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/ebeffff3cd54225fbbcac36a8f2ced5645f2079e/xilinx_alveo_u250/alveo_u250_firesim_gemmini_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
 alveo_u200_firesim_rocket_singlecore_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/48c880eb7afc103733e0ea766f8413a5856c3771/xilinx_alveo_u200/alveo_u200_firesim_rocket_singlecore_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/9fa5d271407bd7057885c02f19f510842f3f3c95/xilinx_alveo_u200/alveo_u200_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
 alveo_u280_firesim_rocket_singlecore_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/11ce62962fe3f6ddc52c3cd76e03dec111206f42/xilinx_alveo_u280/alveo_u280_firesim_rocket_singlecore_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/808bce6788100b700730bd5b39b86e5c004cf43d/xilinx_alveo_u280/alveo_u280_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
 xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/41aa6a93316788aadd05f557b2f2b43417ba6702/xilinx_vcu118/xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/c3adc1471a61cb1415a0c800271baad5bf753d02/xilinx_vcu118/xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null
 nitefury_firesim_rocket_singlecore_no_nic:
-    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/66257f4896490cf5c2621ac77b9bf1301708b9e0/rhsresearch_nitefury_ii/nitefury_firesim_rocket_singlecore_no_nic.tar.gz
+    bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/7fa19e457374d98cc7abf7a196b93db23db2dc52/rhsresearch_nitefury_ii/nitefury_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
     custom_runtime_config: null

--- a/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/RHS-Research-Nitefury-II.rst
+++ b/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/RHS-Research-Nitefury-II.rst
@@ -11,6 +11,9 @@
 .. |fpga_spi_part_number| replace:: ``s25fl256xxxxxx0-spi-x1_x2_x4``
 .. |fpga_attach_prereq| replace:: into either an open M.2. slot on your machine or into an M.2. to Thunderbolt enclosure (then attach the enclosure to your system via a Thunderbolt cable). We have successfully used this enclosure: https://www.amazon.com/ORICO-Enclosure-Compatible-Thunderbolt-Type-C-M2V01/dp/B08R9DMFFT. Before permanently installing your Nitefury into your M.2. slot or enclosure, ensure that you have attached the ribbon cable that will be used for JTAG to the underside of the board (see step 4 below).
 .. |jtag_help| replace:: JTAG. For the Nitefury, this requires attaching the 14-pin JTAG adapter included with the board to the board using the included ribbon cable, then attaching a USB to JTAG adapter such as the Digilent HS2: https://digilent.com/shop/jtag-hs2-programming-cable/.
+.. |extra_mcs| replace:: file from step 7.
+.. |mcs_info| replace:: Inside, you will find three files; the one we are currently interested in will be called ``firesim.mcs``. Note the full path of this ``firesim.mcs`` file for the next step.
+.. |dip_switch_extra| replace:: power).
 .. |nitefury_patch_xdma| replace:: The directory you are now in contains the XDMA kernel module. For the Nitefury to work, we will need to make one modification to the driver. Find the line containing ``#define XDMA_ENGINE_XFER_MAX_DESC``. Change the value on this line from ``0x800`` to ``16``. Then, build and install the driver:
 
 .. include:: Xilinx-XDMA-Template.rst

--- a/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-Alveo-U250.rst
+++ b/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-Alveo-U250.rst
@@ -11,6 +11,9 @@
 .. |fpga_spi_part_number| replace:: ``mt25qu01g-spi-x1_x2_x4``
 .. |fpga_attach_prereq| replace:: into an open PCIe slot in the machine.
 .. |jtag_help| replace:: JTAG. 
+.. |extra_mcs| replace:: file from step 7.
+.. |mcs_info| replace:: Inside, you will find three files; the one we are currently interested in will be called ``firesim.mcs``. Note the full path of this ``firesim.mcs`` file for the next step.
+.. |dip_switch_extra| replace:: power).
 .. |nitefury_patch_xdma| replace:: The directory you are now in contains the XDMA kernel module. Now, let's build and install it:
 
 .. include:: Xilinx-XDMA-Template.rst

--- a/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-Alveo-U280.rst
+++ b/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-Alveo-U280.rst
@@ -11,6 +11,9 @@
 .. |fpga_spi_part_number| replace:: ``mt25qu01g-spi-x1_x2_x4``
 .. |fpga_attach_prereq| replace:: into an open PCIe slot in the machine.
 .. |jtag_help| replace:: JTAG. 
+.. |extra_mcs| replace:: file from step 7.
+.. |mcs_info| replace:: Inside, you will find three files; the one we are currently interested in will be called ``firesim.mcs``. Note the full path of this ``firesim.mcs`` file for the next step.
+.. |dip_switch_extra| replace:: power).
 .. |nitefury_patch_xdma| replace:: The directory you are now in contains the XDMA kernel module. Now, let's build and install it:
 
 .. include:: Xilinx-XDMA-Template.rst

--- a/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-VCU118.rst
+++ b/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-VCU118.rst
@@ -8,9 +8,12 @@
 .. |tool_type_lab| replace:: Xilinx Vivado Lab
 .. |example_var| replace:: ``XILINX_VIVADO``
 .. |deploy_manager_code| replace:: ``XilinxVCU118InstanceDeployManager``
-.. |fpga_spi_part_number| replace:: ``mt25qu01g-spi-x1_x2_x4``
-.. |fpga_attach_prereq| replace:: into an open PCIe slot in the machine. Also, ensure that the SW16 switches on the FPGA are set to ``0101`` to enable QSPI flashing over JTAG (i.e., ``position 1 = 0``, ``position 2 = 1``, ``position 3 = 0``, and ``position 4 = 1``. Having the switch set to the side of the position label indicates 0.)
+.. |fpga_spi_part_number| replace:: ``mt25qu01g-spi-x1_x2_x4_x8``
+.. |mcs_info| replace:: Inside, you will find four files; the ones we are currently interested in will be called ``firesim.mcs`` and ``firesim_secondary.mcs``. Note the full path of the ``firesim.mcs`` and ``firesim_secondary.mcs`` files for the next step.
+.. |fpga_attach_prereq| replace:: into an open PCIe slot in the machine. Also, ensure that the SW16 switches on the board are set to ``0101`` to enable QSPI flashing over JTAG (i.e., ``position 1 = 0``, ``position 2 = 1``, ``position 3 = 0``, and ``position 4 = 1``. Having the switch set to the side of the position label indicates 0.)
 .. |jtag_help| replace:: JTAG. 
+.. |extra_mcs| replace:: file from step 7 and for Configuration file 2, choose the ``firesim_secondary.mcs`` file from step 7.
+.. |dip_switch_extra| replace:: power). Then, set the SW16 switches on the board to ``0001`` to set the board to automatically program the FPGA from the QSPI at boot (i.e., ``position 1 = 0``, ``position 2 = 0``, ``position 3 = 0``, and ``position 4 = 1``. Having the switch set to the side of the position label indicates 0.)
 .. |nitefury_patch_xdma| replace:: The directory you are now in contains the XDMA kernel module. Now, let's build and install it:
 
 .. include:: Xilinx-XDMA-Template.rst

--- a/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-XDMA-Template.rst
+++ b/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-XDMA-Template.rst
@@ -187,21 +187,18 @@ Now, let's attach your |fpga_name|_ FPGA(s) to your Run Farm Machines:
 
 6. Obtain an existing bitstream tar file for your FPGA by opening the ``bitstream_tar`` URL listed
    under |hwdb_entry_name| in the following file: :gh-file-ref:`deploy/sample-backup-configs/sample_config_hwdb.yaml`.
-7. Extract the ``.tar.gz`` file to a known location. Inside, you will find
-   three files; the one we are currently interested in will be called
-   ``firesim.mcs``. Note the full path of this ``firesim.mcs`` file for the
-   next step.
+7. Extract the ``.tar.gz`` file to a known location. |mcs_info|
 
 8. Open Vivado Lab and click "Open Hardware Manager". Then click "Open Target" and "Auto connect".
 
 9. Right-click on your FPGA and click "Add Configuration Memory Device". For a |fpga_name|_, choose |fpga_spi_part_number|
    as the Configuration Memory Part. Click "OK" when prompted to program the configuration memory device.
 
-10. For Configuration file, choose the ``firesim.mcs`` file from step 7.
+10. For Configuration file, choose the ``firesim.mcs`` |extra_mcs|.
 
 11. Uncheck "Verify" and click OK.
 
-12. When programming the configuration memory device is completed, power off your machine fully (i.e., the FPGA should completely lose power).
+12. When programming the configuration memory device is completed, power off your machine fully (i.e., the FPGA should completely lose |dip_switch_extra|
 
 13. Cold-boot the machine. A cold boot is required for the FPGA to be successfully re-programmed from its flash.
 

--- a/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-XDMA-Template.rst
+++ b/docs/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Initial-Setup/Xilinx-XDMA-Template.rst
@@ -194,7 +194,7 @@ Now, let's attach your |fpga_name|_ FPGA(s) to your Run Farm Machines:
 9. Right-click on your FPGA and click "Add Configuration Memory Device". For a |fpga_name|_, choose |fpga_spi_part_number|
    as the Configuration Memory Part. Click "OK" when prompted to program the configuration memory device.
 
-10. For Configuration file, choose the ``firesim.mcs`` |extra_mcs|.
+10. For Configuration file, choose the ``firesim.mcs`` |extra_mcs|
 
 11. Uncheck "Verify" and click OK.
 

--- a/platforms/xilinx_vcu118/build-bitstream.sh
+++ b/platforms/xilinx_vcu118/build-bitstream.sh
@@ -82,3 +82,4 @@ vivado -mode batch -source ../tcl/build.tcl -tclargs $FREQUENCY $STRATEGY $BOARD
 mkdir -p ../vivado_proj
 cp example_pblock_partition_partial.bit ../vivado_proj/firesim.bit
 cp ../../shell/prebuilt/empty_primary.mcs ../vivado_proj/firesim.mcs
+cp ../../shell/prebuilt/empty_secondary.mcs ../vivado_proj/firesim_secondary.mcs


### PR DESCRIPTION
Fix missing secondary mcs file in bitstream_tar. Update docs for switch position fix and specify that secondary mcs needs to be given too.

#### Related PRs / Issues

Fixes #1605 

#### UI / API Impact

Fix VCU118 flow. Tested working end-to-end on firestation, from scratch.

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
