### PR TITLE
fix compile error for drivers when glibc >= 2.34

### DIFF
--- a/sim/make/driver.mk
+++ b/sim/make/driver.mk
@@ -35,7 +35,7 @@ $(f1): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 $(xilinx_alveo_u250): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
               -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include
 $(xilinx_alveo_u250): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu
+              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64
 
 # Compile Driver
 $(xilinx_alveo_u250): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -52,7 +52,7 @@ $(xilinx_alveo_u250): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 $(xilinx_alveo_u280): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
               -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include
 $(xilinx_alveo_u280): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu
+              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64
 
 # Compile Driver
 $(xilinx_alveo_u280): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -70,7 +70,7 @@ $(xilinx_alveo_u280): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 $(xilinx_alveo_u200): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
               -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include
 $(xilinx_alveo_u200): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu
+              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64
 
 # Compile Driver
 $(xilinx_alveo_u200): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -88,7 +88,7 @@ $(xilinx_alveo_u200): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 $(xilinx_vcu118): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
               -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include
 $(xilinx_vcu118): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu
+              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64
 
 # Compile Driver
 $(xilinx_vcu118): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -105,7 +105,7 @@ $(xilinx_vcu118): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
 $(rhsresearch_nitefury_ii): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
               -idirafter ${CONDA_PREFIX}/include -idirafter /usr/include
 $(rhsresearch_nitefury_ii): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu
+              -L${CONDA_PREFIX}/lib -Wl,-rpath-link=${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64
 
 # Compile Driver
 $(rhsresearch_nitefury_ii): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)
@@ -123,7 +123,7 @@ $(vitis): export CXXFLAGS := $(CXXFLAGS) $(common_cxx_flags) $(DRIVER_CXXOPTS) \
 	-idirafter ${CONDA_PREFIX}/include -idirafter /usr/include -idirafter $(XILINX_XRT)/include
 # -ldl needed for Ubuntu 20.04 systems (is backwards compatible with U18.04 systems)
 $(vitis): export LDFLAGS := $(LDFLAGS) $(common_ld_flags) -Wl,-rpath='$$$$ORIGIN' \
-	-L${CONDA_PREFIX}/lib -Wl,-rpath-link=/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil -ldl
+	-L${CONDA_PREFIX}/lib -Wl,-rpath-link=${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L${CONDA_PREFIX}/x86_64-conda-linux-gnu/sysroot/lib64 -L$(XILINX_XRT)/lib -luuid -lxrt_coreutil -ldl
 
 # Compile Driver
 $(vitis): $(header) $(DRIVER_CC) $(DRIVER_H) $(midas_cc) $(midas_h)


### PR DESCRIPTION
#### Related PRs / Issues

I'm trying to compile firesim on Debian sid, which uses glibc 2.37.

However, an error shows when compiling drivers:

```console
$ make PLATFORM=xilinx_vcu118 TARGET_PROJECT=firesim DESIGN=FireSim TARGET_CONFIG=FireSimRocket4GiBDRAMConfig PLATFORM_CONFIG=BaseXilinxVCU118Config replace-rtl
...
/home/cyy/firesim/firesim/.conda-env/bin/../lib/gcc/x86_64-conda-linux-gnu/12.2.0/../../../../x86_64-conda-linux-gnu/bin/ld: /home/cyy/firesim/firesim/.conda-env/bin/../x86_64-conda-linux-gnu/sysroot/usr/lib/../lib/Scrt1.o: in function `_start':
(.text+0x12): undefined reference to `__libc_csu_fini'
/home/cyy/firesim/firesim/.conda-env/bin/../lib/gcc/x86_64-conda-linux-gnu/12.2.0/../../../../x86_64-conda-linux-gnu/bin/ld: (.text+0x19): undefined reference to `__libc_csu_init'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:47: /home/cyy/firesim/firesim/sim/output/xilinx_vcu118/xilinx_vcu118-firesim-FireSim-FireSimRocket4GiBDRAMConfig-BaseXilinxVCU118Config/FireSim-xilinx_vcu118] Error 1
make[1]: Leaving directory '/home/cyy/firesim/firesim/sim/midas/src/main/cc'
make: *** [make/driver.mk:97: /home/cyy/firesim/firesim/sim/output/xilinx_vcu118/xilinx_vcu118-firesim-FireSim-FireSimRocket4GiBDRAMConfig-BaseXilinxVCU118Config/FireSim-xilinx_vcu118] Error 2
```

I tried to debug and find out the issue is that we use the libraries from conda-env. However, some libraries do not support the newer version of glibc, which causes compile errors on newer versions of the host environment.

Then I changed the rpath when linking, and the driver successfully compiled and ran on Debian sid.

#### UI / API Impact

No change

#### Verilog / AGFI Compatibility

No change

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
