### PR TITLE
Remove OS_VERSION in machine-launch-script.sh

### DIFF
--- a/scripts/machine-launch-script.sh
+++ b/scripts/machine-launch-script.sh
@@ -116,7 +116,6 @@ set -o pipefail
     fi
 
     OS_FLAVOR=$(grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"')
-    OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"')
 
     echo "machine launch script started" > "$MACHINE_LAUNCH_DIR/machine-launchstatus"
     chmod ugo+r "$MACHINE_LAUNCH_DIR/machine-launchstatus"


### PR DESCRIPTION
It is not present on all distros and is not used anyway.

#### Related PRs / Issues

N/A

#### UI / API Impact

N/A

#### Verilog / AGFI Compatibility

N/A

### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?


### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [x] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [x] Did you mark the proper release milestone?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
