### PR TITLE
Add initial implementation of variable FESVR rate during loading phase of simulation

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/tsibridge.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/tsibridge.cc
@@ -21,16 +21,32 @@ tsibridge_t::tsibridge_t(simif_t &simif,
       loadmem_widget(loadmem_widget), has_mem(has_mem),
       mem_host_offset(mem_host_offset) {
 
-  std::string num_equals = std::to_string(tsino) + std::string("=");
-  std::string prog_arg = std::string("+prog") + num_equals;
+  const std::string num_equals = std::to_string(tsino) + std::string("=");
+  const std::string prog_arg = std::string("+prog") + num_equals;
   std::vector<std::string> args_vec;
   args_vec.push_back("firesim_tsi");
 
   // This particular selection is vestigial. You may change it freely.
   step_size = 2004765L;
+
+  // Enable switching step-sizes
+  fast_fesvr = true;
+
+  // This particular selection is correlated to the amount of reset cycles. It should be larger than the reset period.
+  wait_ticks = 8;
+
+  // This particular selection is vestigial. You may change it freely. This * wait_ticks is should be larger than the reset period.
+  loading_step_size = fast_fesvr ? 8 : step_size;
+
   for (auto &arg : args) {
     if (arg.find("+fesvr-step-size=") == 0) {
       step_size = atoi(arg.c_str() + 17);
+    }
+    if (arg.find("+fesvr-disable-early-fast") == 0) {
+      fast_fesvr = false;
+    }
+    if (arg.find("+fesvr-wait-ticks=") == 0) {
+      wait_ticks = atoi(arg.c_str() + 18);
     }
     if (arg.find(prog_arg) == 0) {
       std::string clean_target_args =
@@ -83,7 +99,14 @@ void tsibridge_t::init() {
   // built here, as the bridge constructor may be invoked from a thread other
   // than the one it will run on later in meta-simulations.
   fesvr = new firesim_tsi_t(tsi_argc, tsi_argv, has_mem);
-  write(mmio_addrs.step_size, step_size);
+  if (fast_fesvr) {
+    printf("tsibridge_t::init set FESVR step-size to %" PRIu32 " initially\n", loading_step_size);
+    write(mmio_addrs.step_size, loading_step_size);
+  }
+  else {
+    write(mmio_addrs.step_size, step_size);
+    fesvr->set_loaded(true); // pre-set to unblock fs_tsi_t::reset
+  }
   go();
 }
 
@@ -169,6 +192,12 @@ void tsibridge_t::tick() {
   // First, check to see step_size tokens have been enqueued
   if (!read(mmio_addrs.done))
     return;
+  if (wait_ticks != 0) {
+    wait_ticks -= 1;
+    printf("tsibridge_t::tick skipping tick\n");
+    go();
+    return;
+  }
   // Collect all the responses from the target
   this->recv();
   // Punt to FESVR
@@ -181,6 +210,16 @@ void tsibridge_t::tick() {
   if (!terminate()) {
     // Write all the requests to the target
     this->send();
+    if (fast_fesvr) {
+      if (fesvr->loaded_in_sw()) {
+        if (!fesvr->data_available()) {
+          fesvr->set_loaded(true); // done w/ firesim loading
+          printf("tsibridge_t::tick reverting FESVR step-size to %" PRIu32 "\n", step_size);
+          write(mmio_addrs.step_size, step_size);
+          fast_fesvr = false; // only write this user-defined step size once
+        }
+      }
+    }
     go();
   }
 }

--- a/sim/firesim-lib/src/main/cc/bridges/tsibridge.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tsibridge.h
@@ -49,6 +49,12 @@ private:
   int64_t mem_host_offset;
   // Number of target cycles between fesvr interactions
   uint32_t step_size;
+  // Same as step_size but value during initial programing phase
+  uint32_t loading_step_size;
+  // During the initial program phase speed up when FESVR is called (i.e. speed up program loading outside of loadmem)
+  bool fast_fesvr;
+  // Delay n ticks to avoid race-condition where target reset resets the bridge state and drops xacts
+  uint32_t wait_ticks;
 
   // Arguments passed to firesim_tsi.
   char **tsi_argv = nullptr;

--- a/sim/firesim-lib/src/main/cc/bridges/tsibridge.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tsibridge.h
@@ -51,9 +51,11 @@ private:
   uint32_t step_size;
   // Same as step_size but value during initial programing phase
   uint32_t loading_step_size;
-  // During the initial program phase speed up when FESVR is called (i.e. speed up program loading outside of loadmem)
+  // During the initial program phase speed up when FESVR is called
+  // (i.e. speed up program loading when loadmem isn't/can't be used)
   bool fast_fesvr;
-  // Delay n ticks to avoid race-condition where target reset resets the bridge state and drops xacts
+  // Delay n ticks to avoid race-condition where target reset resets the bridge
+  // state and drops xacts
   uint32_t wait_ticks;
 
   // Arguments passed to firesim_tsi.

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
@@ -1,12 +1,13 @@
 // See LICENSE for license details
-#include <stdio.h>
-#include <inttypes.h>
 #include "firesim_tsi.h"
+#include <inttypes.h>
+#include <stdio.h>
 
 #define fprintf(stdout, fmt, ...) (0)
 
 firesim_tsi_t::firesim_tsi_t(int argc, char **argv, bool can_have_loadmem)
-    : testchip_tsi_t(argc, argv, can_have_loadmem), is_busy(false), is_loaded(false), is_loaded_in_sw(false) {
+    : testchip_tsi_t(argc, argv, can_have_loadmem), is_busy(false),
+      is_loaded_in_host(false), is_loaded_in_target(false) {
   idle_counts = 10;
   std::vector<std::string> args(argv + 1, argv + argc);
   for (auto &arg : args) {
@@ -30,7 +31,11 @@ void firesim_tsi_t::send_loadmem_word(uint32_t word) {
 void firesim_tsi_t::load_mem_write(addr_t addr,
                                    size_t nbytes,
                                    const void *src) {
-  fprintf(stdout, "firesim_tsi_t::load_mem_write addr: %" PRIx64 " nbytes: %" PRIu64 "\n", addr, nbytes);
+  fprintf(stdout,
+          "firesim_tsi_t::load_mem_write addr: %" PRIx64 " nbytes: %" PRIu64
+          "\n",
+          addr,
+          nbytes);
   fflush(stdout);
 
   loadmem_write_reqs.push_back(firesim_loadmem_t(addr, nbytes));
@@ -39,7 +44,11 @@ void firesim_tsi_t::load_mem_write(addr_t addr,
 }
 
 void firesim_tsi_t::load_mem_read(addr_t addr, size_t nbytes, void *dst) {
-  fprintf(stdout, "firesim_tsi_t::load_mem_read addr: %" PRIx64 " nbytes: %" PRIu64 "\n", addr, nbytes);
+  fprintf(stdout,
+          "firesim_tsi_t::load_mem_read addr: %" PRIx64 " nbytes: %" PRIu64
+          "\n",
+          addr,
+          nbytes);
   fflush(stdout);
 
   while (!loadmem_write_reqs.empty())
@@ -59,10 +68,14 @@ void firesim_tsi_t::load_mem_read(addr_t addr, size_t nbytes, void *dst) {
 void firesim_tsi_t::tick() { switch_to_host(); }
 
 void firesim_tsi_t::reset() {
-  is_loaded_in_sw = true;
-  while (!is_loaded)
+  // after program loading, this function is called and spins until the target thread/bridge
+  // has synced/drained all in-flight fesvr xacts
+  is_loaded_in_host = true;
+  while (!is_loaded_in_target)
     switch_to_target();
-  fprintf(stdout, "firesim_tsi_t::reset done loading program. sending reset signal(s)\n");
+  fprintf(
+      stdout,
+      "firesim_tsi_t::reset done loading program. sending reset signal(s)\n");
   fflush(stdout);
   testchip_tsi_t::reset();
 }

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
@@ -68,8 +68,8 @@ void firesim_tsi_t::load_mem_read(addr_t addr, size_t nbytes, void *dst) {
 void firesim_tsi_t::tick() { switch_to_host(); }
 
 void firesim_tsi_t::reset() {
-  // after program loading, this function is called and spins until the target thread/bridge
-  // has synced/drained all in-flight fesvr xacts
+  // after program loading, this function is called and spins until the target
+  // thread/bridge has synced/drained all in-flight fesvr xacts
   is_loaded_in_host = true;
   while (!is_loaded_in_target)
     switch_to_target();

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
@@ -1,8 +1,12 @@
 // See LICENSE for license details
+#include <stdio.h>
+#include <inttypes.h>
 #include "firesim_tsi.h"
 
+#define fprintf(stdout, fmt, ...) (0)
+
 firesim_tsi_t::firesim_tsi_t(int argc, char **argv, bool can_have_loadmem)
-    : testchip_tsi_t(argc, argv, can_have_loadmem), is_busy(false) {
+    : testchip_tsi_t(argc, argv, can_have_loadmem), is_busy(false), is_loaded(false), is_loaded_in_sw(false) {
   idle_counts = 10;
   std::vector<std::string> args(argv + 1, argv + argc);
   for (auto &arg : args) {
@@ -26,12 +30,18 @@ void firesim_tsi_t::send_loadmem_word(uint32_t word) {
 void firesim_tsi_t::load_mem_write(addr_t addr,
                                    size_t nbytes,
                                    const void *src) {
+  fprintf(stdout, "firesim_tsi_t::load_mem_write addr: %" PRIx64 " nbytes: %" PRIu64 "\n", addr, nbytes);
+  fflush(stdout);
+
   loadmem_write_reqs.push_back(firesim_loadmem_t(addr, nbytes));
   loadmem_write_data.insert(
       loadmem_write_data.end(), (const char *)src, (const char *)src + nbytes);
 }
 
 void firesim_tsi_t::load_mem_read(addr_t addr, size_t nbytes, void *dst) {
+  fprintf(stdout, "firesim_tsi_t::load_mem_read addr: %" PRIx64 " nbytes: %" PRIu64 "\n", addr, nbytes);
+  fflush(stdout);
+
   while (!loadmem_write_reqs.empty())
     switch_to_target();
   loadmem_read_reqs.push_back(firesim_loadmem_t(addr, nbytes));
@@ -47,6 +57,15 @@ void firesim_tsi_t::load_mem_read(addr_t addr, size_t nbytes, void *dst) {
 }
 
 void firesim_tsi_t::tick() { switch_to_host(); }
+
+void firesim_tsi_t::reset() {
+  is_loaded_in_sw = true;
+  while (!is_loaded)
+    switch_to_target();
+  fprintf(stdout, "firesim_tsi_t::reset done loading program. sending reset signal(s)\n");
+  fflush(stdout);
+  testchip_tsi_t::reset();
+}
 
 bool firesim_tsi_t::has_loadmem_reqs() {
   return (!loadmem_write_reqs.empty() || !loadmem_read_reqs.empty());

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
@@ -17,6 +17,8 @@ public:
   ~firesim_tsi_t() {}
 
   bool busy() { return is_busy; };
+  bool loaded_in_sw() { return is_loaded_in_sw; };
+  void set_loaded(bool loaded) { is_loaded = loaded; };
 
   void tick();
   void tick(bool out_valid, uint32_t out_bits, bool in_ready) { tick(); };
@@ -30,6 +32,8 @@ public:
 
 protected:
   void idle() override;
+
+  void reset() override;
 
   void load_mem_write(addr_t addr, size_t nbytes, const void *src) override;
   void load_mem_read(addr_t addr, size_t nbytes, void *dst) override;
@@ -48,5 +52,7 @@ protected:
 private:
   size_t idle_counts;
   bool is_busy;
+  bool is_loaded;
+  bool is_loaded_in_sw;
 };
 #endif // __FIRESIM_TSI_H

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
@@ -17,8 +17,8 @@ public:
   ~firesim_tsi_t() {}
 
   bool busy() { return is_busy; };
-  bool loaded_in_sw() { return is_loaded_in_sw; };
-  void set_loaded(bool loaded) { is_loaded = loaded; };
+  bool loaded_in_host() { return is_loaded_in_host; };
+  void set_loaded_in_target(bool loaded) { is_loaded_in_target = loaded; };
 
   void tick();
   void tick(bool out_valid, uint32_t out_bits, bool in_ready) { tick(); };
@@ -52,7 +52,9 @@ protected:
 private:
   size_t idle_counts;
   bool is_busy;
-  bool is_loaded;
-  bool is_loaded_in_sw;
+  // program load has completed in the host thread (i.e. all fesvr xacts for program load have been sent by fesvr)
+  bool is_loaded_in_host;
+  // program load has completed in the target thread (i.e. all in-flight fesvr xacts for program load have been synced/drained by the target thread/bridge)
+  bool is_loaded_in_target;
 };
 #endif // __FIRESIM_TSI_H

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
@@ -52,9 +52,12 @@ protected:
 private:
   size_t idle_counts;
   bool is_busy;
-  // program load has completed in the host thread (i.e. all fesvr xacts for program load have been sent by fesvr)
+  // program load has completed in the host thread (i.e. all fesvr xacts for
+  // program load have been sent by fesvr)
   bool is_loaded_in_host;
-  // program load has completed in the target thread (i.e. all in-flight fesvr xacts for program load have been synced/drained by the target thread/bridge)
+  // program load has completed in the target thread (i.e. all in-flight fesvr
+  // xacts for program load have been synced/drained by the target
+  // thread/bridge)
   bool is_loaded_in_target;
 };
 #endif // __FIRESIM_TSI_H


### PR DESCRIPTION
Generally speaking, there are two phases of simulation: (1) initial loading of payloads/binaries + (2) starting execution of the SoC (i.e. the workload). Right now during (1) we use the LoadMem widget to load the main target binary. However, there are cases where we can load other payloads (i.e. `+payload=...` flag in FESVR) that don't use the LoadMem widget. In these cases, the main target binary will load "fast" (i.e. bypassing the target SoC memory fabric directly to DRAM) but the other payloads will load using the traditional TSI xacts to the target memory fabric (this is slow). To help speed this 2nd use case up, this PR adds a "fast FESVR" mode where the FESVR calls at phase (1) are sped up. This ensures that FESVR pushes as many R/W xacts to the target as fast as possible (as fast as the target can sink these xacts). Then once phase (1) is over, it reverts to the user-specified FESVR step size.

Two new simulator flags:
- `+fesvr-disable-early-fast`. boolean control over this new functionality which is enabled by default
- `+fesvr-wait-ticks`. wait N FESVR ticks before driving FESVR xacts. this fixes a corner-case where FESVR could drive xacts from the host into the bridge HW queue, then the reset from the target would clear the bridge HW queue forming malformed TSI xacts. This only occurs when the FESVR step size is low (I tested 8 only). This is set to a default value of 8 (wait 8 TSI ticks) which seems to work well with a small step size of 8).

Side Note:
The `firesim_tsi_t::reset` is overridden to allow some synchronization between the bridge tick and the host thread. In essence we wait for all FESVR xacts from phase (1) to complete before switching to the faster step size.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
