### PR TITLE
Fix LazyRawModuleImp implicit clock in the `VitisShim` 

### DIFF
--- a/sim/midas/src/main/scala/midas/platform/VitisShim.scala
+++ b/sim/midas/src/main/scala/midas/platform/VitisShim.scala
@@ -31,6 +31,9 @@ class VitisShim(implicit p: Parameters) extends PlatformShim {
     .copy(addrBits = VitisConstants.axi4MAddressBits)
 
   lazy val module             = new LazyRawModuleImp(this) {
+    // drive all {Lazy}Modules with a default clock/reset (defaults to an incorrect clock/reset)
+    override def provideImplicitClockToLazyChildren = true
+
     val ap_rst_n   = IO(Input(AsyncReset()))
     val ap_clk     = IO(Input(Clock()))
     val s_axi_lite = IO(Flipped(new XilinxAXI4Bundle(ctrlAXI4BundleParams, isAXI4Lite = true)))
@@ -51,6 +54,7 @@ class VitisShim(implicit p: Parameters) extends PlatformShim {
 
     val hostClock     = firesimMMCM.io.clk_out1
     val hostSyncReset = ResetSynchronizer(ap_rst || !firesimMMCM.io.locked, hostClock, initValue = true)
+    // overrides the implicit clock/reset given
     top.module.reset := hostSyncReset
     top.module.clock := hostClock
 


### PR DESCRIPTION
Fixes Vitis builds that errored on not having an implicit clock.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
