### PR TITLE
Catch HTIF exceptions and fix TracerV bridge for larger iaddr widths 

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/tracerv.h
+++ b/sim/firesim-lib/src/main/cc/bridges/tracerv.h
@@ -103,7 +103,7 @@ private:
 
 public:
   void flush();
-  static constexpr uint64_t valid_mask = (1ULL << 40);
+  static constexpr uint64_t valid_mask = (1ULL << 63); // valid bit is 64th bit
 };
 
 #endif // __TRACERV_H

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
@@ -115,20 +115,27 @@ void firesim_tsi_t::recv_loadmem_data(void *buf, size_t len) {
 // re-enable fprintfs in file
 #undef fprintf
 
-// try to catch exceptions in the htif thread (specifically from program loading)
-// TODO: ideally you override the htif_t::run function but currently un-overrideable
+// try to catch exceptions in the htif thread (specifically from program
+// loading)
+// TODO: ideally you override the htif_t::run function but currently
+// un-overrideable
 void firesim_tsi_t::load_program() {
   try {
     testchip_tsi_t::load_program();
   } catch (std::exception &e) {
-    fprintf(
-        stderr, "Caught Exception headed for the simulator (in TSI thread): %s.\n", e.what());
-    throw std::runtime_error(e.what()); // runtime_error used here to throw exception in main thread
+    fprintf(stderr,
+            "Caught Exception headed for the simulator (in TSI thread): %s.\n",
+            e.what());
+    throw std::runtime_error(
+        e.what()); // runtime_error used here to throw exception in main thread
   } catch (...) {
     // seriously, VCS will give you an unhelpful message if you let an exception
     // propagate catch it here and if we hit this, I can go remember how to
     // unwind the stack to print a trace
-    fprintf(stderr, "Caught non std::exception headed for the simulator (in TSI thread)\n");
-    throw std::runtime_error("unknown"); // runtime_error used here to throw exception in main thread
+    fprintf(
+        stderr,
+        "Caught non std::exception headed for the simulator (in TSI thread)\n");
+    throw std::runtime_error(
+        "unknown"); // runtime_error used here to throw exception in main thread
   }
 }

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.cc
@@ -111,3 +111,24 @@ void firesim_tsi_t::recv_loadmem_data(void *buf, size_t len) {
   loadmem_write_data.erase(loadmem_write_data.begin(),
                            loadmem_write_data.begin() + len);
 }
+
+// re-enable fprintfs in file
+#undef fprintf
+
+// try to catch exceptions in the htif thread (specifically from program loading)
+// TODO: ideally you override the htif_t::run function but currently un-overrideable
+void firesim_tsi_t::load_program() {
+  try {
+    testchip_tsi_t::load_program();
+  } catch (std::exception &e) {
+    fprintf(
+        stderr, "Caught Exception headed for the simulator (in TSI thread): %s.\n", e.what());
+    throw std::runtime_error(e.what()); // runtime_error used here to throw exception in main thread
+  } catch (...) {
+    // seriously, VCS will give you an unhelpful message if you let an exception
+    // propagate catch it here and if we hit this, I can go remember how to
+    // unwind the stack to print a trace
+    fprintf(stderr, "Caught non std::exception headed for the simulator (in TSI thread)\n");
+    throw std::runtime_error("unknown"); // runtime_error used here to throw exception in main thread
+  }
+}

--- a/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
+++ b/sim/firesim-lib/src/main/cc/fesvr/firesim_tsi.h
@@ -30,6 +30,8 @@ public:
 
   void send_loadmem_word(uint32_t word);
 
+  void load_program() override;
+
 protected:
   void idle() override;
 

--- a/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/TracerVBridge.scala
@@ -94,6 +94,8 @@ class TracerVBridgeModule(key: TraceBundleWidths)(implicit p: Parameters)
     })
     private val pcWidth   = traces.map(_.iaddr.getWidth).max
     private val insnWidth = traces.map(_.insn.getWidth).max
+    println(s"TracerVBridge: Max {Iaddr, Insn} Widths = {$pcWidth, $insnWidth}")
+    require(pcWidth + 1 <= 64, "Instruction address + 1 bit (for valid) must fit in 64b (for SW-side of bridge)")
     val cycleCountWidth   = 64
 
     // Set after trigger-dependent memory-mapped registers have been set, to
@@ -211,7 +213,7 @@ class TracerVBridgeModule(key: TraceBundleWidths)(implicit p: Parameters)
     val allTraceArms = traces.grouped(armWidth).toSeq
 
     // an intermediate value used to build allStreamBits
-    val allUintTraces = allTraceArms.map(arm => arm.map((trace => Cat(trace.valid, trace.iaddr).pad(64))).reverse)
+    val allUintTraces = allTraceArms.map(arm => arm.map((trace => Cat(trace.valid, trace.iaddr.pad(63)))).reverse)
 
     // Literally each arm of the mux, these are directly the bits that get put into the bump
     val allStreamBits =

--- a/sim/midas/src/main/cc/emul/dpi.cc
+++ b/sim/midas/src/main/cc/emul/dpi.cc
@@ -282,13 +282,13 @@ void simulator_tick(
     }
   } catch (std::exception &e) {
     fprintf(
-        stderr, "Caught Exception headed for the simulator: %s.\n", e.what());
+        stderr, "Caught Exception headed for the simulator (in DPI thread): %s.\n", e.what());
     abort();
   } catch (...) {
     // seriously, VCS will give you an unhelpful message if you let an exception
-    // propagate catch it here and if we hit this, I can go rememeber how to
+    // propagate catch it here and if we hit this, I can go remember how to
     // unwind the stack to print a trace
-    fprintf(stderr, "Caught non std::exception headed for the simulator\n");
+    fprintf(stderr, "Caught non std::exception headed for the simulator (in DPI thread)\n");
     abort();
   }
 }

--- a/sim/midas/src/main/cc/emul/dpi.cc
+++ b/sim/midas/src/main/cc/emul/dpi.cc
@@ -281,14 +281,17 @@ void simulator_tick(
         exit(exit_code);
     }
   } catch (std::exception &e) {
-    fprintf(
-        stderr, "Caught Exception headed for the simulator (in DPI thread): %s.\n", e.what());
+    fprintf(stderr,
+            "Caught Exception headed for the simulator (in DPI thread): %s.\n",
+            e.what());
     abort();
   } catch (...) {
     // seriously, VCS will give you an unhelpful message if you let an exception
     // propagate catch it here and if we hit this, I can go remember how to
     // unwind the stack to print a trace
-    fprintf(stderr, "Caught non std::exception headed for the simulator (in DPI thread)\n");
+    fprintf(
+        stderr,
+        "Caught non std::exception headed for the simulator (in DPI thread)\n");
     abort();
   }
 }


### PR DESCRIPTION
This PR does 2 things:

- Throw exceptions from program loading. Originally, if the HTIF thread threw an exception in VCS it would give a gibberish exception message to STDOUT. This PR instead catches that exception, prints something reasonable out to the console, and then errors.
- Fixes TracerV bridge for any iaddr width < 64. With the bump to SV48 in Chipyard, TracerV was broken since it expected the iaddr width to be 40 (and the valid bit to be in the 41th bit position). This fixes that assumption by just putting the valid bit at the end of integer (i.e. 64th bit).

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
