### PR TITLE
Fix cospike bridge for sv48

### DIFF
--- a/sim/firesim-lib/src/main/cc/bridges/cospike.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/cospike.cc
@@ -63,7 +63,6 @@ cospike_t::cospike_t(simif_t &sim,
                         1,
                         bits_per_trace,
                         hartid);
-
   this->cospike_failed = false;
   this->cospike_exit_code = 0;
 
@@ -75,10 +74,20 @@ cospike_t::cospike_t(simif_t &sim,
       this->_trace_printers.start(num_threads);
 
       size_t max_input_bytes = stream_depth * STREAM_WIDTH_BYTES;
+      size_t buffer_bytes = num_threads * max_input_bytes; // based on perf experiments
       this->_trace_mempool = new mempool_t(
-          num_threads, num_threads * max_input_bytes, max_input_bytes);
+          num_threads, buffer_bytes, max_input_bytes);
 
       std::filesystem::create_directory("COSPIKE-TRACES");
+
+      FILE* config_file = fopen("COSPIKE-CONFIG", "w");
+      fprintf(config_file, "num_threads: %d uncompressed_buffer_bytes: %lu\n",
+             num_threads, buffer_bytes);
+      fclose(config_file);
+
+      FILE* bootrom_file = fopen("FIRESIM-BOOTROM", "w");
+      fprintf(bootrom_file, "%s\n", bootrom);
+      fclose(bootrom_file);
     }
   }
 }

--- a/sim/firesim-lib/src/main/cc/bridges/cospike.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/cospike.cc
@@ -74,18 +74,21 @@ cospike_t::cospike_t(simif_t &sim,
       this->_trace_printers.start(num_threads);
 
       size_t max_input_bytes = stream_depth * STREAM_WIDTH_BYTES;
-      size_t buffer_bytes = num_threads * max_input_bytes; // based on perf experiments
-      this->_trace_mempool = new mempool_t(
-          num_threads, buffer_bytes, max_input_bytes);
+      size_t buffer_bytes =
+          num_threads * max_input_bytes; // based on perf experiments
+      this->_trace_mempool =
+          new mempool_t(num_threads, buffer_bytes, max_input_bytes);
 
       std::filesystem::create_directory("COSPIKE-TRACES");
 
-      FILE* config_file = fopen("COSPIKE-CONFIG", "w");
-      fprintf(config_file, "num_threads: %d uncompressed_buffer_bytes: %lu\n",
-             num_threads, buffer_bytes);
+      FILE *config_file = fopen("COSPIKE-CONFIG", "w");
+      fprintf(config_file,
+              "num_threads: %d uncompressed_buffer_bytes: %lu\n",
+              num_threads,
+              buffer_bytes);
       fclose(config_file);
 
-      FILE* bootrom_file = fopen("FIRESIM-BOOTROM", "w");
+      FILE *bootrom_file = fopen("FIRESIM-BOOTROM", "w");
       fprintf(bootrom_file, "%s\n", bootrom);
       fclose(bootrom_file);
     }

--- a/sim/firesim-lib/src/main/cc/bridges/cospike/thread_pool.cc
+++ b/sim/firesim-lib/src/main/cc/bridges/cospike/thread_pool.cc
@@ -39,7 +39,7 @@ void print_insn_logs(trace_t trace, const std::string &oname) {
 
     if (valid || exception || cause) {
       gzprintf(trace_file,
-               "%lld %llu %llx %d %d %d %d %d %lx\n",
+               "%ld %lu %lx %d %d %d %d %d %lx\n",
                cfg._hartid,
                time,
                iaddr,

--- a/sim/firesim-lib/src/main/scala/bridges/CospikeBridge.scala
+++ b/sim/firesim-lib/src/main/scala/bridges/CospikeBridge.scala
@@ -92,6 +92,11 @@ class CospikeBridgeModule(params: CospikeBridgeParams)(implicit p: Parameters)
       temp
     }
 
+    def Sext(x: UInt, size: Int): UInt = {
+      if (x.getWidth == size) x
+      else Cat(Fill(size - x.getWidth, x(x.getWidth-1)), x)
+    }
+
     // matches order of TracedInstruction in CSR.scala
     val paddedTraces = traces.map { trace =>
       val pre_cat = Cat(
@@ -100,7 +105,7 @@ class CospikeBridgeModule(params: CospikeBridgeParams)(implicit p: Parameters)
         boolPad(trace.exception, 8),
         trace.priv.asUInt.pad(8),
         trace.insn.pad(insnWidth),
-        trace.iaddr.pad(iaddrWidth),
+        Sext(trace.iaddr, iaddrWidth),
         boolPad(trace.valid, 8),
         timestamp.pad(64)
       )


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

This PR does two things.
1. Dump some information about the cospike trace.
2. In the original `CoSpikeBridge` implementation, the PC is zero padded. Meanwhile, when parsing the bits in the host driver, the `EXTRACT_ALIGNED` macro (in `thread_pool.h`) performs sign extension only when the number of PC bits is a multiple of 8. For SV48, PC contains 49 bits (BOOM/Rocket implementation details), the parsed PC from the host bridge is zero extended instead of being sign extended. This PR sign extends the PC inside the bridge RTL.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
