### PR TITLE
Fix dependabot ccbench branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 
 updates:
-  # submit a PR for bumping submodules daily (for all submodules)
+  # submit a PR for bumping submodules daily (for all submodules).
+  # updates a submodule to the latest commit on the branch given in .gitmodules.
+  # if branch not given, then it defaults to the main/master branch.
   - package-ecosystem: gitsubmodule
     schedule:
       interval: "daily"

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,7 @@
 [submodule "deploy/workloads/ccbench-cache-sweep/ccbench"]
 	path = deploy/workloads/ccbench-cache-sweep/ccbench
 	url = https://github.com/ucb-bar/ccbench
+	branch = firesim-linux
 [submodule "deploy/workloads/runscripts/gapbs-scripts/gapbs"]
 	path = deploy/workloads/runscripts/gapbs-scripts/gapbs
 	url = https://github.com/sbeamer/gapbs.git


### PR DESCRIPTION
Submodules are checked/updated to the branch found in `.gitmodules`. This update the ccbench branch to use the proper branch s.t. dependabot checks/updates correctly.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
- [ ] If applicable, did you apply the `ci:fpga-deploy` label?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
