### PR TITLE
Support pointing to makefrags in YAML

### DIFF
--- a/deploy/awstools/afitools.py
+++ b/deploy/awstools/afitools.py
@@ -106,14 +106,14 @@ def share_agfi_in_all_regions(agfi_id, useridlist):
         afi_id = get_afi_for_agfi(agfi_id, region)
         share_afi_with_users(afi_id, region, useridlist)
 
-def firesim_tags_to_description(build_quintuplet, deploy_quintuplet, build_triplet, deploy_triplet, commit):
+def firesim_tags_to_description(build_quintuplet, deploy_quintuplet, build_triplet, deploy_triplet, commit, build_makefrag, deploy_makefrag):
     """ Serialize the tags we want to set for storage in the AGFI description """
     # note: the serialized rep still includes "triplets" for future manager versions to be compatible with old agfis
-    return f"""firesim-buildquintuplet:{build_quintuplet},firesim-deployquintuplet:{deploy_quintuplet},firesim-buildtriplet:{build_triplet},firesim-deploytriplet:{deploy_triplet},firesim-commit:{commit}"""
+    return f"""firesim-buildquintuplet:{build_quintuplet},firesim-deployquintuplet:{deploy_quintuplet},firesim-buildtriplet:{build_triplet},firesim-deploytriplet:{deploy_triplet},firesim-commit:{commit},firesim-buildmakefrag:{build_makefrag},firesim-deploymakefrag:{deploy_makefrag}"""
 
 def firesim_description_to_tags(description):
     """ Deserialize the tags we want to read from the AGFI description string.
-    Return dictionary of keys/vals [{build,deploy}quintuplet, {build,deploy}triplet, commit]. """
+    Return dictionary of keys/vals [{build,deploy}quintuplet, {build,deploy}triplet, commit, {build,deploy}makefrag]. """
     returndict = dict()
     desc_split = description.split(",")
     for keypair in desc_split:

--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -105,6 +105,9 @@ class BitBuilder(metaclass=abc.ABCMeta):
         tag_build_triplet = self.build_config.get_chisel_triplet()
         tag_deploy_triplet = self.build_config.get_effective_deploy_triplet()
 
+        tag_build_makefrag = self.build_config.get_deploy_makefrag()
+        tag_deploy_makefrag = self.build_config.get_deploy_makefrag()
+
         # the asserts are left over from when we tried to do this with tags
         # - technically I don't know how long these descriptions are allowed to be,
         # but it's at least 2048 chars, so I'll leave these here for now as sanity
@@ -113,6 +116,10 @@ class BitBuilder(metaclass=abc.ABCMeta):
         assert len(tag_deploy_quintuplet) <= 255, "ERR: does not support tags longer than 256 chars for deploy_quintuplet"
         assert len(tag_build_triplet) <= 255, "ERR: does not support tags longer than 256 chars for build_triplet"
         assert len(tag_deploy_triplet) <= 255, "ERR: does not support tags longer than 256 chars for deploy_triplet"
+        if tag_build_makefrag:
+            assert len(tag_build_makefrag) <= 255, "ERR: does not support tags longer than 256 chars for build_makefrag"
+        if tag_deploy_makefrag:
+            assert len(tag_deploy_makefrag) <= 255, "ERR: does not support tags longer than 256 chars for deploy_makefrag"
 
         is_dirty_str = local("if [[ $(git status --porcelain) ]]; then echo '-dirty'; fi", capture=True)
         hash = local("git rev-parse HEAD", capture=True)
@@ -121,7 +128,7 @@ class BitBuilder(metaclass=abc.ABCMeta):
         assert len(tag_fsimcommit) <= 255, "ERR: aws does not support tags longer than 256 chars for fsimcommit"
 
         # construct the serialized description from these tags.
-        return firesim_tags_to_description(tag_build_quintuplet, tag_deploy_quintuplet, tag_build_triplet, tag_deploy_triplet, tag_fsimcommit)
+        return firesim_tags_to_description(tag_build_quintuplet, tag_deploy_quintuplet, tag_build_triplet, tag_deploy_triplet, tag_fsimcommit, tag_build_makefrag, tag_deploy_makefrag)
 
 class F1BitBuilder(BitBuilder):
     """Bit builder class that builds a AWS EC2 F1 AGFI (bitstream) from the build config.

--- a/deploy/buildtools/buildconfigfile.py
+++ b/deploy/buildtools/buildconfigfile.py
@@ -30,6 +30,7 @@ class BuildConfigFile:
         build_ip_set: List of IPs to use for builds.
         num_builds: Number of builds to run.
         build_farm: Build farm used to host builds.
+        path: Path to build config file
     """
     args: argparse.Namespace
     forceterminate: bool
@@ -40,6 +41,7 @@ class BuildConfigFile:
     build_ip_set: Set[str]
     num_builds: int
     build_farm: BuildFarm
+    path: str
 
     def __init__(self, args: argparse.Namespace) -> None:
         """
@@ -58,6 +60,8 @@ class BuildConfigFile:
         global_build_config_file = None
         with open(args.buildconfigfile, "r") as yaml_file:
             global_build_config_file = yaml.safe_load(yaml_file)
+
+        self.path = args.buildconfigfile
 
         # aws specific options
         self.agfistoshare = global_build_config_file['agfis_to_share']

--- a/deploy/sample-backup-configs/sample_config_build_recipes.yaml
+++ b/deploy/sample-backup-configs/sample_config_build_recipes.yaml
@@ -32,6 +32,7 @@
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.QuadRocketConfig
     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -48,6 +49,7 @@ firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.QuadRocketConfig
     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -64,6 +66,7 @@ firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.LargeBoomV3Config
     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -80,6 +83,7 @@ firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomV3Config
     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -95,6 +99,7 @@ firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
 firesim_cva6_singlecore_no_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -110,6 +115,7 @@ firesim_cva6_singlecore_no_nic_l2_llc4mb_ddr3:
 firesim_rocket_singlecore_gemmini_no_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -125,6 +131,7 @@ firesim_rocket_singlecore_gemmini_no_nic_l2_llc4mb_ddr3:
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3_ramopts:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomV3Config
     PLATFORM_CONFIG: WithAutoILA_MCRams_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -140,6 +147,7 @@ firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3_ramopts:
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_SupernodeFireSimRocketConfig
     PLATFORM_CONFIG: WithAutoILA_BaseF1Config
@@ -155,6 +163,7 @@ firesim_supernode_rocket_singlecore_nic_l2_lbp:
 midasexamples_gcd:
     PLATFORM: f1
     TARGET_PROJECT: midasexamples
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: GCD
     TARGET_CONFIG: NoConfig
     PLATFORM_CONFIG: DefaultF1Config
@@ -170,6 +179,7 @@ midasexamples_gcd:
 firesim_rocket_singlecore_no_nic_l2_lbp:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.RocketConfig
     PLATFORM_CONFIG: BaseF1Config
@@ -185,6 +195,7 @@ firesim_rocket_singlecore_no_nic_l2_lbp:
 firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
     PLATFORM_CONFIG: FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -200,6 +211,7 @@ firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
     PLATFORM_CONFIG: FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -215,6 +227,7 @@ firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketPrintfConfig
     PLATFORM_CONFIG: WithPrintfSynthesis_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
@@ -230,6 +243,7 @@ firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
 vitis_firesim_rocket_singlecore_no_nic:
     PLATFORM: vitis
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocketMMIOOnlyConfig
     PLATFORM_CONFIG: BaseVitisConfig
@@ -245,6 +259,7 @@ vitis_firesim_rocket_singlecore_no_nic:
 firesim_gemmini_rocket_singlecore_no_nic:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLeanGemminiRocketConfig
     PLATFORM_CONFIG: BaseF1Config
@@ -260,6 +275,7 @@ firesim_gemmini_rocket_singlecore_no_nic:
 firesim_gemmini_printf_rocket_singlecore_no_nic:
     PLATFORM: f1
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLeanGemminiPrintfRocketConfig
     PLATFORM_CONFIG: WithPrintfSynthesis_BaseF1Config
@@ -275,6 +291,7 @@ firesim_gemmini_printf_rocket_singlecore_no_nic:
 alveo_u250_firesim_rocket_singlecore_no_nic:
     PLATFORM: xilinx_alveo_u250
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocketConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU250Config
@@ -289,6 +306,7 @@ alveo_u250_firesim_rocket_singlecore_no_nic:
 alveo_u250_firesim_rocket_quadcore_no_nic:
     PLATFORM: xilinx_alveo_u250
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimQuadRocketConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU250Config
@@ -303,6 +321,7 @@ alveo_u250_firesim_rocket_quadcore_no_nic:
 alveo_u250_firesim_boom_singlecore_no_nic:
     PLATFORM: xilinx_alveo_u250
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLargeBoomConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU250Config
@@ -317,6 +336,7 @@ alveo_u250_firesim_boom_singlecore_no_nic:
 alveo_u250_firesim_rocket_singlecore_nic:
     PLATFORM: xilinx_alveo_u250
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: WithNIC_FireSimRocketConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU250Config
@@ -333,6 +353,7 @@ alveo_u250_firesim_rocket_singlecore_nic:
 alveo_u250_firesim_gemmini_rocket_singlecore_no_nic:
     PLATFORM: xilinx_alveo_u250
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimLeanGemminiRocketConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU250Config
@@ -348,6 +369,7 @@ alveo_u250_firesim_gemmini_rocket_singlecore_no_nic:
 alveo_u280_firesim_rocket_singlecore_no_nic:
     PLATFORM: xilinx_alveo_u280
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocketConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU280Config
@@ -363,6 +385,7 @@ alveo_u280_firesim_rocket_singlecore_no_nic:
 alveo_u200_firesim_rocket_singlecore_no_nic:
     PLATFORM: xilinx_alveo_u200
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocketConfig
     PLATFORM_CONFIG: BaseXilinxAlveoU200Config
@@ -378,6 +401,7 @@ alveo_u200_firesim_rocket_singlecore_no_nic:
 xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic:
     PLATFORM: xilinx_vcu118
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocket4GiBDRAMConfig
     PLATFORM_CONFIG: BaseXilinxVCU118Config
@@ -393,6 +417,7 @@ xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic:
 nitefury_firesim_rocket_singlecore_no_nic:
     PLATFORM: rhsresearch_nitefury_ii
     TARGET_PROJECT: firesim
+    TARGET_PROJECT_MAKEFRAG: null
     DESIGN: FireSim
     TARGET_CONFIG: FireSimRocket1GiBDRAMConfig
     PLATFORM_CONFIG: BaseNitefuryConfig
@@ -411,6 +436,7 @@ nitefury_firesim_rocket_singlecore_no_nic:
 f1_rocket_split_soc_fast:
   PLATFORM: f1
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimRocketConfig
   PLATFORM_CONFIG: RocketTileF1PCIMBase
@@ -425,6 +451,7 @@ f1_rocket_split_soc_fast:
 f1_rocket_split_tile_fast:
   PLATFORM: f1
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimRocketConfig
   PLATFORM_CONFIG: RocketTileF1PCIMPartition0
@@ -444,6 +471,7 @@ f1_rocket_split_tile_fast:
 f1_firesim_rocket_soc_exact:
   PLATFORM: f1
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimRocketConfig
   PLATFORM_CONFIG: ExactMode_RocketTileF1PCIMBase
@@ -458,6 +486,7 @@ f1_firesim_rocket_soc_exact:
 f1_firesim_rocket_tile_exact:
   PLATFORM: f1
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimRocketConfig
   PLATFORM_CONFIG: ExactMode_RocketTileF1PCIMPartition0
@@ -476,6 +505,7 @@ f1_firesim_rocket_tile_exact:
 xilinx_u250_firesim_dual_rocket_split_base:
   PLATFORM: xilinx_alveo_u250
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.DualRocketConfig
   PLATFORM_CONFIG: DualRocketTileQSFPBase
@@ -490,6 +520,7 @@ xilinx_u250_firesim_dual_rocket_split_base:
 xilinx_u250_firesim_dual_rocket_split_0:
   PLATFORM: xilinx_alveo_u250
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.DualRocketConfig
   PLATFORM_CONFIG: DualRocketTileQSFP0
@@ -504,6 +535,7 @@ xilinx_u250_firesim_dual_rocket_split_0:
 xilinx_u250_firesim_dual_rocket_split_1:
   PLATFORM: xilinx_alveo_u250
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.DualRocketConfig
   PLATFORM_CONFIG: DualRocketTileQSFP1
@@ -523,6 +555,7 @@ xilinx_u250_firesim_dual_rocket_split_1:
 xilinx_u250_quad_rocket_ring_base:
   PLATFORM: xilinx_alveo_u250
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimQuadRocketSbusRingNoCConfig
   PLATFORM_CONFIG: QuadTileRingNoCBase
@@ -537,6 +570,7 @@ xilinx_u250_quad_rocket_ring_base:
 xilinx_u250_quad_rocket_ring_0:
   PLATFORM: xilinx_alveo_u250
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimQuadRocketSbusRingNoCConfig
   PLATFORM_CONFIG: QuadTileRingNoC0
@@ -551,6 +585,7 @@ xilinx_u250_quad_rocket_ring_0:
 xilinx_u250_quad_rocket_ring_1:
   PLATFORM: xilinx_alveo_u250
   TARGET_PROJECT: firesim
+  TARGET_PROJECT_MAKEFRAG: null
   DESIGN: FireSim
   TARGET_CONFIG: FireSimQuadRocketSbusRingNoCConfig
   PLATFORM_CONFIG: QuadTileRingNoC1

--- a/deploy/sample-backup-configs/sample_config_hwdb.yaml
+++ b/deploy/sample-backup-configs/sample_config_hwdb.yaml
@@ -13,89 +13,111 @@
 firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
     agfi: agfi-04de4143495fbdadb
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
     agfi: agfi-0b7484cfa93e064d6
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_gemmini_printf_rocket_singlecore_no_nic:
     agfi: agfi-0ace16d35c5758893
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_gemmini_rocket_singlecore_no_nic:
     agfi: agfi-05eec5fb565f7cfa3
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
     agfi: agfi-072cc9daac93249da
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
     agfi: agfi-0d0cbe59e2914492a
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_no_nic_l2_lbp:
     agfi: agfi-0cfc97258aa8389f0
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
     agfi: agfi-02e4056f9bec5a240
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
     agfi: agfi-0d8abef077c23a4de
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
     agfi: agfi-033e840230f51668f
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 firesim_supernode_rocket_singlecore_nic_l2_lbp:
     agfi: agfi-0eae0fa36537e2835
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 vitis_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/11ba762decd46c5a933960eae699aaf551d6769f/vitis/vitis_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 vitis_firesim_gemmini_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/0af81b912264abbe3f90f8140987814291090560/vitis/vitis_firesim_gemmini_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u250_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/167cd330431fbf2822ad53bcb11322cb6c845e15/xilinx_alveo_u250/alveo_u250_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u250_firesim_rocket_quadcore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/d87d1232dad4dd59ad3c0ebfb698eeff4b9f2c57/xilinx_alveo_u250/alveo_u250_firesim_rocket_quadcore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u250_firesim_boom_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/9fdc7e05d759a46717b7ae90fece95c054ae4751/xilinx_alveo_u250/alveo_u250_firesim_boom_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u250_firesim_rocket_singlecore_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/df431f268fc76631ba785e179f5c2f85433c68e4/xilinx_alveo_u250/alveo_u250_firesim_rocket_singlecore_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u250_firesim_gemmini_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/d22c9f278e9eaf4ed4130dd0bab737d8ade44f9c/xilinx_alveo_u250/alveo_u250_firesim_gemmini_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u200_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/91e33fabf22cf951f29e231f160728ee8720d4d5/xilinx_alveo_u200/alveo_u200_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 alveo_u280_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/9f8c4a36389e6d9506ad79e3e4f38f43f7fa6fca/xilinx_alveo_u280/alveo_u280_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/0f1f768a805af1c2c2d8d9fd6f4693ba6dec11a0/xilinx_vcu118/xilinx_vcu118_firesim_rocket_singlecore_4GB_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null
 nitefury_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/bd1eb4e58c30a7fd38bb332c76bfff2c2ca4823f/rhsresearch_nitefury_ii/nitefury_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null
+    deploy_makefrag_override: null
     custom_runtime_config: null

--- a/deploy/util/targetprojectutils.py
+++ b/deploy/util/targetprojectutils.py
@@ -1,19 +1,35 @@
 import os
+from pathlib import Path
+import logging
 
-def extra_target_project_make_args(targetproject: str, deploydir: str) -> str:
+from typing import Optional
+
+rootLogger = logging.getLogger()
+
+def extra_target_project_make_args(targetproject: str, targetprojectmakefrag: Optional[str], deploydir: str) -> str:
     """Create extra make args for target projects that live outside FireSim.
     Eventually will be replaced by using YAML hooks.
 
     Args:
         targetproject: make arg corresponding to TARGET_PROJECT.
+        targetprojectmakefrag: optional make arg corresponding to TARGET_PROJECT (must be valid path).
         deploydir: Deploy directory of FireSim
 
     Returns:
         any extra args needed for FireSim's make command to function
     """
-    chipyard_dir = f"{deploydir}/../target-design/chipyard" if os.environ.get('FIRESIM_STANDALONE') else f"{deploydir}/../../.."
-    if targetproject == "firesim":
-        return f"TARGET_PROJECT_MAKEFRAG={chipyard_dir}/generators/firechip/chip/src/main/makefrag/{targetproject}"
-    if targetproject == "bridges":
-        return f"TARGET_PROJECT_MAKEFRAG={chipyard_dir}/generators/firechip/bridgestubs/src/main/makefrag/{targetproject}"
-    return ""
+    if targetprojectmakefrag:
+        p = Path(targetprojectmakefrag)
+        if p.exists():
+            rootLogger.debug(f"Using makefrag path given: {p}")
+            return f"TARGET_PROJECT_MAKEFRAG={targetprojectmakefrag}"
+        else:
+            raise Exception(f"Invalid makefrag path given: {targetprojectmakefrag}")
+    else:
+        chipyard_dir = f"{deploydir}/../target-design/chipyard" if os.environ.get('FIRESIM_STANDALONE') else f"{deploydir}/../../.."
+        rootLogger.debug(f"Having manager assume makefrag path from hardcoded Chipyard dir: {chipyard_dir}")
+        if targetproject == "firesim":
+            return f"TARGET_PROJECT_MAKEFRAG={chipyard_dir}/generators/firechip/chip/src/main/makefrag/{targetproject}"
+        if targetproject == "bridges":
+            return f"TARGET_PROJECT_MAKEFRAG={chipyard_dir}/generators/firechip/bridgestubs/src/main/makefrag/{targetproject}"
+        return ""


### PR DESCRIPTION
Allows users to point to a `TARGET_PROJECT_MAKEFRAG` in `build_recipes` instead of the manager assuming where it is. The path can either be an absolute path or a relative path (relative to the build config file).

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
