### PR TITLE
Fix metasimulations

### DIFF
--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -808,6 +808,8 @@ class RuntimeBuildRecipeConfig(RuntimeHWConfig):
 
         # resolve the path as an absolute path if set
         self.deploy_makefrag = build_recipe_dict.get("TARGET_PROJECT_MAKEFRAG")
+        # TODO: rename this since this can either be the hwdb or the build recipes file (in metasim or normal fpga sim)
+        self.hwdb_file = build_recipes_config_file
         if self.deploy_makefrag:
             base = build_recipes_config_file
             abs_deploy_makefrag = resolve_path(self.deploy_makefrag, base)


### PR DESCRIPTION
Metasimulations would break since there was no `self.hwdb_file` member in the `RuntimeBuildRecipeConfig` class when trying to resolve the makefrag path. This fixes that by assigning it to the build recipes file.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
