### PR TITLE
Fix default Buildroot Linux example workload paths

### DIFF
--- a/deploy/workloads/br-base-flamegraph.json
+++ b/deploy/workloads/br-base-flamegraph.json
@@ -1,9 +1,9 @@
 {
   "benchmark_name": "br-base-flamegraph",
-  "common_bootbinary": "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base-bin",
-  "common_rootfs": "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base.img",
+  "common_bootbinary": "../../../../../software/firemarshal/images/firechip/br-base/br-base-bin",
+  "common_rootfs": "../../../../../software/firemarshal/images/firechip/br-base/br-base.img",
   "common_simulation_inputs": [
-    "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base-bin-dwarf"
+    "../../../../../software/firemarshal/images/firechip/br-base/br-base-bin-dwarf"
   ],
   "common_outputs": [
     "/etc/os-release"

--- a/deploy/workloads/br-base-non-uniform.json
+++ b/deploy/workloads/br-base-non-uniform.json
@@ -1,7 +1,7 @@
 {
   "benchmark_name": "br-base-non-uniform",
-  "common_bootbinary": "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base-bin",
-  "common_rootfs": "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base.img",
+  "common_bootbinary": "../../../../../software/firemarshal/images/firechip/br-base/br-base-bin",
+  "common_rootfs": "../../../../../software/firemarshal/images/firechip/br-base/br-base.img",
   "common_outputs": [
     "/etc/os-release"
   ],

--- a/deploy/workloads/br-base-uniform.json
+++ b/deploy/workloads/br-base-uniform.json
@@ -1,7 +1,7 @@
 {
   "benchmark_name": "br-base-uniform",
-  "common_bootbinary": "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base-bin",
-  "common_rootfs": "../../../target-design/chipyard/software/firemarshal/images/firechip/br-base/br-base.img",
+  "common_bootbinary": "../../../../../software/firemarshal/images/firechip/br-base/br-base-bin",
+  "common_rootfs": "../../../../../software/firemarshal/images/firechip/br-base/br-base.img",
   "common_outputs": [
     "/etc/os-release"
   ],


### PR DESCRIPTION
With the change to using Chipyard-As-Top, these example workload paths were broken. These are fixed to the correct path.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
