### PR TITLE
Update the docs

### DIFF
--- a/docs/FireSim-Basics.rst
+++ b/docs/FireSim-Basics.rst
@@ -92,7 +92,9 @@ links to work through the getting started guide for your particular platform.
 
 - :doc:`/Getting-Started-Guides/AWS-EC2-F1-Getting-Started/index`
 
-  - Status: ✅ All FireSim Features Supported.
+  - Status: ✅ All FireSim Features Supported. ⚠️  F1 instances will be discontinued by AWS on Dec. 20, 2025.
+    We expect support for F1 instances and collateral (AMI's, etc) to slowly be removed/degraded over time.
+    For now, we recommend using on-premises FPGAs. **Stay tuned for AWS EC2 F2 updates**.
 
 - :doc:`/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Xilinx-Alveo-U200-FPGAs`
 
@@ -116,7 +118,7 @@ links to work through the getting started guide for your particular platform.
 
 - :doc:`Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Xilinx-Vitis-FPGAs`
 
-  - Status: ⚠️ DMA-based Bridges Not Supported. The Vitis-based U250 flow is **not
+  - Status: ⚠️  DMA-based Bridges Not Supported. The Vitis-based U250 flow is **not
     recommended** unless you have specific constraints that require using Vitis.
     Notably, the Vitis-based flow does not support DMA-based FireSim bridges (e.g.,
     TracerV, Synthesizable Printfs, etc.), while the XDMA-based flows support all

--- a/docs/Local-FPGA-Initial-Setup.rst
+++ b/docs/Local-FPGA-Initial-Setup.rst
@@ -153,14 +153,18 @@ Next, install the cable drivers like so:
     These commands will need to be re-run everytime the kernel is updated (normally
     whenever the machine is rebooted).
 
+.. warning::
+
+    We use a non-Xilinx given XDMA/XVSEC repository since the mainline repository hasn't updated to 6.4.0+ kernels yet.
+
 First, run the following to clone the XDMA kernel module source:
 
 .. code-block:: bash
 
     cd ~/   # or any directory you would like to work from
-    git clone https://github.com/Xilinx/dma_ip_drivers
+    git clone https://github.com/paulmnt/dma_ip_drivers
     cd dma_ip_drivers
-    git checkout 0e8d321
+    git checkout 247a065
     cd XDMA/linux-kernel/xdma
 
 .. note::
@@ -193,7 +197,7 @@ repository due to kernel version incompatibility:
     cd ~/   # or any directory you would like to work from
     git clone https://github.com/paulmnt/dma_ip_drivers dma_ip_drivers_xvsec
     cd dma_ip_drivers_xvsec
-    git checkout 302856a
+    git checkout 247a065
     cd XVSEC/linux-kernel/
 
     make clean all


### PR DESCRIPTION
Update the docs to point to a XDMA/XVSEC driver that supports 6.4.0 kernels or lower. Additionally, add some extra comments about AWS F1 EOL.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
