### PR TITLE
Misc fixes abe

### DIFF
--- a/deploy/runtools/firesim_topology_elements.py
+++ b/deploy/runtools/firesim_topology_elements.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import abc
 import sys
+import copy
 from fabric.contrib.project import rsync_project  # type: ignore
 from fabric.api import run, local, warn_only, get, put, cd, hide  # type: ignore
 from fabric.exceptions import CommandTimeout  # type: ignore
@@ -261,7 +262,8 @@ class FireSimServerNode(FireSimNode):
         rootLogger.info(
             f"set_server_hardware_config {self.server_id_internal} {self.server_hardware_config}"
         )
-        self.server_hardware_config = server_hardware_config
+        # copy instead of referencing s.t. a unique server_hardware_config is created
+        self.server_hardware_config = copy.deepcopy(server_hardware_config)
 
     def get_server_hardware_config(self) -> Optional[Union[RuntimeHWConfig, str]]:
         return self.server_hardware_config

--- a/sim/make/goldengate.mk
+++ b/sim/make/goldengate.mk
@@ -9,7 +9,9 @@ header := $(GENERATED_DIR)/$(BASE_FILE_NAME).const.h
 
 # The midas-generated simulator RTL which will be baked into the FPGA shell project
 simulator_verilog := $(GENERATED_DIR)/$(BASE_FILE_NAME).sv
-simulator_xdc := $(GENERATED_DIR)/$(BASE_FILE_NAME).synthesis.xdc
+# For metasims a simulator XDC file isn't created (thus the rule will always run since it thinks it should create the file from it).
+# For now, comment this out.
+#simulator_xdc := $(GENERATED_DIR)/$(BASE_FILE_NAME).synthesis.xdc
 
 # Pre-simulation-mapping annotations which includes all Bridge Annotations
 # extracted used to generate new runtime configurations.


### PR DESCRIPTION
Two fixes:

1. Fix metasims from rebuilding due to an extra file output.
2. When running multiple binaries on many servers ensure that the server hardware config is unique (otherwise infrasetup will copy only one set of simulation inputs).

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
