### PR TITLE
Fix: VCU118 Hardcoded BDF & XDMA Permissions + RHEL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ scala-doc-env.sh
 vivado*.log
 vivado*.jou
 __pycache__
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ scala-doc-env.sh
 vivado*.log
 vivado*.jou
 __pycache__
-.DS_Store

--- a/deploy/runtools/run_farm_deploy_managers.py
+++ b/deploy/runtools/run_farm_deploy_managers.py
@@ -1371,6 +1371,10 @@ class XilinxVCU118InstanceDeployManager(InstanceDeployManager):
                 run(f"sudo {cmd}", shell=True)
             else:
                 self.instance_logger("XDMA Driver Kernel Module already loaded.")
+            # run the xdma permissions script -- https://github.com/firesim/firesim/blob/396ef364237f387efec29da798981374c3f7d9d0/deploy/sudo-scripts/firesim-chmod-xdma-perm, otherwise fd != 0 assert fails
+            cmd = f"{script_path}/firesim-chmod-xdma-perm"  # fix: https://github.com/firesim/firesim/blob/396ef364237f387efec29da798981374c3f7d9d0/deploy/runtools/run_farm_deploy_managers.py#L1068
+            check_script(cmd)
+            run(f"sudo {cmd}")
 
     def load_xvsec(self) -> None:
         """load the xvsec kernel modules."""
@@ -1404,9 +1408,9 @@ class XilinxVCU118InstanceDeployManager(InstanceDeployManager):
                 self.instance_logger(f"""Determine BDF for {slotno}""")
                 collect = run("lspci | grep -i xilinx")
 
-                # TODO: is hardcoded cap 0x1 correct?
                 # TODO: is "Partial Reconfig Clear File" useful (see xvsecctl help)?
                 bdfs = [
+                    # capno is hardcoded to 0x1 otherwise xvsecctl program fails
                     {"busno": "0x" + i[:2], "devno": "0x" + i[3:5], "capno": "0x1"}
                     for i in collect.splitlines()
                     if len(i.strip()) >= 0
@@ -1432,10 +1436,10 @@ class XilinxVCU118InstanceDeployManager(InstanceDeployManager):
                 self.instance_logger(f"""Determine BDF for {slotno}""")
                 collect = run("lspci | grep -i xilinx")
 
-                # TODO: is hardcoded cap 0x1 correct?
                 # TODO: is "Partial Reconfig Clear File" useful (see xvsecctl help)?
                 bdfs = [
-                    {"busno": "0x" + i[:2], "devno": "0x" + i[3:5], "capno": "0x1"}
+                    # Cannot hardcode capno to 0x1 here, if 0x1 change permissions sometimes cannot find the device in /sys/bus/pci/devices/
+                    {"busno": "0x" + i[:2], "devno": "0x" + i[3:5], "capno": "0x" + i[6:7]}
                     for i in collect.splitlines()
                     if len(i.strip()) >= 0
                 ]

--- a/deploy/runtools/run_farm_deploy_managers.py
+++ b/deploy/runtools/run_farm_deploy_managers.py
@@ -1371,8 +1371,7 @@ class XilinxVCU118InstanceDeployManager(InstanceDeployManager):
                 run(f"sudo {cmd}", shell=True)
             else:
                 self.instance_logger("XDMA Driver Kernel Module already loaded.")
-            # run the xdma permissions script -- https://github.com/firesim/firesim/blob/396ef364237f387efec29da798981374c3f7d9d0/deploy/sudo-scripts/firesim-chmod-xdma-perm, otherwise fd != 0 assert fails
-            cmd = f"{script_path}/firesim-chmod-xdma-perm"  # fix: https://github.com/firesim/firesim/blob/396ef364237f387efec29da798981374c3f7d9d0/deploy/runtools/run_farm_deploy_managers.py#L1068
+            cmd = f"{script_path}/firesim-chmod-xdma-perm"
             check_script(cmd)
             run(f"sudo {cmd}")
 

--- a/deploy/runtools/utils.py
+++ b/deploy/runtools/utils.py
@@ -49,7 +49,7 @@ def get_local_shared_libraries(elf: str) -> List[Tuple[str, str]]:
     )
     rootLogger.debug(f"Running on OS: {os_flavor}")
 
-    if os_flavor not in ["ubuntu", "centos", "amzn", "debian"]:
+    if os_flavor not in ["ubuntu", "centos", "amzn", "debian", "rhel"]:
         raise ValueError(f"Unknown OS: {os_flavor}")
 
     glibc_shared_libs = []
@@ -74,7 +74,7 @@ def get_local_shared_libraries(elf: str) -> List[Tuple[str, str]]:
             glibc_shared_libs.extend(dpkg_output_paths.stdout.split("\n"))
 
         rootLogger.debug(glibc_shared_libs)
-    elif os_flavor in ["centos", "amzn"]:
+    elif os_flavor in ["centos", "amzn", "rhel"]:
         with settings(warn_only=True):
             rpm_output = local(
                 "rpm -q -f /lib64/libc.so* --filesbypkg | grep -P '\.so(\.|\s*$)'"


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

Fixes 3 things: 
1. Hardcoded BDF results in firesim trying to modify permissions for an nonexistent device: https://groups.google.com/g/firesim/c/xTeYBAevWeA
2. firesim doesn't execute a chmod permissions change during `load_xdma` on the VCU118 flow, results in `chmod: cannot access '/sys/bus/pct/devices/0000*01*00*1/vendor': No such file or directory error`
3. Support running firesim on RHEL systems - uses the same execution flow as centos & amazon linux
    * The specific error resulting in running on an unsupported system (RHEL) is:
    ```
    raise ValueError(f"Unknown OS: {os_flavor}")
    ValueError: Unknown OS: rhel
    ```

#### UI / API Impact
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->
None - should restore functionality for the VCU118 flow so that `infrasetup` doesn't throw errors & correct BDF is targeted.


#### Verilog / AGFI Compatibility
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->
This shouldn't affect Verilog / AGFI compatibility

#### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label? [No permissions to add labels]
- [N/A] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [N/A] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [N/A] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?
* Ideally yes, but rolling this out on the next release would be fine as well.

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
