### PR TITLE
docs: clarify AWS F2 setup flow and fix F2 repo setup guidance

### DIFF
--- a/docs/AWS-EC2-F2-Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
@@ -95,6 +95,9 @@ SSH into the ``t2.nano`` like so:
 
     ssh -i firesim.pem ec2-user@INSTANCE_PUBLIC_IP
 
+Replace ``INSTANCE_PUBLIC_IP`` with the **Public IPv4 address** shown in the EC2 console
+for your ``t2.nano`` instance.
+
 Which should present you with something like:
 
 .. code-block:: text
@@ -120,12 +123,23 @@ On this machine, run the following:
 
 Within the prompt, you should specify the same region that you chose above (e.g.,
 ``us-east-1``, ``us-west-2``) and set the default output format to
-``json``. You will need to generate an AWS access key in the "Security Credentials" menu
-of your AWS settings (as instructed in
+``json``. You will also need to provide an AWS access key ID and secret access key for
+programmatic access. There are two ways to obtain these credentials:
+
+- **IAM user (recommended):** Create an IAM user with programmatic access in the
+  `IAM Console <https://console.aws.amazon.com/iam/>`__, attach appropriate permissions
+  (e.g., ``AdministratorAccess`` for simplicity during initial setup), and generate an
+  access key for that user under its *Security credentials* tab. Using an IAM user is
+  the AWS-recommended approach for CLI/programmatic access.
+- **Root user:** You can generate an access key under *Security credentials* in the
+  account dropdown menu at the top-right of the AWS console. However, AWS recommends
+  against using root credentials for day-to-day programmatic access.
+
+See
 https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey
-). You should keep the AWS access key information in a safe place, so that you can refer
-to it again when setting up the manager instance. You can learn more about the ``aws
-configure`` command on the following page:
+for detailed instructions. You should keep the AWS access key information in a safe
+place, so that you can refer to it again when setting up the manager instance. You can
+learn more about the ``aws configure`` command on the following page:
 https://docs.aws.amazon.com/cli/latest/reference/configure/index.html
 
 Again on the ``t2.nano`` instance, do the following:

--- a/docs/AWS-EC2-F2-Initial-Setup/First-time-AWS-User-Setup.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/First-time-AWS-User-Setup.rst
@@ -49,7 +49,16 @@ If you have insufficient limits, request a limit increase by following these ste
 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#request-increase
 
 In your request, enter the vCPU limits for the two instance classes shown above. This
-process sometimes has a human in the loop, so you should submit it ASAP. At this point,
-you should wait for the response to this request.
+process sometimes has a human in the loop, so you should submit it ASAP.
+
+.. note::
+
+    You do not need to wait for the F-instance quota increase to be approved before
+    continuing. You can proceed with the remaining account setup and infrastructure
+    preparation steps (key setup, VPC/security group creation, manager instance launch,
+    etc.) while the quota request is pending. The F-instance quota is only required later,
+    when you actually launch F2-backed run farm instances for simulations. The
+    ``Running On-Demand Standard`` quota **is** needed to launch the manager and build
+    farm instances, so ensure that quota is sufficient before proceeding.
 
 Hit Next below to continue.

--- a/docs/AWS-EC2-F2-Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -51,8 +51,19 @@ To launch a manager instance, follow these steps:
 7.  In the *Configure storage* section, increase the size of the root volume to at least
    300GB. The default of 120GB can quickly become too small as you accumulate large
    Vivado reports/outputs, large waveforms, XSim outputs, and large root filesystems for
-   simulations. You should remove the small (5-8GB) secondary volume that is added by
-   default.
+   simulations. You should also remove the small secondary EBS volume (typically 5-8GB,
+   though the exact size may vary by AMI version) that is added by default — this is a
+   non-root data volume that is not needed for FireSim.
+
+   .. note::
+
+      If the EC2 launch wizard does not provide a clear option to remove the secondary
+      volume, you can proceed with the launch as-is. After the instance is running, go
+      to the **Volumes** section of the EC2 console, identify the small non-root volume
+      attached to your instance (it will not be the volume mounted as ``/``), detach it,
+      and then delete it. This is a pragmatic workaround — removing it during launch is
+      still preferred when the UI allows it.
+
 8.  In the *Advanced details* drop-down, change the following:
 
    1. Under *Termination protection*, select Enable. This adds a layer of protection to
@@ -100,8 +111,9 @@ On this instance, the ``mosh`` server is installed as part of the setup script w
 before, so we need to first ssh into the instance and make sure the setup is complete.
 
 In either case, ``ssh`` into your instance (e.g. ``ssh -i firesim.pem
-ubuntu@YOUR_INSTANCE_IP``) and wait until the ``/tmp/machine-launchstatus`` file
-contains all the following text:
+ubuntu@YOUR_INSTANCE_IP``, where ``YOUR_INSTANCE_IP`` is the **Public IPv4 address**
+shown in the EC2 console for your instance) and wait until the
+``/tmp/machine-launchstatus`` file contains all the following text:
 
 .. code-block:: bash
 
@@ -122,3 +134,12 @@ Key Setup, Part 2
 Now that our manager instance is started, copy the private key that you downloaded from
 AWS earlier (``firesim.pem``) to ``~/firesim.pem`` on your manager instance. This step
 is required to give the manager access to the instances it launches for you.
+
+From your local machine, you can use ``scp`` to copy the key:
+
+.. code-block:: bash
+
+    scp -i /path/to/firesim.pem /path/to/firesim.pem ubuntu@YOUR_INSTANCE_IP:~/firesim.pem
+
+Replace ``/path/to/firesim.pem`` with the local path to your downloaded key file and
+``YOUR_INSTANCE_IP`` with the **Public IPv4 address** of your manager instance.

--- a/docs/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/Setting-Up-The-FireSim-Repo.rst
+++ b/docs/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/Setting-Up-The-FireSim-Repo.rst
@@ -13,20 +13,22 @@ designs (e.g. RISC-V SoCs) and software (e.g. Linux) used for the rest of this g
     machine. Even if you already have a Chipyard checkout elsewhere, you need a fresh
     clone on the manager instance for the AWS flow.
 
-.. note::
+.. warning::
 
-    This guide was built using Chipyard version |cy_docs_version|. It is recommended to
-    use the most up-to-date version of Chipyard with this tutorial.
+    The AWS EC2 F2 flow requires a Chipyard version whose FireSim submodule includes
+    ``f2`` platform support. The pinned commit referenced in some versions of these docs
+    (|cy_docs_version|) was used when this guide was originally authored and **may not
+    include F2 support**. Even the Chipyard ``main`` branch may temporarily lag behind
+    if its pinned FireSim submodule has not yet been updated for F2. Use the
+    verification step after setup to confirm ``f2`` is available before proceeding.
 
 Run:
 
 .. code-block:: bash
-    :substitutions:
 
     git clone https://github.com/ucb-bar/chipyard
     cd chipyard
-    # ideally use the main chipyard release instead of this
-    git checkout |cy_docs_version|
+    git checkout main
     ./build-setup.sh
 
 This will have initialized submodules and installed the RISC-V tools and other
@@ -48,6 +50,24 @@ requires a passphrase, you will be asked for it here and ``ssh-agent`` should ca
 **Every time you login to your manager instance to use FireSim, you should** ``cd``
 **into your firesim directory and source this file again.**
 
+.. tip::
+
+    After sourcing, verify that your checkout supports the F2 platform:
+
+    .. code-block:: bash
+
+        firesim managerinit --help
+
+    Confirm that ``f2`` appears in the list of valid ``--platform`` choices. If it does
+    not, your current Chipyard/FireSim checkout does not include F2 platform support —
+    see the troubleshooting note in the next section.
+
+.. note::
+
+    If you move or delete the Chipyard directory after sourcing
+    ``sourceme-manager.sh``, your current shell may still have stale paths cached.
+    Open a fresh shell (or log out and back in) to resolve this.
+
 Completing Setup Using the Manager
 ==================================
 
@@ -57,6 +77,35 @@ rest of the FireSim setup process. To run it, do the following:
 .. code-block:: bash
 
     firesim managerinit --platform f2
+
+.. note::
+
+    **Troubleshooting: f2 is not listed as a valid platform.**
+    The FireSim submodule pinned by your Chipyard branch may not yet include F2 support
+    (these docs may describe features ahead of the pinned submodule version). To
+    recover, update the submodule and rebuild from a **fresh shell**:
+
+    .. code-block:: bash
+
+        # Start a fresh shell, then:
+        cd ~/chipyard               # adjust to your Chipyard location
+        source env.sh               # sets RISCV and other required variables
+
+        cd sims/firesim
+        git fetch origin
+        git checkout main
+        git pull --ff-only
+
+        ./build-setup.sh --library
+        source sourceme-manager.sh
+        firesim managerinit --help  # verify f2 appears
+
+    Confirm that ``f2`` appears before re-running
+    ``firesim managerinit --platform f2``.
+
+    **Do not** run ``git submodule update`` from the Chipyard root after this recovery —
+    it will reset ``sims/firesim`` back to the (possibly F2-incompatible) revision
+    pinned by your Chipyard branch.
 
 This will first prompt you to setup AWS credentials on the instance, which allows the
 manager to automatically manage build/simulation nodes. You can use the same AWS access

--- a/docs/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/Setting-Up-The-FireSim-Repo.rst
+++ b/docs/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/Setting-Up-The-FireSim-Repo.rst
@@ -6,6 +6,13 @@ Setting up the FireSim Repo
 Lets fetch FireSim's sources with Chipyard. Chipyard provides all the necessary target
 designs (e.g. RISC-V SoCs) and software (e.g. Linux) used for the rest of this guide.
 
+.. important::
+
+    The commands below should be run **on your FireSim manager instance** (the EC2
+    instance you launched in the previous section), not on your local laptop or another
+    machine. Even if you already have a Chipyard checkout elsewhere, you need a fresh
+    clone on the manager instance for the AWS flow.
+
 .. note::
 
     This guide was built using Chipyard version |cy_docs_version|. It is recommended to

--- a/docs/Local-FPGA-Initial-Setup.rst
+++ b/docs/Local-FPGA-Initial-Setup.rst
@@ -9,6 +9,16 @@ machine in your setup**; in this case, you should follow all the installation
 instructions on your single machine, without duplication (i.e., don't re-run a step on
 the same machine if it is required on multiple machine types).
 
+.. note::
+
+    **Machine roles in this guide:**
+    Throughout this page, instructions are labeled with the machine type they apply to
+    (e.g., "Manager Machine", "Run Farm Machines", "Build Farm Machines"). These refer
+    to the actual machines participating in the FireSim deployment — not your personal
+    laptop or workstation. Your laptop/workstation is simply the client you use to SSH
+    into these machines. If all three roles are served by a single physical machine,
+    follow all instructions on that machine.
+
 .. warning::
 
     **We highly recommend using Ubuntu 20.04 LTS as the host operating system for all
@@ -261,7 +271,8 @@ Non-``sudo`` Setup
 **Machines:** Manager Machine, Run Farm Machines, Build Farm Machines.
 
 We need various parts of the ``~/.bashrc`` file to execute even in non-interactive mode.
-To do so, edit your ``~/.bashrc`` file so that the following section is removed:
+To do so, check your ``~/.bashrc`` file for the following section and remove it if
+present:
 
 .. code-block:: bash
 
@@ -270,6 +281,8 @@ To do so, edit your ``~/.bashrc`` file so that the following section is removed:
          *i*) ;;
            *) return;;
     esac
+
+If this block is not present in your ``~/.bashrc``, you can skip this step.
 
 **2. Set up SSH Keys**
 
@@ -282,15 +295,22 @@ machines:
 .. code-block:: bash
 
     cd ~/.ssh
-    ssh-keygen -t ed25519 -C "firesim.pem" -f firesim.pem
+    ssh-keygen -t ed25519 -C "firesim-local" -f firesim-local
     [create passphrase]
+
+.. note::
+
+    We use the key name ``firesim-local`` (rather than ``firesim.pem``) to avoid a
+    naming collision with the AWS EC2 key pair file also called ``firesim.pem``. If you
+    are also following the AWS setup flow, using a distinct name here prevents
+    accidentally overwriting your AWS key.
 
 Next, add this key to the ``authorized_keys`` file on the manager machine:
 
 .. code-block:: bash
 
     cd ~/.ssh
-    cat firesim.pem.pub >> authorized_keys
+    cat firesim-local.pub >> authorized_keys
     chmod 0600 authorized_keys
 
 You should also copy this public key into the ``~/.ssh/authorized_keys`` files on all of
@@ -303,7 +323,7 @@ Returning to the Manager Machine, let's set up an ``ssh-agent``:
     cd ~/.ssh
     ssh-agent -s > AGENT_VARS
     source AGENT_VARS
-    ssh-add firesim.pem
+    ssh-add firesim-local
 
 If you reboot your machine (or otherwise kill the ``ssh-agent``), you will need to
 re-run the above four commands before using FireSim. If you open a new terminal (and


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

This PR clarifies several confusing parts of the AWS F2 and Local FPGA setup docs based on current setup behavior and user-facing pitfalls. It improves quota/credential guidance, manager-instance setup instructions, key-handling clarity, machine-role guidance, and fixes the AWS F2 repo-setup docs so they no longer steer users into a checkout flow that can still yield a FireSim CLI without `f2` platform support. It also adds a concise verification/troubleshooting path for recovering by updating the FireSim submodule and rebuilding in library mode.

#### Related PRs / Issues

None.

#### UI / API Impact

Docs only. No API, config, platform behavior, or user-facing interface changes beyond clearer setup instructions.

#### Verilog / AGFI Compatibility

None. This PR does not change generated Verilog, AGFIs, simulator memory maps, or target behavior.

#### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI