### PR TITLE
fixed enumrate failure for VCU118

### DIFF
--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -291,6 +291,20 @@ class RunFarm(metaclass=abc.ABCMeta):
         )
         raise Exception
 
+    def needs_fpga_enumeration(self) -> bool:
+        """Check if any host in the run farm needs FPGA enumeration.
+        
+        Returns True if at least one host's platform requires enumeration.
+        Platforms like VCU118 discover BDFs dynamically and don't need enumeration.
+        """ 
+        for ip_addr, host_list in self.run_farm_hosts_dict.items():
+            for inst, _ in host_list:
+                deploy_manager = inst.instance_deploy_manager
+                # Default to True if attribute not defined (conservative)
+                if getattr(deploy_manager, 'NEED_ENUMERATION', True):
+                    return True
+        return False
+
     @abc.abstractmethod
     def post_launch_binding(self, mock: bool = False) -> None:
         """Bind launched platform API objects to run hosts (only used in firesim-managed runfarms).
@@ -336,6 +350,7 @@ class RunFarm(metaclass=abc.ABCMeta):
     def terminate_by_inst(self, inst: Inst) -> None:
         """Terminate run farm host based on Inst object."""
         raise NotImplementedError
+    
 
 
 def invert_filter_sort(input_dict: Dict[str, int]) -> List[Tuple[int, str]]:

--- a/deploy/runtools/run_farm_deploy_managers.py
+++ b/deploy/runtools/run_farm_deploy_managers.py
@@ -65,6 +65,10 @@ class InstanceDeployManager(metaclass=abc.ABCMeta):
 
     parent_node: Inst
     nbd_tracker: Optional[NBDTracker]
+    # Not all platforms need enumeration
+    # but the guide still say to do enumeration - which will fail for those platforms
+    # make knob to skip for platforms that dynamically checks BDF
+    NEED_ENUMERATION: bool = True
 
     def __init__(self, parent_node: Inst) -> None:
         """
@@ -1354,6 +1358,7 @@ class XilinxVCU118InstanceDeployManager(InstanceDeployManager):
     garnet shell."""
 
     PLATFORM_NAME: Optional[str]
+    NEED_ENUMERATION = False
 
     def __init__(self, parent_node: Inst) -> None:
         super().__init__(parent_node)

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -1121,15 +1121,23 @@ class RuntimeConfig:
 
         self.args = args
 
-        # construct pythonic db of hardware configurations available to us at
-        # runtime.
-        self.runtimehwdb = RuntimeHWDB(args.hwdbconfigfile)
-        rootLogger.debug(self.runtimehwdb)
-
         self.innerconf = InnerRuntimeConfiguration(
             args.runtimeconfigfile, args.overrideconfigdata
         )
         rootLogger.debug(self.innerconf)
+
+        self.run_farm = self.innerconf.run_farm_dispatcher
+
+        # for enumeration check if platform actually needs it
+        if args.task == "enumeratefpgas" and not self.run_farm.needs_fpga_enumeration():
+            rootLogger.info("Skipping FPGA enumeration - platform discover BDF dynamically")
+            return
+
+        
+        # construct pythonic db of hardware configurations available to us at
+        # runtime.
+        self.runtimehwdb = RuntimeHWDB(args.hwdbconfigfile)
+        rootLogger.debug(self.runtimehwdb)       
 
         self.runtime_build_recipes = RuntimeBuildRecipes(
             args.buildrecipesconfigfile,
@@ -1138,8 +1146,6 @@ class RuntimeConfig:
             self.innerconf.metasimulation_only_vcs_plusargs,
         )
         rootLogger.debug(self.runtime_build_recipes)
-
-        self.run_farm = self.innerconf.run_farm_dispatcher
 
         # setup workload config obj, aka a list of workloads that can be assigned
         # to a server
@@ -1226,7 +1232,11 @@ class RuntimeConfig:
 
     def enumerate_fpgas(self) -> None:
         """directly called by top-level enumeratefpgas command."""
-        use_mock_instances_for_testing = False
+        # if platform dosnt need enum, return
+        if not hasattr(self, 'firesim_topology_with_passes'):
+            return
+        
+        use_mock_instances_for_testing = False        
         self.firesim_topology_with_passes.enumerate_fpgas_passes(
             use_mock_instances_for_testing
         )
@@ -1249,3 +1259,5 @@ class RuntimeConfig:
         self.firesim_topology_with_passes.run_workload_passes(
             use_mock_instances_for_testing
         )
+
+


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

When running on VCU118 - which does not require enumeration, the guide still say to do that step.
unfortunately the step expects a config_hwdb.yaml to be present. which is wont be - hence the enumeration will fail.

This update will check the platform and skip the enumeration step all together.

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact
Adds `NEED_ENUMERATIOM` attribute to base class, and sets this to false for VCU118 (default is true, so this wont impact any other platforms)

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
No Changes to Verilog, just infrastructure!

#### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
