### PR TITLE
Added two options --ssh-key option to specify custom key location, and --ssh-user to use a custom user for connecting to the farms

### DIFF
--- a/deploy/firesim
+++ b/deploy/firesim
@@ -434,6 +434,8 @@ def construct_firesim_argparser() -> argparse.ArgumentParser:
                         help='Give the "Y-m-d--H-M-S" prefix of results-build directory. Useful for tar2afi when finishing a partial buildbitstream')
     parser.add_argument('--platform', type=str, choices=PLATFORM_LIST, default='f2',
                         help='Required argument for "managerinit" to specify which platform you will be using')
+    parser.add_argument('--ssh-key-file', type=str, default=None,
+                        help='Path to SSH private key file for connecting to run farm hosts. If not specified, checks ~/firesim.pem and ~/.ssh/firesim.pem, then falls back to SSH agent or ~/.ssh/id_rsa')
 
     argcomplete.autocomplete(parser)
     return parser
@@ -458,8 +460,18 @@ def main(args: argparse.Namespace) -> None:
     # we elastically spin instances up/down. we can easily get re-used IPs with
     # different keys. also, probably won't get MITM'd
     env.disable_known_hosts = True
-    env.key_filename = os.path.expanduser("~/firesim.pem") #rh: okay so /firesim.pem does work for infrasetup, need to bump paramiko though to support rsa2
 
+    # Set SSH key if found. Check common locations, or use --ssh-key argument to override.
+    # If no key isfound use the default SSH agent or ~/.ssh/id_rsa
+    ssh_key_locations = [
+        args.ssh_key_file,  # command line override (highest priority)
+        os.path.expanduser("~/firesim.pem"),      # AWS default location
+        os.path.expanduser("~/.ssh/firesim.pem"), # alternative location
+    ]
+    for key_path in ssh_key_locations:
+        if key_path and os.path.exists(key_path):
+            env.key_filename = key_path
+            break
 
     rootLogger.info("FireSim Manager. Docs: https://docs.fires.im\nRunning: %s\n", str(args.task))
 

--- a/deploy/firesim
+++ b/deploy/firesim
@@ -436,6 +436,8 @@ def construct_firesim_argparser() -> argparse.ArgumentParser:
                         help='Required argument for "managerinit" to specify which platform you will be using')
     parser.add_argument('--ssh-key-file', type=str, default=None,
                         help='Path to SSH private key file for connecting to run farm hosts. If not specified, checks ~/firesim.pem and ~/.ssh/firesim.pem, then falls back to SSH agent or ~/.ssh/id_rsa')
+    parser.add_argument('--ssh-user', type=str, default=None,
+                        help='use a different user for ssh connections like ec2_user, if not specified default is current user')
 
     argcomplete.autocomplete(parser)
     return parser
@@ -460,6 +462,9 @@ def main(args: argparse.Namespace) -> None:
     # we elastically spin instances up/down. we can easily get re-used IPs with
     # different keys. also, probably won't get MITM'd
     env.disable_known_hosts = True
+    # if user option given, override default
+    if args.ssh_user:
+        env.user = args.ssh_user
 
     # Set SSH key if found. Check common locations, or use --ssh-key argument to override.
     # If no key isfound use the default SSH agent or ~/.ssh/id_rsa

--- a/deploy/ssh-setup.sh
+++ b/deploy/ssh-setup.sh
@@ -32,6 +32,8 @@ if ssh-add -l | grep -q 'firesim\.pem'; then
 else
     if ssh-add ~/firesim.pem; then
         echo "success: ~/firesim.pem added to ssh-agent"
+    elif ssh-add ~/.ssh/firesim.pem; then
+        echo "success: ~/.ssh/firesim.pem added to ssh-agent"
     else
         echo "FAIL: ERROR adding ~/firesim.pem to ssh-agent. If on AWS F2, does it exist?"
     fi


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
These updates are making my life easier on a corporate setup, where I don't have true control.

Adds flexibility for SSH key management by allowing users to specify a custom path to their SSH private key file instead of requiring it in a fixed location. 

implemented as priority based discovery
1 --shh-key-file <path to file> (higest priority)
2 current location
3. ~/.ssh/ (lowest - check this if key not found in 1 or 2)
4.  fall back to ssh agent

adds option to use a different user for ssh access to farms. 


#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
Only affects infrastructure 

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
