### PR TITLE
June 2026 Chipyard & FireSim Release

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-    os: ubuntu-20.04
+    os: ubuntu-lts-latest
     tools:
         python: "mambaforge-4.10"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 This changelog follows the format defined here: https://keepachangelog.com/en/1.0.0/
 
+## [1.21.0] - 2026-06-21
+
+FireSim 1.21.0 adds initial AWS F2 support, updates FPGA/local deployment infrastructure, refreshes key dependencies and documentation, and fixes several VCU118, XDMA, metasimulation, and workload issues. 
+
+FireSim is now returning to regular releases at a 3-4 month pace!
+
+### Added
+
+- Add AWS F2 instance support, including basic support for building F2 AGFIs and running single-node simulations (by @jkjkim in #1868)
+- Add additional F2 upstreaming fixes and remove vestigial driver debug behavior (by @rickydumplings in #1871)
+- Add back the `garnet-firesim` submodule (by @marie-anne-xu in #1878)
+- Pre-populate the `bare-base` workload (by @raghav-g13 in #1835)
+- Add a simple top-level counter example with clock, reset, and max-cycle timeout support (by @abejgonzalez in #1823)
+- Support pointing to makefrags in YAML (by @abejgonzalez in #1806)
+- Support using FIRRTL2 as input for Chipyard’s version of FireSim (by @abejgonzalez in #1804)
+- Decouple FireSim from Chipyard so Chipyard-based designs clone Chipyard first instead of relying on FireSim’s Chipyard submodule (by @abejgonzalez in #1791)
+
+### Changed
+
+- Fix F2 timing, PCI, shim, and manager issues, and bump the upstream `aws-fpga-firesim-f2` support to AWS FPGA 2.3.2 (by @sagark, implemented/co-authored by @marie-anne-xu  @rickydumplings in #1879)
+- Update `doc/README.md` to reflect that Python requirements are now handled by Conda (by @rasmus-madsen in #1866)
+- Update docs to point to the new XDMA flow (by @joonho3020 in #1858)
+- Update FireSim documentation, including XDMA/XVSEC driver guidance and AWS F1 EOL notes (by @abejgonzalez in #1844)
+- Update GitHub release automation by bumping `softprops/action-gh-release` from 2.0.8 to 2.2.0 (by @dependabot in #1843)
+- Update `utils/fireperf/FlameGraph` from `cd9ee4c` to `41fee1f` (by @dependabot in #1833)
+- Bump the VCU118 `garnet-firesim` dependency for a bug fix (by @raghav-g13 in #1827)
+- Bump `sim/rocket-chip` from `d0c6b50` to `1b9f433` (by @dependabot in #1826)
+- Bump to a newer version of Chipyard with documentation fixes (by @abejgonzalez in #1821)
+- Bump `sim/rocket-chip` from `50744b3` to `d0c6b50` (by @dependabot in #1819)
+- Bump `sim/diplomacy` from `6b7dc98` to `a042ff6` (by @dependabot in #1818)
+- Reformat Scala and Python code (by @abejgonzalez in #1814)
+- Bump `sim/rocket-chip` from `ea9979b` to `50744b3` (by @dependabot in #1812)
+- Bump `sim/berkeley-hardfloat` from `4225367` to `26f00d0` (by @dependabot in #1810)
+- Update AMI handling for the release (by @jimfangx)
+- Restrict AGFI descriptions to less than 1000 characters and fix typo (by @jimfangx)
+
+### Fixed
+
+- Fix FPGA enumeration failure for VCU118 (by @rasmus-madsen in #1880)
+- Fix `monitor_job_instance` to return all expected keys (by @Ferran-Hermida-Rivera in #1865)
+- Fix VCU118/local FPGA infrastructure issues, including hardcoded BDF handling, XDMA permission setup, missing XDMA script execution, and RHEL support (by @jimfangx in #1857)
+- Fix default Buildroot Linux example workload paths (by @abejgonzalez in #1832)
+- Switch EC2 setup to CentOS 7 vault archive repos (by @abejgonzalez in #1830)
+- Include 1.20.1 fixes (by @ffard-lbl in #1824)
+- Fix metasimulations by correctly resolving the makefrag path from runtime build recipe configuration (by @abejgonzalez in #1822)
+- Fix and add PointerChaser tests to CI (by @abejgonzalez in #1813)
+- Bump Conda lock requirements to fix broken AWS setup dependencies (by @abejgonzalez in #1805)
+
+### Removed
+
+- Remove checked-in Xilinx Aurora example design collateral from upstream (by @jimfangx in #1873)
+- Remove the Chipyard submodule from FireSim; Chipyard designs must clone Chipyard first (by @abejgonzalez in #1809)
+
+
 ## [1.20.1] - 2024-08-21
 
 Small QoL updates and fixes. Moves FireSim paper workloads to Chipyard.

--- a/deploy/awstools/afitools.py
+++ b/deploy/awstools/afitools.py
@@ -123,7 +123,8 @@ def firesim_tags_to_description(
 ):
     """Serialize the tags we want to set for storage in the AGFI description"""
     # note: the serialized rep still includes "triplets" for future manager versions to be compatible with old agfis
-    return f"""firesim-buildquintuplet:{build_quintuplet},firesim-deployquintuplet:{deploy_quintuplet},firesim-buildtriplet:{build_triplet},firesim-deploytriplet:{deploy_triplet},firesim-commit:{commit},firesim-buildmakefrag:{build_makefrag},firesim-deploymakefrag:{deploy_makefrag}"""
+    # warning: do not exceed 1000 characters in description, otherwise agfis build will not finish/fail to share.
+    return f"""firesim-buildquintuplet:{build_quintuplet},firesim-deployquintuplet:{deploy_quintuplet},firesim-buildtriplet:{build_triplet},firesim-deploytriplet:{deploy_triplet},firesim-commit:{commit}"""
 
 
 def firesim_description_to_tags(description):

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -53,7 +53,7 @@ def get_f2_ami_name() -> str:
             print(
                 "Unknown $USER (expected ubuntu/amzn). Defaulting to the Ubuntu AWS EC2 AMI."
             )
-        return "FPGA Developer AMI (Ubuntu) - 1.17.0   -prod-rhng4b6alkhdq"
+        return "FPGA Developer AMI (Ubuntu) - 1.19.1-prod-rhng4b6alkhdq"
 
 
 def get_incremented_f2_ami_name(ami_name: str, increment: int) -> str:

--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -53,7 +53,7 @@ def get_f2_ami_name() -> str:
             print(
                 "Unknown $USER (expected ubuntu/amzn). Defaulting to the Ubuntu AWS EC2 AMI."
             )
-        return "FPGA Developer AMI (Ubuntu) - 1.19.1-prod-rhng4b6alkhdq"
+        return "FPGA Developer AMI (Ubuntu) - 1.19.2-prod-rhng4b6alkhdq"
 
 
 def get_incremented_f2_ami_name(ami_name: str, increment: int) -> str:

--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -244,7 +244,7 @@ class F2BitBuilder(BitBuilder):
             local_dir=local_awsfpga_dir,
             remote_dir=dest_f2_platform_dir,
             ssh_opts="-o StrictHostKeyChecking=no",
-            exclude=["hdk/cl/developer_designs/cl_*", ".git"],
+            exclude=["hdk/cl/developer_designs/cl_*", ".git", "hdk/common/ip", "hdk/common/shell_stable/hlx"],
             extra_opts="-l",
             capture=True,
         )
@@ -253,7 +253,7 @@ class F2BitBuilder(BitBuilder):
         rsync_cap = rsync_project(
             local_dir=f"{local_awsfpga_dir}/{fpga_build_postfix}/*",
             remote_dir=f"{dest_awsfpga_dir}/{fpga_build_postfix}",
-            exclude=["build/checkpoints", ".git"],
+            exclude=["build/checkpoints", ".git", "hdk/common/ip", "hdk/common/shell_stable/hlx"],
             ssh_opts="-o StrictHostKeyChecking=no",
             extra_opts="-l",
             capture=True,

--- a/deploy/buildtools/bitbuilder.py
+++ b/deploy/buildtools/bitbuilder.py
@@ -222,12 +222,29 @@ class F2BitBuilder(BitBuilder):
         # do the rsync, but ignore any checkpoints that might exist on this machine
         # (in case builds were run locally)
         # extra_opts -l preserves symlinks
+        with prefix("cd ../"):
+            # use local version of aws_fpga on build farm nodes
+            aws_fpga_upstream_version = local(
+                "git -C platforms/f2/aws-fpga-firesim-f2 describe --tags --always --dirty",
+                capture=True,
+            )
+            if "-dirty" in aws_fpga_upstream_version:
+                aws_fpga_upstream_version = aws_fpga_upstream_version.replace("-dirty", "")
+                rootLogger.critical(
+                    "Unable to use local changes to aws-fpga. Continuing without them."
+                )
+
         run(f"mkdir -p {dest_f2_platform_dir}")
+        with prefix("cd " + dest_f2_platform_dir):
+            run("git clone https://github.com/firesim/aws-fpga-firesim-f2.git")
+        with prefix("cd " + dest_awsfpga_dir):
+            run("git checkout " + aws_fpga_upstream_version)
+
         rsync_cap = rsync_project(
             local_dir=local_awsfpga_dir,
             remote_dir=dest_f2_platform_dir,
             ssh_opts="-o StrictHostKeyChecking=no",
-            exclude=["hdk/cl/developer_designs/cl_*"],
+            exclude=["hdk/cl/developer_designs/cl_*", ".git"],
             extra_opts="-l",
             capture=True,
         )
@@ -236,7 +253,7 @@ class F2BitBuilder(BitBuilder):
         rsync_cap = rsync_project(
             local_dir=f"{local_awsfpga_dir}/{fpga_build_postfix}/*",
             remote_dir=f"{dest_awsfpga_dir}/{fpga_build_postfix}",
-            exclude=["build/checkpoints"],
+            exclude=["build/checkpoints", ".git"],
             ssh_opts="-o StrictHostKeyChecking=no",
             extra_opts="-l",
             capture=True,

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -291,6 +291,20 @@ class RunFarm(metaclass=abc.ABCMeta):
         )
         raise Exception
 
+    def needs_fpga_enumeration(self) -> bool:
+        """Check if any host in the run farm needs FPGA enumeration.
+        
+        Returns True if at least one host's platform requires enumeration.
+        Platforms like VCU118 discover BDFs dynamically and don't need enumeration.
+        """ 
+        for ip_addr, host_list in self.run_farm_hosts_dict.items():
+            for inst, _ in host_list:
+                deploy_manager = inst.instance_deploy_manager
+                # Default to True if attribute not defined (conservative)
+                if getattr(deploy_manager, 'NEED_ENUMERATION', True):
+                    return True
+        return False
+
     @abc.abstractmethod
     def post_launch_binding(self, mock: bool = False) -> None:
         """Bind launched platform API objects to run hosts (only used in firesim-managed runfarms).
@@ -336,6 +350,7 @@ class RunFarm(metaclass=abc.ABCMeta):
     def terminate_by_inst(self, inst: Inst) -> None:
         """Terminate run farm host based on Inst object."""
         raise NotImplementedError
+    
 
 
 def invert_filter_sort(input_dict: Dict[str, int]) -> List[Tuple[int, str]]:

--- a/deploy/runtools/run_farm_deploy_managers.py
+++ b/deploy/runtools/run_farm_deploy_managers.py
@@ -691,6 +691,7 @@ class EC2InstanceDeployManager(InstanceDeployManager):
                     capture=True,
                 )
                 if "-dirty" in aws_fpga_upstream_version:
+                    aws_fpga_upstream_version = aws_fpga_upstream_version.replace("-dirty", "")
                     rootLogger.critical(
                         "Unable to use local changes to aws-fpga. Continuing without them."
                     )
@@ -700,8 +701,8 @@ class EC2InstanceDeployManager(InstanceDeployManager):
                 )
             )
             with warn_only():
-                run("git clone https://github.com/firesim/aws-fpga-firesim-f2.git aws-fpga") #rh: "git clone https://github.com/aws/aws-fpga"
-                run("cd aws-fpga && git checkout " + aws_fpga_upstream_version) #rh: keep in mind that if ts says dirty it will fail but continue doing sdk_setup
+                run("git clone https://github.com/firesim/aws-fpga-firesim-f2.git aws-fpga")
+                run("cd aws-fpga && git checkout " + aws_fpga_upstream_version)
             with cd(f"/home/{os.environ['USER']}/aws-fpga"):
                 run("source sdk_setup.sh")
 

--- a/deploy/runtools/run_farm_deploy_managers.py
+++ b/deploy/runtools/run_farm_deploy_managers.py
@@ -65,6 +65,10 @@ class InstanceDeployManager(metaclass=abc.ABCMeta):
 
     parent_node: Inst
     nbd_tracker: Optional[NBDTracker]
+    # Not all platforms need enumeration
+    # but the guide still say to do enumeration - which will fail for those platforms
+    # make knob to skip for platforms that dynamically checks BDF
+    NEED_ENUMERATION: bool = True
 
     def __init__(self, parent_node: Inst) -> None:
         """
@@ -1354,6 +1358,7 @@ class XilinxVCU118InstanceDeployManager(InstanceDeployManager):
     garnet shell."""
 
     PLATFORM_NAME: Optional[str]
+    NEED_ENUMERATION = False
 
     def __init__(self, parent_node: Inst) -> None:
         super().__init__(parent_node)

--- a/deploy/runtools/runtime_config.py
+++ b/deploy/runtools/runtime_config.py
@@ -1121,15 +1121,23 @@ class RuntimeConfig:
 
         self.args = args
 
-        # construct pythonic db of hardware configurations available to us at
-        # runtime.
-        self.runtimehwdb = RuntimeHWDB(args.hwdbconfigfile)
-        rootLogger.debug(self.runtimehwdb)
-
         self.innerconf = InnerRuntimeConfiguration(
             args.runtimeconfigfile, args.overrideconfigdata
         )
         rootLogger.debug(self.innerconf)
+
+        self.run_farm = self.innerconf.run_farm_dispatcher
+
+        # for enumeration check if platform actually needs it
+        if args.task == "enumeratefpgas" and not self.run_farm.needs_fpga_enumeration():
+            rootLogger.info("Skipping FPGA enumeration - platform discover BDF dynamically")
+            return
+
+        
+        # construct pythonic db of hardware configurations available to us at
+        # runtime.
+        self.runtimehwdb = RuntimeHWDB(args.hwdbconfigfile)
+        rootLogger.debug(self.runtimehwdb)       
 
         self.runtime_build_recipes = RuntimeBuildRecipes(
             args.buildrecipesconfigfile,
@@ -1138,8 +1146,6 @@ class RuntimeConfig:
             self.innerconf.metasimulation_only_vcs_plusargs,
         )
         rootLogger.debug(self.runtime_build_recipes)
-
-        self.run_farm = self.innerconf.run_farm_dispatcher
 
         # setup workload config obj, aka a list of workloads that can be assigned
         # to a server
@@ -1226,7 +1232,11 @@ class RuntimeConfig:
 
     def enumerate_fpgas(self) -> None:
         """directly called by top-level enumeratefpgas command."""
-        use_mock_instances_for_testing = False
+        # if platform dosnt need enum, return
+        if not hasattr(self, 'firesim_topology_with_passes'):
+            return
+        
+        use_mock_instances_for_testing = False        
         self.firesim_topology_with_passes.enumerate_fpgas_passes(
             use_mock_instances_for_testing
         )
@@ -1249,3 +1259,5 @@ class RuntimeConfig:
         self.firesim_topology_with_passes.run_workload_passes(
             use_mock_instances_for_testing
         )
+
+

--- a/deploy/ssh-setup.sh
+++ b/deploy/ssh-setup.sh
@@ -33,6 +33,6 @@ else
     if ssh-add ~/firesim.pem; then
         echo "success: ~/firesim.pem added to ssh-agent"
     else
-        echo "FAIL: ERROR adding ~/firesim.pem to ssh-agent. If on AWS F1, does it exist?"
+        echo "FAIL: ERROR adding ~/firesim.pem to ssh-agent. If on AWS F2, does it exist?"
     fi
 fi

--- a/docs/AWS-EC2-F2-Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/Configuring-Required-Infrastructure-in-Your-AWS-Account.rst
@@ -10,9 +10,8 @@ Select a region
 
 Head to the `EC2 Management Console <https://console.aws.amazon.com/ec2/v2/home>`__. In
 the top right corner, ensure that the correct region is selected. You should select one
-of: ``us-east-1`` (N. Virginia), ``us-west-2`` (Oregon), ``ap-northeast-1`` (Tokyo), 
-``ap-northeast-2`` (Seoul), ``ap-southeast-2`` (Sydney), ``eu-central-1`` (Frankfurt), 
-``eu-west-2`` (London), since F2 instances are only available in those regions. 
+of: ``us-east-1`` (N. Virginia), ``us-west-2`` (Oregon), or ``eu-west-2`` (London),
+since F2 instances are only available in those regions.
 For the most current list of regions supporting F2 instance, see `Amazon EC2 instance types by Region
 <https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-instance-regions.html>`__.
 
@@ -49,11 +48,11 @@ instances that you can run at once, which will limit the size of simulations (e.
 number of parallel FPGAs) that you can run. If you need to increase your limits, follow
 the instructions below.
 
-To complete this guide, you need to have the following limits:
+To complete this guide, you need to have the following minimum limits:
 
-- ``Running On-Demand F instances``: 64 vCPUs.
+- ``Running On-Demand F instances``: 192 vCPUs.
 
-      - This is sufficient for 8 parallel FPGAs. Each 8 vCPUs = one FPGA.
+      - This is sufficient for 8 parallel FPGAs. Each 24 vCPUs = one FPGA.
 
 - ``Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances``: 24 vCPUs.
 

--- a/docs/AWS-EC2-F2-Initial-Setup/First-time-AWS-User-Setup.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/First-time-AWS-User-Setup.rst
@@ -23,6 +23,14 @@ protect their infrastructure. You can learn more about how these limits/quotas w
 `here
 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-on-demand-instances.html#ec2-on-demand-instances-limits>`__.
 
+Select one of the following regions, which has F2 support, according to your location: 
+
+-  US East (N. Virginia) [``us-east-1``]
+
+-  US West (Oregon) [``us-west-2``]
+
+-  EU (London) [``eu-west-2``]
+
 You should make sure that your account has the ability to launch a sufficient number of
 instances to follow this guide by looking at the "Service Quotas" page in the AWS
 Console, which you can access `here
@@ -32,13 +40,29 @@ that the correct region is selected once you open this page.
 The values listed on this page represent the maximum number vCPUs of any of these
 instances that you can run at once, which will limit the size of simulations (e.g.,
 number of parallel FPGAs) that you can run. If you need to increase your limits, follow
-the instructions below.
+the instructions below. 
 
-To complete this guide, you need to have the following limits:
+.. Note:: Note that requests will take a few business days to process by Amazon AWS (prepare for a worst case time of 1 week if cases need to be escalated).
 
-- ``Running On-Demand F instances``: 64 vCPUs.
+We recommend the following limits:
 
-      - This is sufficient for 8 parallel FPGAs. Each 8 vCPUs = one FPGA.
+- ``Running On-Demand F instances``: 1024 vCPUs.
+
+      - This is sufficient for 42 parallel FPGAs. Each 24 vCPUs = one FPGA.
+
+- ``Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances``: 1024 vCPUs.
+
+      - We will use ``c5.4xlarge`` for our FireSim manager instance and 
+        ``z1d.2xlarge`` for our build farm instances.
+      - Each ``c5.4xlarge`` requires 10 vCPUs
+      - Each ``z1d.2xlarge`` requires 8 vCPUs
+      - Your 1024 vCPU capacity is shared across the ``A, C, D, H, I, M, R, T, Z`` instances you launch.
+
+At a minimum, you need to have the following limits:
+
+- ``Running On-Demand F instances``: 192 vCPUs.
+
+      - This is sufficient for 8 parallel FPGAs. Each 24 vCPUs = one FPGA.
 
 - ``Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances``: 24 vCPUs.
 
@@ -46,10 +70,23 @@ To complete this guide, you need to have the following limits:
         ``z1d.2xlarge`` build farm instance.
 
 If you have insufficient limits, request a limit increase by following these steps:
-https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#request-increase
 
-In your request, enter the vCPU limits for the two instance classes shown above. This
-process sometimes has a human in the loop, so you should submit it ASAP. At this point,
-you should wait for the response to this request.
+Visit: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#request-increase
+
+In your request, enter the vCPU limits for the two instance classes shown above. 
+
+At this point, you should wait for the response to this request.
+
+If your request gets rejected, you will need to go through the escalation process. Gather the following details from your request:
+
+- Your Support Case ID for your rejected request (or both if both requests were rejected). You can find your case ID from the `AWS Support page <https://support.console.aws.amazon.com/support/home#/case/history>`__, under `Support cases`.
+
+- Your `Service quota` string that you requested a quota increase on. Ex: `Running On-Demand F instances`.
+
+- The number of vCPUs you requested a quota increase to.
+
+- Requested region. Ex: `US West (Oregon)`.
+
+You will then need to send an email to Amazon AWS for escalation. **We are working with AWS to come up with a list of contacts to reach out to, check back for updates. If you want to get started immediately, please reach out to Jim at yf328@eecs.berkeley.edu. Please pardon these issues as we work with Amazon to stabilize the EC2 F2 platform for FireSim.**
 
 Hit Next below to continue.

--- a/docs/AWS-EC2-F2-Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -4,12 +4,12 @@ Setting up your Manager Instance
 Launching a "Manager Instance"
 ------------------------------
 
-.. warning::
+.. .. warning::
 
-    These instructions refer to fields in EC2's new launch instance wizard. Refer to
-    `version 1.13.4 <https://docs.fires.im/en/1.13.4/>`__ of the documentation for
-    references to the old wizard, being wary that specifics, such as the AMI ID
-    selection, may be out of date.
+..     These instructions refer to fields in EC2's new launch instance wizard. Refer to
+..     `version 1.13.4 <https://docs.fires.im/en/1.13.4/>`__ of the documentation for
+..     references to the old wizard, being wary that specifics, such as the AMI ID
+..     selection, may be out of date.
 
 Now, we need to launch a "Manager Instance" that acts as a "head" node that we will
 ``ssh`` or ``mosh`` into to work from. Since we will deploy the heavy lifting to
@@ -24,8 +24,8 @@ To launch a manager instance, follow these steps:
 2. In the *Launch FPGA Developer AMI (Ubuntu)* window:
 
    1. Set the launch method to *Launch from EC2 Console*. 
-   2. Set the version to *1.19.1*.
-      **If you do not change the version, you will likely get an incorrect version of the AMI.**
+   2. Set the version to ``1.19.1-prod-rhng4b6alkhdq``.
+      **If you do not change the version, you will likely get an incorrect version of the AMI; However, version changes to the last digit (i.e. 1.19.1 → 1.19.2) should not lead to any breaking changes and is fine to increment to.**
    
    3. Select the region that corresponds to the region you selected in :ref:`configuring-required-infrastructure-in-your-aws-account`.
    4. Click *Launch from EC2*. It should open a new tab in your browser with the launch instance page.
@@ -49,10 +49,10 @@ To launch a manager instance, follow these steps:
       is also fine if this group does not appear in your list).
 
 7.  In the *Configure storage* section, increase the size of the root volume to at least
-   300GB. The default of 120GB can quickly become too small as you accumulate large
-   Vivado reports/outputs, large waveforms, XSim outputs, and large root filesystems for
-   simulations. You should remove the small (5-8GB) secondary volume that is added by
-   default.
+    **300GB**. The default of 120GB can quickly become too small as you accumulate large
+    Vivado reports/outputs, large waveforms, XSim outputs, and large root filesystems for
+    simulations. You should remove the small (5-8GB) secondary volume that is added by
+    default.
 8.  In the *Advanced details* drop-down, change the following:
 
    1. Under *Termination protection*, select Enable. This adds a layer of protection to

--- a/docs/AWS-EC2-F2-Initial-Setup/Setting-up-your-Manager-Instance.rst
+++ b/docs/AWS-EC2-F2-Initial-Setup/Setting-up-your-Manager-Instance.rst
@@ -24,7 +24,7 @@ To launch a manager instance, follow these steps:
 2. In the *Launch FPGA Developer AMI (Ubuntu)* window:
 
    1. Set the launch method to *Launch from EC2 Console*. 
-   2. Set the version to *1.17.0*.
+   2. Set the version to *1.19.1*.
       **If you do not change the version, you will likely get an incorrect version of the AMI.**
    
    3. Select the region that corresponds to the region you selected in :ref:`configuring-required-infrastructure-in-your-aws-account`.

--- a/docs/FireSim-Basics.rst
+++ b/docs/FireSim-Basics.rst
@@ -67,7 +67,7 @@ running them serially on one cloud FPGA.
 In this mode, FireSim also models a cycle-accurate network with parameterizeable
 bandwidth, link latency, and configurable topology to accurately model current and
 future datacenter-scale systems. For example, FireSim has been used to simulate 1024
-quad-core RISC-V Rocket Chip-based nodes, interconnected by a 200 Gbps, 2us Ethernet
+quad-core RISC-V Rocket Chip-based nodes, interconnected by a 200 Gbps, 2µs Ethernet
 network. To learn more about this use case, see our `ISCA 2018 paper
 <https://sagark.org/assets/pubs/firesim-isca2018.pdf>`__.
 
@@ -79,10 +79,8 @@ If you have other use-cases that we haven't covered, feel free to contact us!
 Non-Chipyard-based target simulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While most users use FireSim with Chipyard, users can also use FireSim seperately from
-Chipyard. For now the best example on how to do this is to follow along with how
-Chipyard is setup with FireSim. Soon we will release a guide on how to use FireSim by
-itself! Stay tuned!
+The recommended way (and most tested way) to use FireSim is with `Chipyard <https://ucb.bar/cydocs>`__. 
+However, users can also use FireSim seperately from Chipyard. For a guide, please see :doc:`/Advanced-Usage/FireSim-without-Chipyard`.
 
 Choose your platform to get started
 -----------------------------------
@@ -92,9 +90,7 @@ links to work through the getting started guide for your particular platform.
 
 - :doc:`/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/index`
 
-  - Status: ✅ All FireSim Features Supported. ⚠️  F1 instances will be discontinued by AWS on Dec. 20, 2025.
-    We expect support for F1 instances and collateral (AMI's, etc) to slowly be removed/degraded over time.
-    For now, we recommend using on-premises FPGAs. **Stay tuned for AWS EC2 F2 updates**.
+  - Status: ⚠️ XDMA is not supported by AWS's EC2 F2 Shell, as of June 2026. We have implemented a mitigation; Impact: high speed FireSim bridges (e.g., TracerV) will function, but at a slower speed. **We are working with Amazon to introduce XDMA support.**
 
 - :doc:`/Getting-Started-Guides/On-Premises-FPGA-Getting-Started/Xilinx-Alveo-U200-FPGAs`
 

--- a/docs/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/Running-Simulations/Running-a-Cluster-Simulation.rst
+++ b/docs/Getting-Started-Guides/AWS-EC2-F2-Getting-Started/Running-Simulations/Running-a-Cluster-Simulation.rst
@@ -1,7 +1,7 @@
 .. _cluster-sim:
 
-Running a Cluster Simulation
-============================
+Running a Cluster Simulation [Coming soon on F2]
+================================================
 
 Now, let's move on to simulating a cluster of eight nodes, interconnected by a network
 with one 8-port Top-of-Rack (ToR) switch and 200 Gbps, 2μs links. This will require one

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,6 +315,6 @@ def cy_gh_file_ref_role(name, rawtext, text, lineno, inliner, options={}, conten
 
 def setup(app):
     # Add roles to simplify github reference generation
-    # app.add_role('gh-file-ref', fs_gh_file_ref_role)
-    # app.add_role('cy-gh-file-ref', cy_gh_file_ref_role)
+    app.add_role('gh-file-ref', fs_gh_file_ref_role)
+    app.add_role('cy-gh-file-ref', cy_gh_file_ref_role)
     app.connect('build-finished', copy_legacy_redirects)

--- a/platforms/f2/build-bitstream.sh
+++ b/platforms/f2/build-bitstream.sh
@@ -62,9 +62,10 @@ fi
 
 AWS_FPGA_DIR=$CL_DIR/../../../..
 
-# setup hdk # rh: -s is a flag that skips some git initialization on device, unnecessary as files already present on manager 
 cd $AWS_FPGA_DIR
-source hdk_setup.sh -s
+echo $AWS_FPGA_DIR
+
+source hdk_setup.sh
 
 export CL_DIR=$CL_DIR
 

--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -153,7 +153,7 @@ class F2Config
           beatBytes = 8,
           idBits    = 16,
         )
-      case HostMemNumChannels          => 4
+      case HostMemNumChannels          => 1
       case PreLinkCircuitPath          => Some("firesim_top")
       case PostLinkCircuitPath         => Some("WRAPPER/CL/firesim_top")
     }) ++ new SimConfig)

--- a/sim/midas/src/main/scala/midas/Config.scala
+++ b/sim/midas/src/main/scala/midas/Config.scala
@@ -142,11 +142,11 @@ class F2Config
           CPUManagedAXI4Params(
             addrBits = 64,
             dataBits = 512,
-            idBits   = 6,
+            idBits   = 16,
           )
         )
       case FPGAManagedAXI4Key          => None
-      case CtrlNastiKey                => NastiParameters(32, 25, 12)
+      case CtrlNastiKey                => NastiParameters(32, 32, 12)
       case HostMemChannelKey           =>
         HostMemChannelParams(
           size      = 0x400000000L, // 16 GiB
@@ -155,7 +155,7 @@ class F2Config
         )
       case HostMemNumChannels          => 4
       case PreLinkCircuitPath          => Some("firesim_top")
-      case PostLinkCircuitPath         => Some("WRAPPER_INST/CL/firesim_top")
+      case PostLinkCircuitPath         => Some("WRAPPER/CL/firesim_top")
     }) ++ new SimConfig)
 
 class XilinxAlveoU250Config


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact

<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility

<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you state the UI / API impact?
- [ ] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
