### PR TITLE
updated aws to support setting ami_id in config_runtime.yaml

### DIFF
--- a/deploy/awstools/awstools.py
+++ b/deploy/awstools/awstools.py
@@ -705,6 +705,7 @@ def launch_run_instances(
     spotmaxprice: str,
     timeout: timedelta,
     always_expand: bool,
+    ami_id: Optional[str] = None,
 ) -> List[EC2InstanceResource]:
     return launch_instances(
         instancetype,
@@ -714,6 +715,7 @@ def launch_run_instances(
         spotmaxprice,
         timeout=timeout,
         always_expand=always_expand,
+        ami_id=ami_id,
         blockdevices=[
             {
                 "DeviceName": "/dev/sda1",

--- a/deploy/runtools/run_farm.py
+++ b/deploy/runtools/run_farm.py
@@ -379,6 +379,7 @@ class AWSEC2F2(RunFarm):
     run_instance_market: str
     spot_interruption_behavior: str
     spot_max_price: str
+    ami_id: Optional[str] = None
 
     def __init__(self, args: Dict[str, Any], metasimulation_enabled: bool) -> None:
         super().__init__(args, metasimulation_enabled)
@@ -419,6 +420,7 @@ class AWSEC2F2(RunFarm):
         self.run_instance_market = self.args["run_instance_market"]
         self.spot_interruption_behavior = self.args["spot_interruption_behavior"]
         self.spot_max_price = self.args["spot_max_price"]
+        self.ami_id = self.args.get("ami_id")
 
         dispatch_dict = dict(
             [(x.__name__, x) for x in inheritors(InstanceDeployManager)]
@@ -565,6 +567,7 @@ class AWSEC2F2(RunFarm):
         spotmaxprice = self.spot_max_price
         timeout = self.launch_timeout
         always_expand = self.always_expand_run_farm
+        ami_id = self.ami_id
 
         # actually launch the instances
         launched_instance_objs = {}
@@ -581,6 +584,7 @@ class AWSEC2F2(RunFarm):
                 spotmaxprice,
                 timeout,
                 always_expand,
+                ami_id,
             )
 
         # wait for instances to get to running state, so that they have been


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/firesim/firesim/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
I am currently having issues with not being allowed to start F2's on default instances.
so I leveraged the awstool option for passing in an ami_id and extended this to work for the firesim script
enabling the option of setting it from the config_runtime.yaml.


#### Related PRs / Issues

<!-- List any related issues here -->

#### UI / API Impact
none
<!-- Roughly, how would this affect the current API or user-facing interfaces? (extend, deprecate, remove, or break) -->
<!-- Of note: manager config_*.yaml interface, targetutils & bridge scala API, platform config behavior -->

#### Verilog / AGFI Compatibility
no verilog changes just an update to the infrastructure
<!-- Does this change the generated Verilog or the simulator memory map of the default targets?  -->

#### Contributor Checklist
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you add Scaladoc/docstring/doxygen to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you state the UI / API impact?
- [x] Did you specify the Verilog / AGFI compatibility impact?
<!-- Do this if this PR changes verilog or breaks the default AGFIs -->
- [ ] If applicable, did you regenerate and publicly share default AGFIs?
<!--
  CI will check linux boot on default targets, when the <ci:fpga-deploy> label is applied. Do this on:
  - Chipyard bumps / AGFIs updates / RTL or Driver changes affecting default targets.
  - If in doubt request a deployment, or ask another developer.

  NB: This *label* should be applied before the PR is created, or the branch
  will need to be resychronized to trigger a new CI workflow with the FPGA-deployment jobs.
-->
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] If applicable, did you apply the `Please Backport` label?

#### Reviewer Checklist (only modified by reviewer)
Note: to run CI on PRs from forks, comment `@Mergifyio copy main` and manage the change from the new PR.
- [ ] Is the title suitable for inclusion in the changelog and does the PR have a `changelog:<topic>` label?
- [ ] Did you mark the proper release milestone?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?

#### CI Help
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:persist-prior-workflows` - Prevent prior CI workflows from automatically cancelling with subsequent changes
- `ci:disable` - Disable CI
- `ci:disable-scala-tests` - Disable Scala tests in CI
